### PR TITLE
Add opam-repository overlay for OCaml < 4.08 on platforms using GCC14

### DIFF
--- a/builds.expected
+++ b/builds.expected
@@ -1916,6 +1916,7 @@ ocurrent/opam-staging:archlinux-opam-amd64 -> ocaml/opam:archlinux-opam
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:archlinux-opam-amd64
+	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.02 --packages=ocaml-base-compiler.4.02.3
 	RUN opam pin add -k version ocaml-base-compiler 4.02.3
@@ -1930,6 +1931,7 @@ ocurrent/opam-staging:archlinux-ocaml-4.02-amd64 -> ocaml/opam:archlinux-ocaml-4
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:archlinux-opam-amd64
+	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.03 --packages=ocaml-base-compiler.4.03.0
 	RUN opam pin add -k version ocaml-base-compiler 4.03.0
@@ -1944,6 +1946,7 @@ ocurrent/opam-staging:archlinux-ocaml-4.03-amd64 -> ocaml/opam:archlinux-ocaml-4
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:archlinux-opam-amd64
+	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.04 --packages=ocaml-base-compiler.4.04.2
 	RUN opam pin add -k version ocaml-base-compiler 4.04.2
@@ -1958,6 +1961,7 @@ ocurrent/opam-staging:archlinux-ocaml-4.04-amd64 -> ocaml/opam:archlinux-ocaml-4
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:archlinux-opam-amd64
+	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.05 --packages=ocaml-base-compiler.4.05.0
 	RUN opam pin add -k version ocaml-base-compiler 4.05.0
@@ -1972,6 +1976,7 @@ ocurrent/opam-staging:archlinux-ocaml-4.05-amd64 -> ocaml/opam:archlinux-ocaml-4
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:archlinux-opam-amd64
+	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.06 --packages=ocaml-base-compiler.4.06.1
 	RUN opam pin add -k version ocaml-base-compiler 4.06.1
@@ -1986,6 +1991,7 @@ ocurrent/opam-staging:archlinux-ocaml-4.06-amd64 -> ocaml/opam:archlinux-ocaml-4
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:archlinux-opam-amd64
+	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.07 --packages=ocaml-base-compiler.4.07.1
 	RUN opam pin add -k version ocaml-base-compiler 4.07.1
@@ -8930,6 +8936,7 @@ ocurrent/opam-staging:debian-testing-opam-amd64 -> ocaml/opam:debian-testing-opa
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-testing-opam-amd64
+	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.02 --packages=ocaml-base-compiler.4.02.3
 	RUN opam pin add -k version ocaml-base-compiler 4.02.3
@@ -8944,6 +8951,7 @@ ocurrent/opam-staging:debian-testing-ocaml-4.02-amd64 -> ocaml/opam:debian-testi
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-testing-opam-amd64
+	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.03 --packages=ocaml-base-compiler.4.03.0
 	RUN opam pin add -k version ocaml-base-compiler 4.03.0
@@ -8958,6 +8966,7 @@ ocurrent/opam-staging:debian-testing-ocaml-4.03-amd64 -> ocaml/opam:debian-testi
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-testing-opam-amd64
+	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.04 --packages=ocaml-base-compiler.4.04.2
 	RUN opam pin add -k version ocaml-base-compiler 4.04.2
@@ -8972,6 +8981,7 @@ ocurrent/opam-staging:debian-testing-ocaml-4.04-amd64 -> ocaml/opam:debian-testi
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-testing-opam-amd64
+	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.05 --packages=ocaml-base-compiler.4.05.0
 	RUN opam pin add -k version ocaml-base-compiler 4.05.0
@@ -8986,6 +8996,7 @@ ocurrent/opam-staging:debian-testing-ocaml-4.05-amd64 -> ocaml/opam:debian-testi
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-testing-opam-amd64
+	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.06 --packages=ocaml-base-compiler.4.06.1
 	RUN opam pin add -k version ocaml-base-compiler 4.06.1
@@ -9000,6 +9011,7 @@ ocurrent/opam-staging:debian-testing-ocaml-4.06-amd64 -> ocaml/opam:debian-testi
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-testing-opam-amd64
+	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.07 --packages=ocaml-base-compiler.4.07.1
 	RUN opam pin add -k version ocaml-base-compiler 4.07.1
@@ -9254,6 +9266,7 @@ ocurrent/opam-staging:debian-unstable-opam-amd64 -> ocaml/opam:debian-unstable-o
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-unstable-opam-amd64
+	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.02 --packages=ocaml-base-compiler.4.02.3
 	RUN opam pin add -k version ocaml-base-compiler 4.02.3
@@ -9268,6 +9281,7 @@ ocurrent/opam-staging:debian-unstable-ocaml-4.02-amd64 -> ocaml/opam:debian-unst
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-unstable-opam-amd64
+	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.03 --packages=ocaml-base-compiler.4.03.0
 	RUN opam pin add -k version ocaml-base-compiler 4.03.0
@@ -9282,6 +9296,7 @@ ocurrent/opam-staging:debian-unstable-ocaml-4.03-amd64 -> ocaml/opam:debian-unst
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-unstable-opam-amd64
+	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.04 --packages=ocaml-base-compiler.4.04.2
 	RUN opam pin add -k version ocaml-base-compiler 4.04.2
@@ -9296,6 +9311,7 @@ ocurrent/opam-staging:debian-unstable-ocaml-4.04-amd64 -> ocaml/opam:debian-unst
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-unstable-opam-amd64
+	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.05 --packages=ocaml-base-compiler.4.05.0
 	RUN opam pin add -k version ocaml-base-compiler 4.05.0
@@ -9310,6 +9326,7 @@ ocurrent/opam-staging:debian-unstable-ocaml-4.05-amd64 -> ocaml/opam:debian-unst
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-unstable-opam-amd64
+	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.06 --packages=ocaml-base-compiler.4.06.1
 	RUN opam pin add -k version ocaml-base-compiler 4.06.1
@@ -9324,6 +9341,7 @@ ocurrent/opam-staging:debian-unstable-ocaml-4.06-amd64 -> ocaml/opam:debian-unst
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-unstable-opam-amd64
+	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.07 --packages=ocaml-base-compiler.4.07.1
 	RUN opam pin add -k version ocaml-base-compiler 4.07.1
@@ -10186,6 +10204,7 @@ ocurrent/opam-staging:fedora-40-opam-arm64, ocurrent/opam-staging:fedora-40-opam
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:fedora-40-opam-amd64
+	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.02 --packages=ocaml-base-compiler.4.02.3
 	RUN opam pin add -k version ocaml-base-compiler 4.02.3
@@ -10201,6 +10220,7 @@ ocurrent/opam-staging:fedora-40-ocaml-4.02-amd64 -> ocaml/opam:fedora-ocaml-4.02
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:fedora-40-opam-amd64
+	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.03 --packages=ocaml-base-compiler.4.03.0
 	RUN opam pin add -k version ocaml-base-compiler 4.03.0
@@ -10216,6 +10236,7 @@ ocurrent/opam-staging:fedora-40-ocaml-4.03-amd64 -> ocaml/opam:fedora-ocaml-4.03
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:fedora-40-opam-amd64
+	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.04 --packages=ocaml-base-compiler.4.04.2
 	RUN opam pin add -k version ocaml-base-compiler 4.04.2
@@ -10231,6 +10252,7 @@ ocurrent/opam-staging:fedora-40-ocaml-4.04-amd64 -> ocaml/opam:fedora-ocaml-4.04
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:fedora-40-opam-amd64
+	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.05 --packages=ocaml-base-compiler.4.05.0
 	RUN opam pin add -k version ocaml-base-compiler 4.05.0
@@ -10246,6 +10268,7 @@ ocurrent/opam-staging:fedora-40-ocaml-4.05-amd64 -> ocaml/opam:fedora-ocaml-4.05
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:fedora-40-opam-amd64
+	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.06 --packages=ocaml-base-compiler.4.06.1
 	RUN opam pin add -k version ocaml-base-compiler 4.06.1
@@ -10261,6 +10284,7 @@ ocurrent/opam-staging:fedora-40-ocaml-4.06-amd64 -> ocaml/opam:fedora-ocaml-4.06
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:fedora-40-opam-amd64
+	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.07 --packages=ocaml-base-compiler.4.07.1
 	RUN opam pin add -k version ocaml-base-compiler 4.07.1
@@ -11956,6 +11980,7 @@ ocurrent/opam-staging:opensuse-tumbleweed-opam-amd64 -> ocaml/opam:opensuse-tumb
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:opensuse-tumbleweed-opam-amd64
+	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.02 --packages=ocaml-base-compiler.4.02.3
 	RUN opam pin add -k version ocaml-base-compiler 4.02.3
@@ -11970,6 +11995,7 @@ ocurrent/opam-staging:opensuse-tumbleweed-ocaml-4.02-amd64 -> ocaml/opam:opensus
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:opensuse-tumbleweed-opam-amd64
+	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.03 --packages=ocaml-base-compiler.4.03.0
 	RUN opam pin add -k version ocaml-base-compiler 4.03.0
@@ -11984,6 +12010,7 @@ ocurrent/opam-staging:opensuse-tumbleweed-ocaml-4.03-amd64 -> ocaml/opam:opensus
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:opensuse-tumbleweed-opam-amd64
+	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.04 --packages=ocaml-base-compiler.4.04.2
 	RUN opam pin add -k version ocaml-base-compiler 4.04.2
@@ -11998,6 +12025,7 @@ ocurrent/opam-staging:opensuse-tumbleweed-ocaml-4.04-amd64 -> ocaml/opam:opensus
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:opensuse-tumbleweed-opam-amd64
+	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.05 --packages=ocaml-base-compiler.4.05.0
 	RUN opam pin add -k version ocaml-base-compiler 4.05.0
@@ -12012,6 +12040,7 @@ ocurrent/opam-staging:opensuse-tumbleweed-ocaml-4.05-amd64 -> ocaml/opam:opensus
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:opensuse-tumbleweed-opam-amd64
+	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.06 --packages=ocaml-base-compiler.4.06.1
 	RUN opam pin add -k version ocaml-base-compiler 4.06.1
@@ -12026,6 +12055,7 @@ ocurrent/opam-staging:opensuse-tumbleweed-ocaml-4.06-amd64 -> ocaml/opam:opensus
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:opensuse-tumbleweed-opam-amd64
+	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.07 --packages=ocaml-base-compiler.4.07.1
 	RUN opam pin add -k version ocaml-base-compiler 4.07.1

--- a/src/pipeline.ml
+++ b/src/pipeline.ml
@@ -26,6 +26,20 @@ let master_distro = Distro.((resolve_alias master_distro : distro :> t))
 
 type 'a run = ('a, unit, string, Dockerfile.t) format4 -> 'a
 
+(* TODO: This opam repository overlay contains patches to OCaml which allows version < 4.08 to build on GCC14
+ * See https://github.com/ocurrent/docker-base-images/issues/279 *)
+let maybe_add_overlay (run : 'a run) distro switch =
+  let gcc14_minimum = Ocaml_version.Releases.v4_08 in
+  match Ocaml_version.compare switch gcc14_minimum < 0, distro with
+  | true, `Archlinux `Latest
+  | true, `Debian `Testing
+  | true, `Debian `Unstable
+  | true, `Fedora `V40
+  | true, `OpenSUSE `Tumbleweed ->
+    run "opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default"
+  | _, _ ->
+    Dockerfile.empty
+
 let maybe_add_beta (run : 'a run) switch =
   if Ocaml_version.Releases.is_dev switch ||
       List.mem switch Ocaml_version.Releases.unreleased_betas then
@@ -91,6 +105,7 @@ let install_compiler_df ~distro ~arch ~switch ?windows_port opam_image =
    | `Windows | `Cygwin -> parser_directive (`Escape '`')) @@
   from opam_image @@
   shell @@
+  maybe_add_overlay run distro switch @@
   maybe_add_beta run switch @@
   maybe_add_multicore run switch @@
   env ["OPAMYES", "1";


### PR DESCRIPTION
This PR is a temporary workaround to build the base images for OCaml < 4.08, which are compiled with GCC 14.  Currently, Arch, Debian, Fedora and OpenSUSE fail to build switches as these distros have moved to GCC 14.