### PR TITLE
Add case for an empty database

### DIFF
--- a/src/index.ml
+++ b/src/index.ml
@@ -63,5 +63,6 @@ let get_latest_build_time () =
   | [ ready ] ->
     (match ready with
     | Sqlite3.Data.TEXT v -> parse v
+    | Sqlite3.Data.NULL -> None
     | _ -> Fmt.failwith "get_latest_build_time: data was not type TEXT")
   | row -> Fmt.failwith "get_latest_build_time: more than one value returned %a" Db.dump_row row


### PR DESCRIPTION
When the database is empty, such as on first use, the application fails to run:-

```
$ ./_build/install/default/bin/base-images
base_images: internal error, uncaught exception:
             Failure("get_latest_build_time: data was not type TEXT")
```

This is because `SELECT MAX(ready) FROM cache WHERE op = 'git-repositories'` returns no rows.