### PR TITLE
Ignore local opam switches

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.install
 .merlin
 _build
+_opam
 var
 capnp-secrets/


### PR DESCRIPTION
by adding `_opam` to the gitignor