### PR TITLE
Remove dedicated pool for Server 2022

### DIFF
--- a/src/conf.ml
+++ b/src/conf.ml
@@ -31,7 +31,7 @@ let pool_name (distro:Dockerfile_distro.t) arch =
   let os_family = Dockerfile_distro.os_family_of_distro distro in
   let os_str = match os_family with
   | `Windows | `Cygwin ->
-    let dedicated_pool = [`V1809; `Ltsc2022] in
+    let dedicated_pool = [`V1809] in
     begin match Dockerfile_distro.resolve_alias distro with
     | `Windows (_, release) | `Cygwin release when List.mem release dedicated_pool ->
       (* Temporary but convenient alias as ltsc2022 is based on 21H1. *)


### PR DESCRIPTION
All the workers are now Server 2022 by default.