### PR TITLE
Remove all hidden files from docker context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,6 @@
 **/_build
 **/*.swp
-**/.git
+**/.*
 **/var
 **/*.orig
 **/*.merlin


### PR DESCRIPTION
When building with `-f -`, docker seems to ignore its cache if hidden files are permitted. Possibly it's using a hidden file to pass the data from stdin and this causes a problem somehow?