### PR TITLE
Update the environment to handle the new --confirm-level option from opam 2.1

### DIFF
--- a/src/pipeline.ml
+++ b/src/pipeline.ml
@@ -57,8 +57,7 @@ let install_compiler_df ~arch ~switch opam_image =
   maybe_add_beta switch @@
   maybe_add_multicore switch @@
   env ["OPAMYES", "1";
-       "OPAMDEPEXTYES", "1"; (* Remove this when https://github.com/ocaml/opam/pull/4563 is merged *)
-       "OPAMUNSAFEDEPEXTYES", "1";
+       "OPAMCONFIRMLEVEL", "unsafe-yes";
        "OPAMERRLOGLEN", "0"; (* Show the whole log if it fails *)
        "OPAMPRECISETRACKING", "1"; (* Mitigate https://github.com/ocaml/opam/issues/3997 *)
       ] @@


### PR DESCRIPTION
https://github.com/ocaml/opam/pull/4582 was merged a few hours ago and changes the `OPAMDEPEXTYES` env variable by the more generic `OPAMCONFIRMLEVEL` env variable. This only affect opam 2.1 as none of the two env variable were used by opam before.