### PR TITLE
Add aliases for the latest version of a distribution

### DIFF
--- a/src/tag.ml
+++ b/src/tag.ml
@@ -11,7 +11,10 @@ let tag_of_compiler switch =
 
 let v ?arch ?switch distro =
   let repo = if arch = None then Conf.public_repo else Conf.staging_repo in
-  let distro = Dockerfile_distro.tag_of_distro distro in
+  let distro =
+    if distro = `Debian `Stable then "debian"
+    else Dockerfile_distro.tag_of_distro distro
+  in
   let switch =
     match switch with
     | Some switch -> "ocaml-" ^ tag_of_compiler switch


### PR DESCRIPTION
We now push `<distro>-ocaml-<ver>` for the latest version of a distribution; e.g. `alpine-ocaml-4.11`.  This provides a convenient way to get the latest version of a distro without having to keep that sub-version up-to-date.

Fixes #73 and helps ocaml-ci-scripts maintain compatibility with the switch to `ocaml/opam`.

This is a slight modification of #76. The main difference is that it includes the full alias name. e.g. we now have separate aliases for `ubuntu` and `ubuntu-lts`.

Note that a result of this is that the `debian` alias is now `debian-stable`. Maybe we should special-case that?