### PR TITLE
Fixes to docker-compose and Dockerfile.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ RUN opam install -y --deps-only .
 ADD --chown=opam . .
 RUN opam config exec -- dune build ./src/base_images.exe
 
-FROM debian:11
+FROM --platform=linux/amd64 debian:11
 RUN apt-get update && apt-get install libev4 curl git graphviz libsqlite3-dev ca-certificates netbase gnupg2 -y --no-install-recommends
 RUN curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add -
 RUN echo 'deb [arch=amd64] https://download.docker.com/linux/debian buster stable' >> /etc/apt/sources.list

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,7 @@ version: "3.8"
 services:
   scheduler:
     image: ocurrent/ocluster-scheduler:live
+    platform: linux/amd64
     command:
       - --secrets-dir=/capnp-secrets
       - --capnp-secret-key-file=/capnp-secrets/key.pem
@@ -30,8 +31,9 @@ services:
       - "capnp-secrets:/capnp-secrets"
   worker:
     image: ocurrent/ocluster-worker:live
+    platform: linux/amd64
     command:
-      - /capnp-secrets/pool-linux-x86_64.cap
+      - --connect=/capnp-secrets/pool-linux-x86_64.cap
       - --name=local
       - --allow-push=ocurrentbuilder/staging,ocurrent/opam-staging
       - --capacity=1


### PR DESCRIPTION
Specify `platform: linux/amd64` to work with Apple M1.
Fix cli usage for ocurrent-worker.