### PR TITLE
Support new ocaml-variants layout

### DIFF
--- a/src/pipeline.ml
+++ b/src/pipeline.ml
@@ -34,6 +34,7 @@ let maybe_install_secondary_compiler ~switch =
 let install_compiler_df ~arch ~switch opam_image =
   let switch_name = Ocaml_version.to_string (Ocaml_version.with_just_major_and_minor switch) in
   let (package_name, package_version) = Ocaml_version.Opam.V2.package switch in
+  let additional_packages = Ocaml_version.Opam.V2.additional_packages switch in
   let open Dockerfile in
   let personality = if Ocaml_version.arch_is_32bit arch then shell ["/usr/bin/linux32"; "/bin/sh"; "-c"] else empty in
   from opam_image @@
@@ -42,7 +43,7 @@ let install_compiler_df ~arch ~switch opam_image =
   env ["OPAMYES", "1";
        "OPAMERRLOGLEN", "0";
       ] @@
-  run "opam switch create %s %s.%s" switch_name package_name package_version @@
+  run "opam switch create %s --packages=%s" switch_name (String.concat "," (Printf.sprintf "%s.%s" package_name package_version :: additional_packages)) @@
   run "opam pin add -k version %s %s" package_name package_version @@
   run "opam install -y opam-depext" @@
   maybe_install_secondary_compiler ~switch @@


### PR DESCRIPTION
[ocaml/opam-repository#17541](https://github.com/ocaml/opam-repository/pull/17541) seeks to solve the combinatorial explosion of `ocaml-variants` packages, with a trial for the 4.12 packages only which affects the generation of the variant packages for tier 1 images (but not by much).

All that changes here is that `opam switch create` needs to use `--packages` and `Ocaml_version.Opam.V2` now has an extra function which returns the list of additional packages which are required.

@AltGr and I are just polishing the opam-repository PR - it should be the case that the 4.12-afl image, for example, will use `ocaml-variants.4.12.0+trunk` and `ocaml-options-only-afl`, the `-only-` versions of packages prevent dependencies from changing the underlying compiler.