### PR TITLE
Add Prometheus metrics

### DIFF
--- a/prometheus.yml
+++ b/prometheus.yml
@@ -1,0 +1,13 @@
+
+
+scrape_configs:
+  - job_name: 'baseimages'
+    scrape_interval: 5s
+    static_configs:
+      - targets: ['localhost:8080']
+
+remote_write:
+  - url: https://prometheus-prod-24-prod-eu-west-2.grafana.net/api/prom/push
+    basic_auth:
+      username: 1221412
+      password: glc_eyJvIjoiOTU5NjM2IiwibiI6Im5ld3Rva2VuIiwiayI6InIxN1c5cDVnNExHa0JWWTJ2b0F0MDk5MiIsIm0iOnsiciI6InByb2QtZXUtd2VzdC0yIn19

--- a/src/base_images.ml
+++ b/src/base_images.ml
@@ -12,8 +12,8 @@ module Metrics = struct
     Gauge.v_labels ~label_names:["platform"; "state"] ~help ~namespace ~subsystem
       "image_state_total"
 
-  type stats = { ok : int; failed : int; active : int; blocked : int }
-  let stats_empty = { ok = 0; failed = 0; active = 0; blocked = 0 }
+  type stats = { ok : int; failed : int; active : int }
+  let stats_empty = { ok = 0; failed = 0; active = 0 }
 
   let update () =
     let f platform sm =
@@ -23,14 +23,12 @@ module Metrics = struct
             match state with
             | Index.Ok -> { stats with ok = stats.ok + 1 }
             | Index.Failed -> { stats with failed = stats.failed + 1 }
-            | Index.Active -> { stats with active = stats.active + 1 }
-            | Index.Blocked -> { stats with blocked = stats.blocked + 1 })
+            | Index.Active -> { stats with active = stats.active + 1 })
           sm stats_empty
       in
       Gauge.set (Gauge.labels family [platform; "ok"]) (float_of_int stats.ok);
       Gauge.set (Gauge.labels family [platform; "failed"]) (float_of_int stats.failed);
-      Gauge.set (Gauge.labels family [platform; "active"]) (float_of_int stats.active);
-      Gauge.set (Gauge.labels family [platform; "blocked"]) (float_of_int stats.blocked)
+      Gauge.set (Gauge.labels family [platform; "active"]) (float_of_int stats.active)
     in
     let v = Index.get () in
     Index.Platform_map.iter f v

--- a/src/dump.ml
+++ b/src/dump.ml
@@ -56,6 +56,8 @@ module Fake = struct
     let ignore_value t =
       of_fn (fun log -> ignore (force t log))
 
+    let state ?hidden t = ignore hidden; of_fn (fun log -> force t log |> Result.ok)
+
     let all xs = of_fn (fun log -> List.iter (fun x -> force x log) xs)
     let all_labelled xs = of_fn (fun log -> List.iter (fun (_l, x) -> force x log) xs)
 
@@ -67,6 +69,12 @@ module Fake = struct
         let x = force x log in
         Log.note log description;
         Log.with_indent (force (fn x)) log
+
+      let (let+) x f =
+        of_fn @@ fun log ->
+        match x.state with
+        | `Ready fn -> f @@ fn log
+        | `Done x -> f x
     end
   end
 

--- a/src/index.ml
+++ b/src/index.ml
@@ -1,7 +1,7 @@
 module Platform_map = Map.Make (String)
 module Switch_map = Map.Make (Ocaml_version)
 
-type state = Ok | Failed | Active | Blocked
+type state = Ok | Failed | Active
 type t = state Switch_map.t Platform_map.t
 
 let v : t ref = ref Platform_map.empty

--- a/src/index.ml
+++ b/src/index.ml
@@ -2,16 +2,22 @@ module Platform_map = Map.Make (String)
 module Switch_map = Map.Make (Ocaml_version)
 
 type state = Ok | Failed | Active
-type t = state Switch_map.t Platform_map.t
+(* Each platform builds one non-OCaml opam image, and then an image for every version of OCaml *)
+type t = state Switch_map.t Platform_map.t * state Platform_map.t
 
-let v : t ref = ref Platform_map.empty
+let v : t ref = ref Platform_map.(empty, empty)
 
 let update ~platform ~switch state =
-  let update_switch_map sm =
+  let update_switch_map switch sm =
     Option.some @@ match sm with
     | None -> Switch_map.singleton switch state
     | Some sm -> Switch_map.update switch (fun _ -> Some state) sm
   in
-  v := Platform_map.update platform update_switch_map !v
+  let m = !v in
+  match switch with
+  | None ->
+      v := fst m, Platform_map.update platform (fun _ -> Some state) (snd m)
+  | Some switch ->
+      v := Platform_map.update platform (update_switch_map switch) (fst m), snd m
 
 let get () = !v

--- a/src/index.ml
+++ b/src/index.ml
@@ -1,0 +1,17 @@
+module Platform_map = Map.Make (String)
+module Switch_map = Map.Make (Ocaml_version)
+
+type state = Ok | Failed | Active | Blocked
+type t = state Switch_map.t Platform_map.t
+
+let v : t ref = ref Platform_map.empty
+
+let update ~platform ~switch state =
+  let update_switch_map sm =
+    Option.some @@ match sm with
+    | None -> Switch_map.singleton switch state
+    | Some sm -> Switch_map.update switch (fun _ -> Some state) sm
+  in
+  v := Platform_map.update platform update_switch_map !v
+
+let get () = !v

--- a/src/index.mli
+++ b/src/index.mli
@@ -1,0 +1,11 @@
+module Platform_map : (Map.S with type key = string)
+
+module Switch_map : (Map.S with type key = Ocaml_version.t)
+
+type state = Ok | Failed | Active | Blocked
+
+type t = state Switch_map.t Platform_map.t
+
+val update : platform:string -> switch:Ocaml_version.t -> state -> unit
+
+val get : unit -> t

--- a/src/index.mli
+++ b/src/index.mli
@@ -2,7 +2,7 @@ module Platform_map : (Map.S with type key = string)
 
 module Switch_map : (Map.S with type key = Ocaml_version.t)
 
-type state = Ok | Failed | Active | Blocked
+type state = Ok | Failed | Active
 
 type t = state Switch_map.t Platform_map.t
 

--- a/src/index.mli
+++ b/src/index.mli
@@ -4,8 +4,8 @@ module Switch_map : (Map.S with type key = Ocaml_version.t)
 
 type state = Ok | Failed | Active
 
-type t = state Switch_map.t Platform_map.t
+type t = state Switch_map.t Platform_map.t * state Platform_map.t
 
-val update : platform:string -> switch:Ocaml_version.t -> state -> unit
+val update : platform:string -> switch:Ocaml_version.t option -> state -> unit
 
 val get : unit -> t

--- a/src/pipeline.ml
+++ b/src/pipeline.ml
@@ -211,7 +211,6 @@ module Make (OCurrent : S.OCURRENT) = struct
 
     (* Build the base image for [distro], plus an image for each compiler version. *)
     let pipeline ~ocluster ~repos ~distro arch =
-      Logs.err (fun m -> m "%s" (Distro.human_readable_string_of_distro distro));
       let opam_image =
         let push_target =
           Tag.v distro ~arch
@@ -242,7 +241,6 @@ module Make (OCurrent : S.OCURRENT) = struct
             ~switch s
         in
         ignore x;
-        Logs.err (fun m -> m "  %s" (Ocaml_version.to_string switch));
         (switch, repo_id)
       in
       (* Build the archive image for the debian 10 / x86_64 image only *)

--- a/src/pipeline.ml
+++ b/src/pipeline.ml
@@ -211,6 +211,17 @@ module Make (OCurrent : S.OCURRENT) = struct
 
     (* Build the base image for [distro], plus an image for each compiler version. *)
     let pipeline ~ocluster ~repos ~distro arch =
+      let update_index current distro switch =
+        let+ state = Current.state ~hidden:true current in
+        let s = match state with
+        | Ok _ -> Index.Ok
+        | Error (`Active _) -> Active
+        | Error (`Msg _) -> Failed
+        in
+        Index.update
+          ~platform:(Distro.human_readable_string_of_distro distro)
+          ~switch s
+      in
       let opam_image =
         let push_target =
           Tag.v distro ~arch
@@ -219,6 +230,7 @@ module Make (OCurrent : S.OCURRENT) = struct
         in
         install_opam ~arch ~ocluster ~distro ~repos ~push_target
       in
+      let _ = update_index opam_image distro None in
       let compiler_images =
         Conf.switches ~arch ~distro |> List.map @@ fun switch ->
         let push_target =
@@ -228,19 +240,7 @@ module Make (OCurrent : S.OCURRENT) = struct
         in
         let windows_port = match distro with  `Windows (port, _) -> Some port | _ -> None in
         let repo_id = install_compiler ~distro ~arch ~ocluster ~switch ~push_target ?windows_port opam_image in
-        let open OCurrent.Current.Syntax in
-        let x =
-          let+ state = Current.state ~hidden:true repo_id in
-          let s = match state with
-          | Ok _ -> Index.Ok
-          | Error (`Active _) -> Active
-          | Error (`Msg _) -> Failed
-          in
-          Index.update
-            ~platform:(Distro.human_readable_string_of_distro distro)
-            ~switch s
-        in
-        ignore x;
+        let _ = update_index repo_id distro (Some switch) in
         (switch, repo_id)
       in
       (* Build the archive image for the debian 10 / x86_64 image only *)

--- a/src/s.ml
+++ b/src/s.ml
@@ -15,12 +15,14 @@ module type OCURRENT = sig
 
     val component : ('a, Format.formatter, unit, description) format4 -> 'a
     val ignore_value : 'a t -> unit t
+    val state : ?hidden:bool -> 'a t -> ( 'a, [ `Active of Current_term.Output.active | `Msg of string ] ) result t
     val all : unit t list -> unit t
     val all_labelled : (string * unit t) list -> unit t
     val collapse : key:string -> value:string -> input:_ t -> 'a t -> 'a t
 
     module Syntax : sig
       val (let>) : 'a t -> ('a -> 'b Primitive.t) -> description -> 'b t
+      val (let+) : 'a t -> ('a -> 'b) -> 'b t
     end
   end
 


### PR DESCRIPTION
Creates Prometheus metrics describing for each platform, how many images are running, have successfully built and have failed to build.