### PR TITLE
Embed ocaml-secondary-compiler

### DIFF
--- a/src/pipeline.ml
+++ b/src/pipeline.ml
@@ -22,6 +22,14 @@ let maybe_add_beta switch =
   else
     empty
 
+let maybe_install_secondary_compiler ~switch =
+  let dune_min_native_support = Ocaml_version.Releases.v4_08 in
+  let open Dockerfile in
+  if Ocaml_version.compare switch dune_min_native_support < 0 then
+    run "opam install -y ocaml-secondary-compiler"
+  else
+    empty
+
 (* Generate a Dockerfile to install OCaml compiler [switch] in [opam_image]. *)
 let install_compiler_df ~arch ~switch opam_image =
   let switch_name = Ocaml_version.to_string (Ocaml_version.with_just_major_and_minor switch) in
@@ -40,6 +48,7 @@ let install_compiler_df ~arch ~switch opam_image =
   run "rm -rf .opam/repo/default/.git" @@
   run "opam pin add -k version %s %s" package_name package_version @@
   run "opam install -y opam-depext" @@
+  maybe_install_secondary_compiler ~switch @@
   entrypoint_exec ((if Ocaml_version.arch_is_32bit arch then ["/usr/bin/linux32"] else []) @ ["opam"; "exec"; "--"]) @@
   cmd "bash" @@
   copy ~src:["Dockerfile"] ~dst:"/Dockerfile.ocaml" ()

--- a/src/pipeline.ml
+++ b/src/pipeline.ml
@@ -39,7 +39,7 @@ let install_compiler_df ~arch ~switch opam_image =
   run "opam switch create %s %s.%s" switch_name package_name package_version @@
   run "rm -rf .opam/repo/default/.git" @@
   run "opam pin add -k version %s %s" package_name package_version @@
-  run "opam install -y depext" @@
+  run "opam install -y opam-depext" @@
   entrypoint_exec ((if Ocaml_version.arch_is_32bit arch then ["/usr/bin/linux32"] else []) @ ["opam"; "exec"; "--"]) @@
   cmd "bash" @@
   copy ~src:["Dockerfile"] ~dst:"/Dockerfile.ocaml" ()


### PR DESCRIPTION
Dune currently does not support OCaml < 4.08 natively and requires `ocaml-secondary-compiler` to build.
Adding it directly in the base docker images would greatly simplify CI systems, as this sort of hack has to be installed in almost every CI systems out-there anyway (mirage-ci, ocaml-ci-scripts and opam-repo-ci currently has it). Not having it installed in the base image (be it in `ocurrent/opam` or in a custom base used by those CI systems) increases the compilation time quite significantly.
This also simplifies updating the requirements. Per one of the dune lead dev, dune only supports the latest 3 versions of the compiler natively. So updates will happen after each OCaml releases and having it in one place simplifies this update process.

The only two downsides I'm seeing from this is the increase in image size and having one more package installed by default that is thus not checked by CI systems if some packages somehow relies on it directly but forgot to list it in its dependencies.
In practice I don't know any packages that do that (even dune just relies on `ocamlfind-secondary`, not `ocaml-secondary-compiler` directly). As for the size issue this is a bit unfortunate to add ~285Mo but oh well.. :cry: