### PR TITLE
Fixup docker-compose to run local ocluster-worker.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,11 +28,11 @@ RUN opam install -y --deps-only .
 ADD --chown=opam . .
 RUN opam config exec -- dune build ./src/base_images.exe
 
-FROM --platform=linux/amd64 debian:11
+FROM debian:11
 RUN apt-get update && apt-get install libev4 curl git graphviz libsqlite3-dev ca-certificates netbase gnupg2 -y --no-install-recommends
 RUN curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add -
-RUN echo 'deb [arch=amd64] https://download.docker.com/linux/debian buster stable' >> /etc/apt/sources.list
-RUN apt-get update && apt-get install docker-ce -y --no-install-recommends
+RUN echo 'deb https://download.docker.com/linux/debian buster stable' >> /etc/apt/sources.list
+RUN apt-get update && apt-get install docker-ce docker-buildx-plugin -y --no-install-recommends
 COPY --from=build /src/_build/default/src/base_images.exe /usr/local/bin/base-images
 WORKDIR /var/lib/ocurrent
 ENTRYPOINT ["/usr/local/bin/base-images"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.8"
 services:
   scheduler:
     image: ocurrent/ocluster-scheduler:live
-    platform: linux/amd64
+    platform: linux
     command:
       - --secrets-dir=/capnp-secrets
       - --capnp-secret-key-file=/capnp-secrets/key.pem
@@ -30,15 +30,23 @@ services:
       - 'base-builder-data:/var/lib/ocurrent'
       - "capnp-secrets:/capnp-secrets"
   worker:
-    image: ocurrent/ocluster-worker:live
-    platform: linux/amd64
+    build:
+      dockerfile: docker/worker/Dockerfile
+      context: .
+    platform: linux
     command:
       - --connect=/capnp-secrets/pool-linux-x86_64.cap
+      # - --connect=/capnp-secrets/pool-linux-arm64.cap  # NOTE replace with arm64 if running on macos/arm64
       - --name=local
       - --allow-push=ocurrentbuilder/staging,ocurrent/opam-staging
       - --capacity=1
       - --state-dir=/var/lib/ocluster
+      - --store=rsync:/var/cache/obuilder
+      - --rsync-mode=hardlink
+      - --obuilder-healthcheck=0
+      - --verbose
     init: true
+    privileged: true            # required for the Docker in Docker container to work
     restart: on-failure         # (wait for the scheduler to write the pool cap)
     volumes:
       - 'worker-data:/var/lib/ocluster'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,7 +41,7 @@ services:
       - --allow-push=ocurrentbuilder/staging,ocurrent/opam-staging
       - --capacity=1
       - --state-dir=/var/lib/ocluster
-      - --store=rsync:/var/cache/obuilder
+      - --obuilder-store=rsync:/var/cache/obuilder
       - --rsync-mode=hardlink
       - --obuilder-healthcheck=0
       - --verbose

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,12 @@
+# Helper dockerfiles
+
+They must be built using the root of the project as context:
+
+``` shell
+docker build -f docker/worker/Dockerfile .
+```
+
+## worker
+
+ocluster worker to run in a Linux x86_64 pool to test local builds.
+The worker uses Docker in Docker to run builds as the production cluster would on Linux.

--- a/docker/worker/Dockerfile
+++ b/docker/worker/Dockerfile
@@ -1,0 +1,11 @@
+FROM ocurrent/ocluster-worker:alpine AS build
+
+## Using a Docker in Docker container to run the worker
+## See https://devopscube.com/run-docker-in-docker/
+FROM docker:dind
+RUN apk add rsync libev capnproto m4 sqlite libgmpxx curl gnupg git ca-certificates
+RUN mkdir /var/cache/obuilder
+WORKDIR /var/lib/ocluster-worker
+ENTRYPOINT ["/usr/local/bin/ocluster-worker"]
+ENV PROGRESS_NO_TRUNC=1
+COPY --from=build /usr/local/bin/ocluster-worker /usr/local/bin/


### PR DESCRIPTION
Removes the linux/amd64 requirement, we publish arm64 builds of scheduler and worker so this should continue to work on Linux and MacOS (x86 and Arm64).