### PR TITLE
Add Prometheus metrics for time of last and next image builds

### DIFF
--- a/base-images.opam
+++ b/base-images.opam
@@ -30,6 +30,7 @@ depends: [
   "dockerfile" {>= "8.2.1"}
   "dockerfile-opam" {>= "8.2.1"}
   "ocaml-version" {>= "3.6.1"}
+  "timedesc" {>= "0.9.0"}
   "odoc" {with-doc}
 ]
 build: [

--- a/dune-project
+++ b/dune-project
@@ -33,4 +33,5 @@
   (cmdliner (>= 1.1.1))
   (dockerfile (>= 8.2.1))
   (dockerfile-opam (>= 8.2.1))
-  (ocaml-version (>= 3.6.1))))
+  (ocaml-version (>= 3.6.1))
+  (timedesc (>= 0.9.0))))

--- a/src/base_images.ml
+++ b/src/base_images.ml
@@ -1,56 +1,6 @@
 open Capnp_rpc_lwt
 open Lwt.Infix
 
-module Metrics = struct
-  open Prometheus
-
-  let namespace = "baseimages"
-  let subsystem = "pipeline"
-
-  let family =
-    let help = "Number of images by platform" in
-    Gauge.v_labels ~label_names:["platform"; "state"] ~help ~namespace ~subsystem
-      "image_state_total"
-
-  let next_build_time =
-    let help = "The next time that the images will be rebuilt, in unix time" in
-    Gauge.v ~help ~namespace ~subsystem "next_build_time"
-
-  type stats = { ok : int; failed : int; active : int }
-  let stats_empty = { ok = 0; failed = 0; active = 0 }
-
-  let update () =
-    let incr_stats stats = function
-      | Index.Ok -> { stats with ok = stats.ok + 1 }
-      | Index.Failed -> { stats with failed = stats.failed + 1 }
-      | Index.Active -> { stats with active = stats.active + 1 }
-    in
-    let f opam_map platform sm =
-      let stats =
-        Index.Switch_map.fold
-          (fun _ state stats -> incr_stats stats state)
-          sm stats_empty
-      in
-      let stats =
-        Option.map (incr_stats stats) (Index.Platform_map.find_opt platform opam_map)
-        |> Option.value ~default:stats
-      in
-      Gauge.set (Gauge.labels family [platform; "ok"]) (float_of_int stats.ok);
-      Gauge.set (Gauge.labels family [platform; "failed"]) (float_of_int stats.failed);
-      Gauge.set (Gauge.labels family [platform; "active"]) (float_of_int stats.active)
-    in
-    let v = Index.get_images_per_platform () in
-    Index.Platform_map.iter (f (snd v)) (fst v)
-
-  let set_next_build_time () =
-    Index.get_latest_build_time ()
-    |> Option.iter (fun t ->
-      let time_delta_seconds =
-        float_of_int @@ Pipeline.days_between_rebuilds * 60 * 60 * 24
-      in
-      Gauge.set next_build_time (t +. time_delta_seconds))
-end
-
 let program_name = "base_images"
 
 module Rpc = Current_rpc.Impl(Current)
@@ -59,7 +9,7 @@ let setup_log style_renderer default_level =
   Prometheus_unix.Logging.init ?default_level ();
   Fmt_tty.setup_std_outputs ?style_renderer ();
   Prometheus.CollectorRegistry.(register_pre_collect default) Metrics.update;
-  Metrics.set_next_build_time ()
+  Metrics.init_next_build_time ()
 
 (* A low-security Docker Hub user used to push images to the staging area.
    Low-security because we never rely on the tags in this repository, just the hashes. *)

--- a/src/base_images.ml
+++ b/src/base_images.ml
@@ -9,7 +9,7 @@ let setup_log style_renderer default_level =
   Prometheus_unix.Logging.init ?default_level ();
   Fmt_tty.setup_std_outputs ?style_renderer ();
   Prometheus.CollectorRegistry.(register_pre_collect default) Metrics.update;
-  Metrics.init_next_build_time ()
+  Metrics.init_last_build_time ()
 
 (* A low-security Docker Hub user used to push images to the staging area.
    Low-security because we never rely on the tags in this repository, just the hashes. *)

--- a/src/conf.ml
+++ b/src/conf.ml
@@ -8,6 +8,8 @@ let password_path =
   let root = v (if Sys.win32 then "C:\\ProgramData\\Docker" else "/run") in
   root / "secrets" / "ocurrent-hub" |> to_string
 
+let days_between_rebuilds = 7
+
 module Capnp = struct
   (* Cap'n Proto RPC is enabled by passing --capnp-public-address. These values are hard-coded
      (because they're just internal to the Docker container). *)

--- a/src/dune
+++ b/src/dune
@@ -15,6 +15,7 @@
   lwt.unix
   prometheus-app.unix
   fmt.cli
-  logs.cli)
+  logs.cli
+  timedesc)
  (preprocess
   (pps ppx_deriving_yojson)))

--- a/src/git_repositories.ml
+++ b/src/git_repositories.ml
@@ -62,6 +62,7 @@ module Repositories = struct
     Lwt.return (Ok (String.trim hash))
 
   let build No_context job {Key.opam_repository_master; opam_repository_mingw_sunset; opam_overlays; opam_2_0; opam_2_1; opam_master} =
+    Metrics.set_next_build_time_now ();
     Current.Job.start job ~level:Current.Level.Mostly_harmless >>= fun () ->
     get_commit_hash ~job ~repo:opam_repository_master ~branch:"master" >>!= fun opam_repository_master ->
     get_commit_hash ~job ~repo:opam_repository_mingw_sunset ~branch:"sunset" >>!= fun opam_repository_mingw_sunset ->

--- a/src/git_repositories.ml
+++ b/src/git_repositories.ml
@@ -62,7 +62,7 @@ module Repositories = struct
     Lwt.return (Ok (String.trim hash))
 
   let build No_context job {Key.opam_repository_master; opam_repository_mingw_sunset; opam_overlays; opam_2_0; opam_2_1; opam_master} =
-    Metrics.set_next_build_time_now ();
+    Metrics.set_last_build_time_now ();
     Current.Job.start job ~level:Current.Level.Mostly_harmless >>= fun () ->
     get_commit_hash ~job ~repo:opam_repository_master ~branch:"master" >>!= fun opam_repository_master ->
     get_commit_hash ~job ~repo:opam_repository_mingw_sunset ~branch:"sunset" >>!= fun opam_repository_mingw_sunset ->

--- a/src/index.ml
+++ b/src/index.ml
@@ -7,7 +7,7 @@ type t = state Switch_map.t Platform_map.t * state Platform_map.t
 
 let v : t ref = ref Platform_map.(empty, empty)
 
-let update ~platform ~switch state =
+let update_images_per_platform ~platform ~switch state =
   let update_switch_map switch sm =
     Option.some @@ match sm with
     | None -> Switch_map.singleton switch state
@@ -20,4 +20,48 @@ let update ~platform ~switch state =
   | Some switch ->
       v := Platform_map.update platform (update_switch_map switch) (fst m), snd m
 
-let get () = !v
+let get_images_per_platform () = !v
+
+module Db = Current.Db
+
+type db_t = {
+  get_latest_build_time : Sqlite3.stmt;
+}
+
+let db =
+  lazy
+    (let db = Lazy.force Current.Db.v in
+     Current_cache.Db.init ();
+     let get_latest_build_time =
+       Sqlite3.prepare db
+         "SELECT MAX(ready) FROM cache WHERE op = 'git-repositories'"
+     in
+     {
+      get_latest_build_time;
+     })
+
+let get_latest_build_time () =
+  let t = Lazy.force db in
+  let ts =
+    Db.query t.get_latest_build_time []
+    |> List.map @@ function
+      | [ ready ] -> ready
+      | row -> Fmt.failwith "get_latest_build_time: invalid row %a" Db.dump_row row
+  in
+  let parse v =
+    (* Timedesc parsing will fail without a timezone, so add Z for UTC *)
+    let v = Printf.sprintf "%sZ" v in
+    match Timedesc.of_iso8601 v with
+    | Error msg -> Fmt.failwith "get_latest_build_time: failure parsing %s: %s" v msg
+    | Ok v ->
+      Timedesc.(to_timestamp_float_s v
+      |> min_of_local_dt_result)
+      |> Option.some
+  in
+  match ts with
+  | [] -> None
+  | [ ready ] ->
+    (match ready with
+    | Sqlite3.Data.TEXT v -> parse v
+    | _ -> Fmt.failwith "get_latest_build_time: data was not type TEXT")
+  | row -> Fmt.failwith "get_latest_build_time: more than one value returned %a" Db.dump_row row

--- a/src/index.mli
+++ b/src/index.mli
@@ -6,6 +6,8 @@ type state = Ok | Failed | Active
 
 type t = state Switch_map.t Platform_map.t * state Platform_map.t
 
-val update : platform:string -> switch:Ocaml_version.t option -> state -> unit
+val update_images_per_platform : platform:string -> switch:Ocaml_version.t option -> state -> unit
 
-val get : unit -> t
+val get_images_per_platform : unit -> t
+
+val get_latest_build_time : unit -> float option

--- a/src/metrics.ml
+++ b/src/metrics.ml
@@ -8,9 +8,13 @@ let family =
   Gauge.v_labels ~label_names:["platform"; "state"] ~help ~namespace ~subsystem
     "image_state_total"
 
-let next_build_time =
-  let help = "The next time that the images will be rebuilt, in unix time" in
-  Gauge.v ~help ~namespace ~subsystem "next_build_time"
+let last_build_time =
+  let help = "When the images were last built, in unix time" in
+  Gauge.v ~help ~namespace ~subsystem "last_build_time"
+
+let image_valid_time =
+  let help = "How long images are valid for until they are rebuilt, in seconds" in
+  Gauge.v ~help ~namespace ~subsystem "valid_time"
 
 type stats = { ok : int; failed : int; active : int }
 let stats_empty = { ok = 0; failed = 0; active = 0 }
@@ -38,23 +42,19 @@ let update () =
   let v = Index.get_images_per_platform () in
   Index.Platform_map.iter (f (snd v)) (fst v)
 
-let add_days_between_to_ts t =
-  let time_delta_seconds =
-    float_of_int @@ Conf.days_between_rebuilds * 60 * 60 * 24
-  in
-  Gauge.set next_build_time (t +. time_delta_seconds)
-
-let init_next_build_time () =
+let init_last_build_time () =
   Index.get_latest_build_time ()
-  |> Option.iter add_days_between_to_ts
+  |> Option.iter (Gauge.set last_build_time);
+  Gauge.set image_valid_time
+    (float_of_int @@ Conf.days_between_rebuilds * 60 * 60 * 24)
 (** Initialise the next build time by reading
    the last build time from the OCurrent DB
    and adding `days_between_rebuilds` *)
 
-let set_next_build_time_now () =
+let set_last_build_time_now () =
   Timedesc.(now ()
   |> to_timestamp_float_s
   |> min_of_local_dt_result)
-  |> add_days_between_to_ts
+  |> Gauge.set last_build_time
 (** Set the next build time to the current
    time adding `days_between_rebuilds` *)

--- a/src/metrics.ml
+++ b/src/metrics.ml
@@ -1,0 +1,60 @@
+open Prometheus
+
+let namespace = "baseimages"
+let subsystem = "pipeline"
+
+let family =
+  let help = "Number of images by platform" in
+  Gauge.v_labels ~label_names:["platform"; "state"] ~help ~namespace ~subsystem
+    "image_state_total"
+
+let next_build_time =
+  let help = "The next time that the images will be rebuilt, in unix time" in
+  Gauge.v ~help ~namespace ~subsystem "next_build_time"
+
+type stats = { ok : int; failed : int; active : int }
+let stats_empty = { ok = 0; failed = 0; active = 0 }
+
+let update () =
+  let incr_stats stats = function
+    | Index.Ok -> { stats with ok = stats.ok + 1 }
+    | Index.Failed -> { stats with failed = stats.failed + 1 }
+    | Index.Active -> { stats with active = stats.active + 1 }
+  in
+  let f opam_map platform sm =
+    let stats =
+      Index.Switch_map.fold
+        (fun _ state stats -> incr_stats stats state)
+        sm stats_empty
+    in
+    let stats =
+      Option.map (incr_stats stats) (Index.Platform_map.find_opt platform opam_map)
+      |> Option.value ~default:stats
+    in
+    Gauge.set (Gauge.labels family [platform; "ok"]) (float_of_int stats.ok);
+    Gauge.set (Gauge.labels family [platform; "failed"]) (float_of_int stats.failed);
+    Gauge.set (Gauge.labels family [platform; "active"]) (float_of_int stats.active)
+  in
+  let v = Index.get_images_per_platform () in
+  Index.Platform_map.iter (f (snd v)) (fst v)
+
+let add_days_between_to_ts t =
+  let time_delta_seconds =
+    float_of_int @@ Conf.days_between_rebuilds * 60 * 60 * 24
+  in
+  Gauge.set next_build_time (t +. time_delta_seconds)
+
+let init_next_build_time () =
+  Index.get_latest_build_time ()
+  |> Option.iter add_days_between_to_ts
+(** Initialise the next build time by reading
+   the last build time from the OCurrent DB
+   and adding `days_between_rebuilds` *)
+
+let set_next_build_time_now () =
+  Timedesc.(now ()
+  |> to_timestamp_float_s
+  |> min_of_local_dt_result)
+  |> add_days_between_to_ts
+(** Set the next build time to the current
+   time adding `days_between_rebuilds` *)

--- a/src/metrics.mli
+++ b/src/metrics.mli
@@ -1,0 +1,3 @@
+val update : unit -> unit
+val init_next_build_time : unit -> unit
+val set_next_build_time_now : unit -> unit

--- a/src/metrics.mli
+++ b/src/metrics.mli
@@ -1,3 +1,3 @@
 val update : unit -> unit
-val init_next_build_time : unit -> unit
-val set_next_build_time_now : unit -> unit
+val init_last_build_time : unit -> unit
+val set_last_build_time_now : unit -> unit

--- a/src/pipeline.ml
+++ b/src/pipeline.ml
@@ -3,7 +3,9 @@ module Windows = Dockerfile_opam.Windows
 
 module Switch_map = Map.Make(Ocaml_version)
 
-let weekly = Current_cache.Schedule.v ~valid_for:(Duration.of_day 7) ()
+let days_between_rebuilds = 7
+
+let weekly = Current_cache.Schedule.v ~valid_for:(Duration.of_day days_between_rebuilds) ()
 
 let git_repositories () =
   Git_repositories.get ~schedule:weekly
@@ -218,7 +220,7 @@ module Make (OCurrent : S.OCURRENT) = struct
         | Error (`Active _) -> Active
         | Error (`Msg _) -> Failed
         in
-        Index.update
+        Index.update_images_per_platform
           ~platform:(Distro.human_readable_string_of_distro distro)
           ~switch s
       in

--- a/src/pipeline.ml
+++ b/src/pipeline.ml
@@ -3,9 +3,7 @@ module Windows = Dockerfile_opam.Windows
 
 module Switch_map = Map.Make(Ocaml_version)
 
-let days_between_rebuilds = 7
-
-let weekly = Current_cache.Schedule.v ~valid_for:(Duration.of_day days_between_rebuilds) ()
+let weekly = Current_cache.Schedule.v ~valid_for:(Duration.of_day Conf.days_between_rebuilds) ()
 
 let git_repositories () =
   Git_repositories.get ~schedule:weekly

--- a/src/pipeline.mli
+++ b/src/pipeline.mli
@@ -4,7 +4,5 @@ module Make (OCurrent : S.OCURRENT) : sig
   val v : ocluster:OCluster.t -> Git_repositories.t Current.t -> unit Current.t
 end
 
-val days_between_rebuilds : int
-
 val v : ?channel:Current_slack.channel -> ocluster:Current_ocluster.t -> unit -> unit Current.t
 (** The main pipeline. Builds images for all supported distribution, compiler version and architecture combinations. *)

--- a/src/pipeline.mli
+++ b/src/pipeline.mli
@@ -4,5 +4,7 @@ module Make (OCurrent : S.OCURRENT) : sig
   val v : ocluster:OCluster.t -> Git_repositories.t Current.t -> unit Current.t
 end
 
+val days_between_rebuilds : int
+
 val v : ?channel:Current_slack.channel -> ocluster:Current_ocluster.t -> unit -> unit Current.t
 (** The main pipeline. Builds images for all supported distribution, compiler version and architecture combinations. *)


### PR DESCRIPTION
This PR adds Prometheus metrics that support showing when the images were last built, and when they will be rebuilt. The two added metrics are the last build time and the time between builds, from which the next build time can be calculated.

This requires two features:
- To initialise the last-build-time value when `base-images` starts, we read the OCurrent DB to find the timestamp of the latest build. Here we also set the time-between-builds value.
- To update the value, when `base-images` reruns the pipeline we update last-build-time with the current timestamp. time-between-builds does not need to be updated as it doesn't change.

Example Grafana output:
<img width="708" alt="Screenshot 2023-11-16 at 17 10 50" src="https://github.com/ocurrent/docker-base-images/assets/13054139/c1749a07-f03d-4f01-b3c4-11d52d74de4b">

