### PR TITLE
Update README for new repository location

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ocurrent/opam:debian-10-ocaml-4.10@sha256:b8683f4ddd6ec3fc979637e9e8140b0f6fc67e48f6913e73bbc4311dfb8dd130 AS build
+FROM ocaml/opam:debian-10-ocaml-4.10@sha256:15bc5676151b4ae0e40dbe5d7233a734c54788e222dd6ab470c23a433deaaa1a AS build
 RUN sudo apt-get update && sudo apt-get install capnproto graphviz m4 pkg-config libsqlite3-dev libgmp-dev libssl-dev -y --no-install-recommends
 RUN cd ~/opam-repository && git pull origin -q master && git reset --hard c574ab6909d6027c5338b7de2e0754035444019e && opam update
 COPY --chown=opam \

--- a/README.md
+++ b/README.md
@@ -1,17 +1,13 @@
-Status: **experimental**
-
 This is an [OCurrent][] pipeline that builds Docker images for OCaml, for
 various combinations of Linux distribution, OCaml version and architecture.
 
 The resulting images can be run as e.g.
 
 ```
-docker run --rm -it ocurrent/opam:debian-10-ocaml-4.08
+docker run --rm -it ocaml/opam:debian-10-ocaml-4.11
 ```
 
-(this is a temporary location and will likely change in future)
-
-These images are very similar to the ones currently available as `ocaml/opam2`,
+These images are very similar to the ones previously available as `ocaml/opam2`,
 and use the same scripts from [avsm/ocaml-dockerfile][].
 However, they are much smaller because each image only includes one OCaml compiler.
 


### PR DESCRIPTION
Since ce239f54089b6d we push to `ocaml/opam`.