### PR TITLE
Mark as unavailable on debian 12 x86 32

### DIFF
--- a/base-images.opam.template
+++ b/base-images.opam.template
@@ -1,0 +1,2 @@
+# See https://github.com/ocurrent/ocaml-ci/issues/931
+available: !(os-distribution = "debian" & os-version = "12" & arch = "x86_32")


### PR DESCRIPTION
This will fix our CI, as per https://github.com/ocurrent/ocaml-ci/issues/931#issuecomment-2211396652