### PR TITLE
alias debian-stable to debian in the manifests

### DIFF
--- a/src/pipeline.ml
+++ b/src/pipeline.ml
@@ -202,8 +202,10 @@ let v ?channel ~ocluster () =
       else (
         let full_tag = Tag.v distro ~switch in
         let tags =
-          (* Push the image as e.g. debian-10-ocaml-4.09 and debian-ocaml-4.09 *)
+          (* Push the image as e.g. debian-10-ocaml-4.09 and debian-stable-ocaml-4.09 *)
           let tags = full_tag :: List.map (Tag.v ~switch) distro_aliases in
+          (* Add on any alternate aliases (e.g. debian-ocaml-4.09 *)
+          let tags = tags @ (List.map (Tag.v_alt ~switch) distro_aliases |> List.flatten) in
           if switch <> Ocaml_version.Releases.latest then tags
           else (
             (* For every distro, also create a link to the latest OCaml compiler.

--- a/src/tag.ml
+++ b/src/tag.ml
@@ -9,24 +9,25 @@ let tag_of_compiler switch =
       | x -> x
     )
 
-let v ?arch ?switch distro =
+let make_tag ?arch ?switch distro_tag =
   let repo = if arch = None then Conf.public_repo else Conf.staging_repo in
-  let distro =
-    if distro = `Debian `Stable then "debian"
-    else Dockerfile_distro.tag_of_distro distro
-  in
   let switch =
     match switch with
     | Some switch -> "ocaml-" ^ tag_of_compiler switch
     | None -> "opam"
   in
-  Fmt.strf "%s:%s-%s%a" repo distro switch pp_arch arch
+  Fmt.strf "%s:%s-%s%a" repo distro_tag switch pp_arch arch
+
+let v ?arch ?switch distro =
+  make_tag ?arch ?switch (Dockerfile_distro.tag_of_distro distro)
+
+let v_alt ?arch ?switch distro =
+  match distro with
+  | `Debian `Stable -> [ make_tag ?arch ?switch "debian" ]
+  | _ -> []
 
 let v_alias alias =
-  let alias =
-    if alias = `Debian `Stable then "debian"
-    else Dockerfile_distro.tag_of_distro alias
-  in
+  let alias = Dockerfile_distro.tag_of_distro alias in
   Fmt.strf "%s:%s" Conf.public_repo alias
 
 let latest =

--- a/src/tag.mli
+++ b/src/tag.mli
@@ -4,6 +4,11 @@ val v : ?arch:Ocaml_version.arch -> ?switch:Ocaml_version.t -> Dockerfile_distro
     with no switches. If [arch] is set then this is a staging image, which will later be combined
     into a cross-platform image. *)
 
+val v_alt : ?arch:Ocaml_version.arch -> ?switch:Ocaml_version.t -> Dockerfile_distro.t -> string list
+(** [v_alt ?arch ?switch distro] is the list of alternate alias tags to use for an image
+    built on [distro] and [arch] with OCaml compiler [switch] installed. Right now
+    [debian-stable] is mapped to [debian] as the only alternate tag. *)
+
 val v_alias : Dockerfile_distro.t -> string
 (** [v_alias distro] is a short tag for [distro], without the OCaml version. *)
 


### PR DESCRIPTION
This maintains compatibility with ocaml-ci-scripts, and doesnt
push any new container images (just manifests, which are the pointers
to the actual container images).

Fixes #81