### PR TITLE
Add metric for images per OCaml version

### DIFF
--- a/src/index.ml
+++ b/src/index.ml
@@ -2,7 +2,7 @@ module Platform_map = Map.Make (String)
 module Switch_map = Map.Make (Ocaml_version)
 
 type state = Ok | Failed | Active
-(* Each platform builds one non-OCaml opam image, and then an image for every version of OCaml *)
+
 type t = state Switch_map.t Platform_map.t * state Platform_map.t
 
 let v : t ref = ref Platform_map.(empty, empty)

--- a/src/index.mli
+++ b/src/index.mli
@@ -4,10 +4,13 @@ module Switch_map : (Map.S with type key = Ocaml_version.t)
 
 type state = Ok | Failed | Active
 
+(** Each platform builds one non-OCaml opam image, and then an image for every version of OCaml.
+    For [p : platforms], [fst p] is the state for the image of each switch for each platform,
+    and [snd p] is the state for the non-OCaml image for each platform. *)
 type t = state Switch_map.t Platform_map.t * state Platform_map.t
 
-val update_images_per_platform : platform:string -> switch:Ocaml_version.t option -> state -> unit
-
 val get_images_per_platform : unit -> t
+
+val update_images_per_platform : platform:string -> switch:Ocaml_version.t option -> state -> unit
 
 val get_latest_build_time : unit -> float option

--- a/src/metrics.ml
+++ b/src/metrics.ml
@@ -3,10 +3,15 @@ open Prometheus
 let namespace = "baseimages"
 let subsystem = "pipeline"
 
-let family =
+let platform_family =
   let help = "Number of images by platform" in
   Gauge.v_labels ~label_names:["platform"; "state"] ~help ~namespace ~subsystem
-    "image_state_total"
+    "image_platform_state_total"
+
+let version_family =
+  let help = "Number of images by OCaml version" in
+  Gauge.v_labels ~label_names:["version"; "state"] ~help ~namespace ~subsystem
+    "image_version_state_total"
 
 let last_build_time =
   let help = "When the images were last built, in unix time" in
@@ -19,31 +24,61 @@ let image_valid_time =
 type stats = { ok : int; failed : int; active : int }
 let stats_empty = { ok = 0; failed = 0; active = 0 }
 
-let update () =
-  let incr_stats stats = function
-    | Index.Ok -> { stats with ok = stats.ok + 1 }
-    | Index.Failed -> { stats with failed = stats.failed + 1 }
-    | Index.Active -> { stats with active = stats.active + 1 }
-  in
+open Index
+
+let incr_stats stats = function
+  | Ok -> { stats with ok = stats.ok + 1 }
+  | Failed -> { stats with failed = stats.failed + 1 }
+  | Active -> { stats with active = stats.active + 1 }
+
+let update_images_per_platform ocaml_images non_ocaml_images =
   let f opam_map platform sm =
     let stats =
-      Index.Switch_map.fold
+      Switch_map.fold
         (fun _ state stats -> incr_stats stats state)
         sm stats_empty
     in
     let stats =
-      Option.map (incr_stats stats) (Index.Platform_map.find_opt platform opam_map)
+      Option.map (incr_stats stats) (Platform_map.find_opt platform opam_map)
       |> Option.value ~default:stats
     in
-    Gauge.set (Gauge.labels family [platform; "ok"]) (float_of_int stats.ok);
-    Gauge.set (Gauge.labels family [platform; "failed"]) (float_of_int stats.failed);
-    Gauge.set (Gauge.labels family [platform; "active"]) (float_of_int stats.active)
+    Gauge.set (Gauge.labels platform_family [platform; "ok"])
+      (float_of_int stats.ok);
+    Gauge.set (Gauge.labels platform_family [platform; "failed"])
+      (float_of_int stats.failed);
+    Gauge.set (Gauge.labels platform_family [platform; "active"])
+      (float_of_int stats.active)
   in
-  let v = Index.get_images_per_platform () in
-  Index.Platform_map.iter (f (snd v)) (fst v)
+  Platform_map.iter (f non_ocaml_images) ocaml_images
+
+let update_images_per_version ocaml_images =
+  let f v state acc =
+    let stats =
+      Option.value ~default:stats_empty @@ Switch_map.find_opt v acc
+    in
+    Switch_map.add v (incr_stats stats state) acc
+  in
+  let stats =
+    Platform_map.fold (fun _ sm acc -> Switch_map.fold f sm acc)
+      ocaml_images Switch_map.empty
+  in
+  Switch_map.iter (fun v stats ->
+    let version = Ocaml_version.to_string v in
+    Gauge.set (Gauge.labels version_family [version; "ok"])
+      (float_of_int stats.ok);
+    Gauge.set (Gauge.labels version_family [version; "failed"])
+      (float_of_int stats.failed);
+    Gauge.set (Gauge.labels version_family [version; "active"])
+      (float_of_int stats.active))
+    stats
+
+let update () =
+  let ocaml_images, non_ocaml_images = get_images_per_platform () in
+  update_images_per_platform ocaml_images non_ocaml_images;
+  update_images_per_version ocaml_images
 
 let init_last_build_time () =
-  Index.get_latest_build_time ()
+  get_latest_build_time ()
   |> Option.iter (Gauge.set last_build_time);
   Gauge.set image_valid_time
     (float_of_int @@ Conf.days_between_rebuilds * 60 * 60 * 24)


### PR DESCRIPTION
Similar to the existing metric for counting the statuses of images per platform.