### PR TITLE
Remove opam pin <compiler> to avoid issues with opam 2.1

### DIFF
--- a/src/pipeline.ml
+++ b/src/pipeline.ml
@@ -84,7 +84,6 @@ let install_compiler_df ~distro ~arch ~switch ?windows_port opam_image =
        "OPAMPRECISETRACKING", "1"; (* Mitigate https://github.com/ocaml/opam/issues/3997 *)
       ] @@
   run_no_opam "opam switch create %s --packages=%s" switch_name packages @@
-  run "opam pin add -k version %s %s" package_name package_version @@
   run "opam install -y %s" depext @@
   maybe_install_secondary_compiler run os_family switch @@
   entrypoint_exec (Option.to_list personality @ opam_exec) @@


### PR DESCRIPTION
See https://github.com/ocaml/opam/issues/4501
Some more details on the issue can be seen in https://github.com/ocurrent/opam-repo-ci/pull/148/commits/a4cbe3f3ad89ba6d7816df9280b209639d4c72f6