### PR TITLE
Update the opam 2.1 support to use the new 2.1 branch instead of master

### DIFF
--- a/src/git_repositories.mli
+++ b/src/git_repositories.mli
@@ -1,7 +1,7 @@
 type t = {
   opam_repository_master : Current_git.Commit_id.t;
   opam_2_0 : Current_git.Commit_id.t;
-  opam_master : Current_git.Commit_id.t;
+  opam_2_1 : Current_git.Commit_id.t;
 }
 
 val get : schedule:Current_cache.Schedule.t -> t Current.t

--- a/src/pipeline.ml
+++ b/src/pipeline.ml
@@ -79,12 +79,12 @@ module Arch = struct
     let arch_name = Ocaml_version.string_of_arch arch in
     let distro_tag = Dockerfile_distro.tag_of_distro distro in
     Current.component "%s@,%s" distro_tag arch_name |>
-    let> {Git_repositories.opam_repository_master; opam_2_0; opam_master} = repos in
+    let> {Git_repositories.opam_repository_master; opam_2_0; opam_2_1} = repos in
     let dockerfile =
       let hash_opam_2_0 = Current_git.Commit_id.hash opam_2_0 in
-      let hash_opam_master = Current_git.Commit_id.hash opam_master in
+      let hash_opam_2_1 = Current_git.Commit_id.hash opam_2_1 in
       `Contents (
-        let opam = snd @@ Dockerfile_opam.gen_opam2_distro ~arch ~clone_opam_repo:false ~hash_opam_2_0 ~hash_opam_master distro in
+        let opam = snd @@ Dockerfile_opam.gen_opam2_distro ~arch ~clone_opam_repo:false ~hash_opam_2_0 ~hash_opam_2_1 distro in
         let open Dockerfile in
         string_of_t (
           opam @@


### PR DESCRIPTION
opam 2.1 just branched from master so this PR is here to update dockerfile-opam to use this new branch instead of master.

Uses https://github.com/avsm/ocaml-dockerfile/pull/52