### PR TITLE
Add aliases for the latest version of a distribution

### DIFF
--- a/src/pipeline.ml
+++ b/src/pipeline.ml
@@ -169,8 +169,13 @@ let v ?channel ~ocluster () =
         let tags =
           (* Push the image as e.g. debian-10-ocaml-4.09: *)
           let tags = [full_tag] in
-          if switch <> Ocaml_version.Releases.latest then tags
-          else (
+          if switch <> Ocaml_version.Releases.latest then (
+            (* For every OCaml version, for every latest distro create an alias
+               (e.g. alpine-ocaml-4.10) *)
+            match distro_latest_alias with
+            | None -> tags
+            | Some latest -> Tag.v ~latest_distro:true ~switch latest :: tags
+          ) else (
             (* For every distro, also create a link to the latest OCaml compiler.
                e.g. debian-9 -> debian-9-ocaml-4.09 *)
             let tags = Tag.v_alias distro :: tags in
@@ -179,7 +184,7 @@ let v ?channel ~ocluster () =
             match distro_latest_alias with
             | None -> tags
             | Some latest ->
-              let tags = Tag.v_alias latest :: tags in
+              let tags = Tag.v_alias latest :: Tag.v ~latest_distro:true ~switch latest :: tags in
               (* The top-level alias: latest -> debian-10-ocaml-4.09 *)
               if distro <> master_distro then tags
               else Tag.latest :: tags

--- a/src/tag.ml
+++ b/src/tag.ml
@@ -9,9 +9,11 @@ let tag_of_compiler switch =
       | x -> x
     )
 
-let v ?arch ?switch distro =
+let v ?(latest_distro=false) ?arch ?switch distro =
   let repo = if arch = None then Conf.public_repo else Conf.staging_repo in
-  let distro = Dockerfile_distro.tag_of_distro distro in
+  let distro =
+    if latest_distro then Dockerfile_distro.latest_tag_of_distro distro
+    else Dockerfile_distro.tag_of_distro distro in
   let switch =
     match switch with
     | Some switch -> "ocaml-" ^ tag_of_compiler switch

--- a/src/tag.mli
+++ b/src/tag.mli
@@ -1,11 +1,13 @@
-val v : ?arch:Ocaml_version.arch -> ?switch:Ocaml_version.t -> Dockerfile_distro.t -> string
-(** [v ?arch ?switch distro] is the Docker tag to use for an image built on [distro] and [arch]
+val v : ?latest_distro:bool -> ?arch:Ocaml_version.arch -> ?switch:Ocaml_version.t -> Dockerfile_distro.t -> string
+(** [v ?latest_distro ?arch ?switch distro] is the Docker tag to use for an image built on [distro] and [arch]
     with OCaml compiler [switch] installed. If [switch] is [None] then this is a base image
     with no switches. If [arch] is set then this is a staging image, which will later be combined
-    into a cross-platform image. *)
+    into a cross-platform image. If [latest_distro] is true (default: false) then the distro
+    version will not be included in the tag (e.g. [alpine-ocaml-4.10]).  *)
 
 val v_alias : Dockerfile_distro.t -> string
-(** [v_alias distro] is a short tag for [distro], without the OCaml version. *)
+(** [v_alias ?switch distro] is a short tag for [distro], without the OCaml version (e.g. [alpine-3.12]).
+    If [latest] is [true] (default: [false]) then the distro version will not be included (e.g. [alpine]). *)
 
 val latest : string
 (** [latest] is the single ":latest" tag. *)


### PR DESCRIPTION
We now push `<distro>-ocaml-<ver>` for the latest version of a distribution; e.g. `alpine-ocaml-4.11`.  This provides a convenient way to get the latest version of a distro without having to keep that sub-version up-to-date.
    
Fixes #73 and helps ocaml-ci-scripts maintain compatibility with the switch to `ocaml/opam`.
