### PR TITLE
opam 2.1beta5 onwards renames OPAMDEPEXTYES to OPAMUNSAFEDEPEXTYES

### DIFF
--- a/src/pipeline.ml
+++ b/src/pipeline.ml
@@ -50,7 +50,8 @@ let install_compiler_df ~arch ~switch opam_image =
   personality @@
   maybe_add_beta switch @@
   env ["OPAMYES", "1";
-       "OPAMDEPEXTYES", "1";
+       "OPAMDEPEXTYES", "1"; (* Remove this when https://github.com/ocaml/opam/pull/4563 is merged *)
+       "OPAMUNSAFEDEPEXTYES", "1";
        "OPAMERRLOGLEN", "0"; (* Show the whole log if it fails *)
        "OPAMPRECISETRACKING", "1"; (* Mitigate https://github.com/ocaml/opam/issues/3997 *)
       ] @@


### PR DESCRIPTION
See https://github.com/ocaml/opam/pull/4563

This currently just sets both, so we have a transition period and
can then remove the older env var.