### PR TITLE
Support Logs.cli

### DIFF
--- a/src/base_images.ml
+++ b/src/base_images.ml
@@ -5,7 +5,9 @@ let program_name = "base_images"
 
 module Rpc = Current_rpc.Impl(Current)
 
-let () = Prometheus_unix.Logging.init ()
+let setup_log default_level =
+  Prometheus_unix.Logging.init ?default_level ();
+  ()
 
 (* A low-security Docker Hub user used to push images to the staging area.
    Low-security because we never rely on the tags in this repository, just the hashes. *)
@@ -56,7 +58,7 @@ let has_role user = function
            ) -> true
     | _ -> false
 
-let main config mode channel capnp_address github_auth submission_uri staging_password_file =
+let main () config mode channel capnp_address github_auth submission_uri staging_password_file =
   Lwt_main.run begin
     let channel = Option.map read_channel_uri channel in
     let staging_auth = staging_password_file |> Option.map (fun path -> staging_user, read_first_line path) in
@@ -129,10 +131,14 @@ let staging_password =
     ~docv:"FILE"
     ["staging-password-file"]
 
+let setup_log =
+  Term.(const setup_log $ Logs_cli.level ())
+
 let cmd =
   let doc = "Build the ocaml/opam images for Docker Hub" in
-  Term.(term_result (const main $ Current.Config.cmdliner $ Current_web.cmdliner $ slack $ capnp_address $ Current_github.Auth.cmdliner $
-                     submission_service $ staging_password)),
+  Term.(term_result (const main $ setup_log $ Current.Config.cmdliner $ Current_web.cmdliner
+                     $ slack $ capnp_address $ Current_github.Auth.cmdliner $ submission_service
+                     $ staging_password)),
   Term.info program_name ~doc
 
 let () = Term.(exit @@ eval cmd)

--- a/src/dune
+++ b/src/dune
@@ -12,5 +12,6 @@
              capnp-rpc-unix
              dockerfile-opam
              lwt.unix
-             prometheus-app.unix)
+             prometheus-app.unix
+             logs.cli)
   (preprocess (pps ppx_deriving_yojson)))


### PR DESCRIPTION
The first commit is just a switch to Cmdliner.Arg.&, I find it cleaner and it's more in line with Cmdliner's documentation, but I can remove it if you prefer.
The second introduces support for setting logs verbosity through the command line. This introduces a bit of noise in the help page, but helps development by not having to patch the source to get more logs.  The executable doesn't use Fmt.cli as its logs are given to Prometheus.