### PR TITLE
Add missing debian-stable images

### DIFF
--- a/src/tag.ml
+++ b/src/tag.ml
@@ -23,10 +23,7 @@ let v ?arch ?switch distro =
   Fmt.strf "%s:%s-%s%a" repo distro switch pp_arch arch
 
 let v_alias alias =
-  let alias =
-    if alias = `Debian `Stable then "debian"
-    else Dockerfile_distro.tag_of_distro alias
-  in
+  let alias = Dockerfile_distro.tag_of_distro alias in
   Fmt.strf "%s:%s" Conf.public_repo alias
 
 let latest =


### PR DESCRIPTION
The old `ocaml/opam2` never had any image called `debian`, it was always `debian-stable`. This also would simplify the special case made for debian in regards to how `dockerfile-opam` defines the set of tag names.

`debian-stable` was wildly used for `ocaml-ci-scripts`. For instance: https://travis-ci.org/github/realworldocaml/mdx/builds/745486303