### PR TITLE
A non-ideal (and probably erroneous) approach to retrying on failed pushes

### DIFF
--- a/src/dune
+++ b/src/dune
@@ -2,20 +2,20 @@
  (public_name base-images)
  (name base_images)
  (libraries
+  capnp-rpc-unix
   current
-  current_web
   current_docker
-  current_slack
   current_git
   current_github
   current_ocluster
   current_rpc
-  capnp-rpc-unix
+  current_slack
+  current_web
   dockerfile-opam
-  lwt.unix
-  prometheus-app.unix
   fmt.cli
   logs.cli
+  lwt.unix
+  prometheus-app.unix
   timedesc)
  (preprocess
   (pps ppx_deriving_yojson)))

--- a/src/dune
+++ b/src/dune
@@ -16,6 +16,7 @@
   logs.cli
   lwt.unix
   prometheus-app.unix
+  str
   timedesc)
  (preprocess
   (pps ppx_deriving_yojson)))


### PR DESCRIPTION
Sharing this draft to help inform discussion on approaches to #211

I think this shows that it is possible to add retry logic to docker pushes without either reimplementing the `push_manifest` current or making changes to ocurrent. However, I think it also shows that this approach isn't ideal.

I don't think we'll consider this for merging, but in case we do: I suspect the caching logic of `Wait_current` is wrong, and would want to validate that.