### PR TITLE
Include opam repository archive

### DIFF
--- a/builds.expected
+++ b/builds.expected
@@ -158,6 +158,7 @@ ocurrent/opam-staging:alpine-3.21-opam-arm64, ocurrent/opam-staging:alpine-3.21-
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:alpine-3.21-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.02 --packages=ocaml-base-compiler.4.02.3
@@ -174,6 +175,7 @@ ocurrent/opam-staging:alpine-3.21-ocaml-4.02-amd64 -> ocaml/opam:alpine-ocaml-4.
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:alpine-3.21-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.03 --packages=ocaml-base-compiler.4.03.0
@@ -190,6 +192,7 @@ ocurrent/opam-staging:alpine-3.21-ocaml-4.03-amd64 -> ocaml/opam:alpine-ocaml-4.
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:alpine-3.21-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.03 --packages=ocaml-variants.4.03.0+flambda
@@ -206,6 +209,7 @@ ocurrent/opam-staging:alpine-3.21-ocaml-4.03-flambda-amd64 -> ocaml/opam:alpine-
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:alpine-3.21-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.04 --packages=ocaml-base-compiler.4.04.2
@@ -222,6 +226,7 @@ ocurrent/opam-staging:alpine-3.21-ocaml-4.04-amd64 -> ocaml/opam:alpine-ocaml-4.
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:alpine-3.21-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.04 --packages=ocaml-variants.4.04.2+flambda
@@ -238,6 +243,7 @@ ocurrent/opam-staging:alpine-3.21-ocaml-4.04-flambda-amd64 -> ocaml/opam:alpine-
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:alpine-3.21-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.05 --packages=ocaml-base-compiler.4.05.0
@@ -254,6 +260,7 @@ ocurrent/opam-staging:alpine-3.21-ocaml-4.05-amd64 -> ocaml/opam:alpine-ocaml-4.
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:alpine-3.21-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.05 --packages=ocaml-variants.4.05.0+afl
@@ -270,6 +277,7 @@ ocurrent/opam-staging:alpine-3.21-ocaml-4.05-afl-amd64 -> ocaml/opam:alpine-ocam
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:alpine-3.21-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.05 --packages=ocaml-variants.4.05.0+flambda
@@ -286,6 +294,7 @@ ocurrent/opam-staging:alpine-3.21-ocaml-4.05-flambda-amd64 -> ocaml/opam:alpine-
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:alpine-3.21-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.06 --packages=ocaml-base-compiler.4.06.1
@@ -300,6 +309,7 @@ ocurrent/opam-staging:alpine-3.21-ocaml-4.05-flambda-amd64 -> ocaml/opam:alpine-
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:alpine-3.21-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.06 --packages=ocaml-base-compiler.4.06.1
@@ -316,6 +326,7 @@ ocurrent/opam-staging:alpine-3.21-ocaml-4.06-arm64, ocurrent/opam-staging:alpine
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:alpine-3.21-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.06 --packages=ocaml-variants.4.06.1+afl
@@ -330,6 +341,7 @@ ocurrent/opam-staging:alpine-3.21-ocaml-4.06-arm64, ocurrent/opam-staging:alpine
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:alpine-3.21-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.06 --packages=ocaml-variants.4.06.1+afl
@@ -346,6 +358,7 @@ ocurrent/opam-staging:alpine-3.21-ocaml-4.06-afl-arm64, ocurrent/opam-staging:al
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:alpine-3.21-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.06 --packages=ocaml-variants.4.06.1+flambda
@@ -360,6 +373,7 @@ ocurrent/opam-staging:alpine-3.21-ocaml-4.06-afl-arm64, ocurrent/opam-staging:al
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:alpine-3.21-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.06 --packages=ocaml-variants.4.06.1+flambda
@@ -376,6 +390,7 @@ ocurrent/opam-staging:alpine-3.21-ocaml-4.06-flambda-arm64, ocurrent/opam-stagin
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:alpine-3.21-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.07 --packages=ocaml-base-compiler.4.07.1
@@ -390,6 +405,7 @@ ocurrent/opam-staging:alpine-3.21-ocaml-4.06-flambda-arm64, ocurrent/opam-stagin
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:alpine-3.21-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.07 --packages=ocaml-base-compiler.4.07.1
@@ -406,6 +422,7 @@ ocurrent/opam-staging:alpine-3.21-ocaml-4.07-arm64, ocurrent/opam-staging:alpine
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:alpine-3.21-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.07 --packages=ocaml-variants.4.07.1+afl
@@ -420,6 +437,7 @@ ocurrent/opam-staging:alpine-3.21-ocaml-4.07-arm64, ocurrent/opam-staging:alpine
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:alpine-3.21-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.07 --packages=ocaml-variants.4.07.1+afl
@@ -436,6 +454,7 @@ ocurrent/opam-staging:alpine-3.21-ocaml-4.07-afl-arm64, ocurrent/opam-staging:al
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:alpine-3.21-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.07 --packages=ocaml-variants.4.07.1+flambda
@@ -450,6 +469,7 @@ ocurrent/opam-staging:alpine-3.21-ocaml-4.07-afl-arm64, ocurrent/opam-staging:al
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:alpine-3.21-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.07 --packages=ocaml-variants.4.07.1+flambda
@@ -466,6 +486,7 @@ ocurrent/opam-staging:alpine-3.21-ocaml-4.07-flambda-arm64, ocurrent/opam-stagin
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:alpine-3.21-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.08 --packages=ocaml-base-compiler.4.08.1
 	RUN opam pin add -k version ocaml-base-compiler 4.08.1
@@ -478,6 +499,7 @@ ocurrent/opam-staging:alpine-3.21-ocaml-4.07-flambda-arm64, ocurrent/opam-stagin
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:alpine-3.21-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.08 --packages=ocaml-base-compiler.4.08.1
 	RUN opam pin add -k version ocaml-base-compiler 4.08.1
@@ -492,6 +514,7 @@ ocurrent/opam-staging:alpine-3.21-ocaml-4.08-arm64, ocurrent/opam-staging:alpine
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:alpine-3.21-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.08 --packages=ocaml-variants.4.08.1+afl
 	RUN opam pin add -k version ocaml-variants 4.08.1+afl
@@ -504,6 +527,7 @@ ocurrent/opam-staging:alpine-3.21-ocaml-4.08-arm64, ocurrent/opam-staging:alpine
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:alpine-3.21-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.08 --packages=ocaml-variants.4.08.1+afl
 	RUN opam pin add -k version ocaml-variants 4.08.1+afl
@@ -518,6 +542,7 @@ ocurrent/opam-staging:alpine-3.21-ocaml-4.08-afl-arm64, ocurrent/opam-staging:al
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:alpine-3.21-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.08 --packages=ocaml-variants.4.08.1+flambda
 	RUN opam pin add -k version ocaml-variants 4.08.1+flambda
@@ -530,6 +555,7 @@ ocurrent/opam-staging:alpine-3.21-ocaml-4.08-afl-arm64, ocurrent/opam-staging:al
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:alpine-3.21-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.08 --packages=ocaml-variants.4.08.1+flambda
 	RUN opam pin add -k version ocaml-variants 4.08.1+flambda
@@ -544,6 +570,7 @@ ocurrent/opam-staging:alpine-3.21-ocaml-4.08-flambda-arm64, ocurrent/opam-stagin
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:alpine-3.21-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.08 --packages=ocaml-variants.4.08.1+fp
 	RUN opam pin add -k version ocaml-variants 4.08.1+fp
@@ -558,6 +585,7 @@ ocurrent/opam-staging:alpine-3.21-ocaml-4.08-fp-amd64 -> ocaml/opam:alpine-ocaml
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:alpine-3.21-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.09 --packages=ocaml-base-compiler.4.09.1
 	RUN opam pin add -k version ocaml-base-compiler 4.09.1
@@ -570,6 +598,7 @@ ocurrent/opam-staging:alpine-3.21-ocaml-4.08-fp-amd64 -> ocaml/opam:alpine-ocaml
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:alpine-3.21-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.09 --packages=ocaml-base-compiler.4.09.1
 	RUN opam pin add -k version ocaml-base-compiler 4.09.1
@@ -584,6 +613,7 @@ ocurrent/opam-staging:alpine-3.21-ocaml-4.09-arm64, ocurrent/opam-staging:alpine
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:alpine-3.21-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.09 --packages=ocaml-variants.4.09.1+afl
 	RUN opam pin add -k version ocaml-variants 4.09.1+afl
@@ -596,6 +626,7 @@ ocurrent/opam-staging:alpine-3.21-ocaml-4.09-arm64, ocurrent/opam-staging:alpine
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:alpine-3.21-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.09 --packages=ocaml-variants.4.09.1+afl
 	RUN opam pin add -k version ocaml-variants 4.09.1+afl
@@ -610,6 +641,7 @@ ocurrent/opam-staging:alpine-3.21-ocaml-4.09-afl-arm64, ocurrent/opam-staging:al
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:alpine-3.21-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.09 --packages=ocaml-variants.4.09.1+flambda
 	RUN opam pin add -k version ocaml-variants 4.09.1+flambda
@@ -622,6 +654,7 @@ ocurrent/opam-staging:alpine-3.21-ocaml-4.09-afl-arm64, ocurrent/opam-staging:al
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:alpine-3.21-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.09 --packages=ocaml-variants.4.09.1+flambda
 	RUN opam pin add -k version ocaml-variants 4.09.1+flambda
@@ -636,6 +669,7 @@ ocurrent/opam-staging:alpine-3.21-ocaml-4.09-flambda-arm64, ocurrent/opam-stagin
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:alpine-3.21-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.09 --packages=ocaml-variants.4.09.1+fp
 	RUN opam pin add -k version ocaml-variants 4.09.1+fp
@@ -650,6 +684,7 @@ ocurrent/opam-staging:alpine-3.21-ocaml-4.09-fp-amd64 -> ocaml/opam:alpine-ocaml
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:alpine-3.21-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.10 --packages=ocaml-base-compiler.4.10.2
 	RUN opam pin add -k version ocaml-base-compiler 4.10.2
@@ -662,6 +697,7 @@ ocurrent/opam-staging:alpine-3.21-ocaml-4.09-fp-amd64 -> ocaml/opam:alpine-ocaml
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:alpine-3.21-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.10 --packages=ocaml-base-compiler.4.10.2
 	RUN opam pin add -k version ocaml-base-compiler 4.10.2
@@ -676,6 +712,7 @@ ocurrent/opam-staging:alpine-3.21-ocaml-4.10-arm64, ocurrent/opam-staging:alpine
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:alpine-3.21-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.10 --packages=ocaml-variants.4.10.2+afl
 	RUN opam pin add -k version ocaml-variants 4.10.2+afl
@@ -688,6 +725,7 @@ ocurrent/opam-staging:alpine-3.21-ocaml-4.10-arm64, ocurrent/opam-staging:alpine
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:alpine-3.21-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.10 --packages=ocaml-variants.4.10.2+afl
 	RUN opam pin add -k version ocaml-variants 4.10.2+afl
@@ -702,6 +740,7 @@ ocurrent/opam-staging:alpine-3.21-ocaml-4.10-afl-arm64, ocurrent/opam-staging:al
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:alpine-3.21-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.10 --packages=ocaml-variants.4.10.2+flambda
 	RUN opam pin add -k version ocaml-variants 4.10.2+flambda
@@ -714,6 +753,7 @@ ocurrent/opam-staging:alpine-3.21-ocaml-4.10-afl-arm64, ocurrent/opam-staging:al
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:alpine-3.21-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.10 --packages=ocaml-variants.4.10.2+flambda
 	RUN opam pin add -k version ocaml-variants 4.10.2+flambda
@@ -728,6 +768,7 @@ ocurrent/opam-staging:alpine-3.21-ocaml-4.10-flambda-arm64, ocurrent/opam-stagin
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:alpine-3.21-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.10 --packages=ocaml-variants.4.10.2+fp
 	RUN opam pin add -k version ocaml-variants 4.10.2+fp
@@ -742,6 +783,7 @@ ocurrent/opam-staging:alpine-3.21-ocaml-4.10-fp-amd64 -> ocaml/opam:alpine-ocaml
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:alpine-3.21-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.11 --packages=ocaml-base-compiler.4.11.2
 	RUN opam pin add -k version ocaml-base-compiler 4.11.2
@@ -754,6 +796,7 @@ ocurrent/opam-staging:alpine-3.21-ocaml-4.10-fp-amd64 -> ocaml/opam:alpine-ocaml
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:alpine-3.21-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.11 --packages=ocaml-base-compiler.4.11.2
 	RUN opam pin add -k version ocaml-base-compiler 4.11.2
@@ -768,6 +811,7 @@ ocurrent/opam-staging:alpine-3.21-ocaml-4.11-arm64, ocurrent/opam-staging:alpine
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:alpine-3.21-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.11 --packages=ocaml-variants.4.11.2+afl
 	RUN opam pin add -k version ocaml-variants 4.11.2+afl
@@ -780,6 +824,7 @@ ocurrent/opam-staging:alpine-3.21-ocaml-4.11-arm64, ocurrent/opam-staging:alpine
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:alpine-3.21-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.11 --packages=ocaml-variants.4.11.2+afl
 	RUN opam pin add -k version ocaml-variants 4.11.2+afl
@@ -794,6 +839,7 @@ ocurrent/opam-staging:alpine-3.21-ocaml-4.11-afl-arm64, ocurrent/opam-staging:al
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:alpine-3.21-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.11 --packages=ocaml-variants.4.11.2+flambda
 	RUN opam pin add -k version ocaml-variants 4.11.2+flambda
@@ -806,6 +852,7 @@ ocurrent/opam-staging:alpine-3.21-ocaml-4.11-afl-arm64, ocurrent/opam-staging:al
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:alpine-3.21-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.11 --packages=ocaml-variants.4.11.2+flambda
 	RUN opam pin add -k version ocaml-variants 4.11.2+flambda
@@ -820,6 +867,7 @@ ocurrent/opam-staging:alpine-3.21-ocaml-4.11-flambda-arm64, ocurrent/opam-stagin
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:alpine-3.21-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.11 --packages=ocaml-variants.4.11.2+fp
 	RUN opam pin add -k version ocaml-variants 4.11.2+fp
@@ -834,6 +882,7 @@ ocurrent/opam-staging:alpine-3.21-ocaml-4.11-fp-amd64 -> ocaml/opam:alpine-ocaml
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:alpine-3.21-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.12 --packages=ocaml-base-compiler.4.12.1
 	RUN opam pin add -k version ocaml-base-compiler 4.12.1
@@ -846,6 +895,7 @@ ocurrent/opam-staging:alpine-3.21-ocaml-4.11-fp-amd64 -> ocaml/opam:alpine-ocaml
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:alpine-3.21-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.12 --packages=ocaml-base-compiler.4.12.1
 	RUN opam pin add -k version ocaml-base-compiler 4.12.1
@@ -860,6 +910,7 @@ ocurrent/opam-staging:alpine-3.21-ocaml-4.12-arm64, ocurrent/opam-staging:alpine
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:alpine-3.21-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.12 --packages=ocaml-variants.4.12.1+options,ocaml-options-only-afl
 	RUN opam pin add -k version ocaml-variants 4.12.1+options
@@ -872,6 +923,7 @@ ocurrent/opam-staging:alpine-3.21-ocaml-4.12-arm64, ocurrent/opam-staging:alpine
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:alpine-3.21-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.12 --packages=ocaml-variants.4.12.1+options,ocaml-options-only-afl
 	RUN opam pin add -k version ocaml-variants 4.12.1+options
@@ -886,6 +938,7 @@ ocurrent/opam-staging:alpine-3.21-ocaml-4.12-afl-arm64, ocurrent/opam-staging:al
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:alpine-3.21-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.12 --packages=ocaml-variants.4.12.1+options,ocaml-options-only-flambda
 	RUN opam pin add -k version ocaml-variants 4.12.1+options
@@ -898,6 +951,7 @@ ocurrent/opam-staging:alpine-3.21-ocaml-4.12-afl-arm64, ocurrent/opam-staging:al
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:alpine-3.21-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.12 --packages=ocaml-variants.4.12.1+options,ocaml-options-only-flambda
 	RUN opam pin add -k version ocaml-variants 4.12.1+options
@@ -912,6 +966,7 @@ ocurrent/opam-staging:alpine-3.21-ocaml-4.12-flambda-arm64, ocurrent/opam-stagin
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:alpine-3.21-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.12 --packages=ocaml-variants.4.12.1+options,ocaml-options-only-flambda-fp
 	RUN opam pin add -k version ocaml-variants 4.12.1+options
@@ -926,6 +981,7 @@ ocurrent/opam-staging:alpine-3.21-ocaml-4.12-flambda-fp-amd64 -> ocaml/opam:alpi
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:alpine-3.21-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.12 --packages=ocaml-variants.4.12.1+options,ocaml-options-only-fp
 	RUN opam pin add -k version ocaml-variants 4.12.1+options
@@ -940,6 +996,7 @@ ocurrent/opam-staging:alpine-3.21-ocaml-4.12-fp-amd64 -> ocaml/opam:alpine-ocaml
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:alpine-3.21-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.12 --packages=ocaml-variants.4.12.1+options,ocaml-options-only-nnp
 	RUN opam pin add -k version ocaml-variants 4.12.1+options
@@ -952,6 +1009,7 @@ ocurrent/opam-staging:alpine-3.21-ocaml-4.12-fp-amd64 -> ocaml/opam:alpine-ocaml
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:alpine-3.21-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.12 --packages=ocaml-variants.4.12.1+options,ocaml-options-only-nnp
 	RUN opam pin add -k version ocaml-variants 4.12.1+options
@@ -966,6 +1024,7 @@ ocurrent/opam-staging:alpine-3.21-ocaml-4.12-nnp-arm64, ocurrent/opam-staging:al
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:alpine-3.21-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.12 --packages=ocaml-variants.4.12.1+options,ocaml-options-only-nnpchecker
 	RUN opam pin add -k version ocaml-variants 4.12.1+options
@@ -980,6 +1039,7 @@ ocurrent/opam-staging:alpine-3.21-ocaml-4.12-nnpchecker-amd64 -> ocaml/opam:alpi
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:alpine-3.21-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.12 --packages=ocaml-variants.4.12.1+options,ocaml-options-only-no-flat-float-array
 	RUN opam pin add -k version ocaml-variants 4.12.1+options
@@ -992,6 +1052,7 @@ ocurrent/opam-staging:alpine-3.21-ocaml-4.12-nnpchecker-amd64 -> ocaml/opam:alpi
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:alpine-3.21-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.12 --packages=ocaml-variants.4.12.1+options,ocaml-options-only-no-flat-float-array
 	RUN opam pin add -k version ocaml-variants 4.12.1+options
@@ -1006,6 +1067,7 @@ ocurrent/opam-staging:alpine-3.21-ocaml-4.12-no-flat-float-array-arm64, ocurrent
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:alpine-3.21-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.13 --packages=ocaml-base-compiler.4.13.1
 	RUN opam pin add -k version ocaml-base-compiler 4.13.1
@@ -1018,6 +1080,7 @@ ocurrent/opam-staging:alpine-3.21-ocaml-4.12-no-flat-float-array-arm64, ocurrent
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:alpine-3.21-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.13 --packages=ocaml-base-compiler.4.13.1
 	RUN opam pin add -k version ocaml-base-compiler 4.13.1
@@ -1032,6 +1095,7 @@ ocurrent/opam-staging:alpine-3.21-ocaml-4.13-arm64, ocurrent/opam-staging:alpine
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:alpine-3.21-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.13 --packages=ocaml-variants.4.13.1+options,ocaml-options-only-afl
 	RUN opam pin add -k version ocaml-variants 4.13.1+options
@@ -1044,6 +1108,7 @@ ocurrent/opam-staging:alpine-3.21-ocaml-4.13-arm64, ocurrent/opam-staging:alpine
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:alpine-3.21-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.13 --packages=ocaml-variants.4.13.1+options,ocaml-options-only-afl
 	RUN opam pin add -k version ocaml-variants 4.13.1+options
@@ -1058,6 +1123,7 @@ ocurrent/opam-staging:alpine-3.21-ocaml-4.13-afl-arm64, ocurrent/opam-staging:al
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:alpine-3.21-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.13 --packages=ocaml-variants.4.13.1+options,ocaml-options-only-flambda
 	RUN opam pin add -k version ocaml-variants 4.13.1+options
@@ -1070,6 +1136,7 @@ ocurrent/opam-staging:alpine-3.21-ocaml-4.13-afl-arm64, ocurrent/opam-staging:al
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:alpine-3.21-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.13 --packages=ocaml-variants.4.13.1+options,ocaml-options-only-flambda
 	RUN opam pin add -k version ocaml-variants 4.13.1+options
@@ -1084,6 +1151,7 @@ ocurrent/opam-staging:alpine-3.21-ocaml-4.13-flambda-arm64, ocurrent/opam-stagin
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:alpine-3.21-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.13 --packages=ocaml-variants.4.13.1+options,ocaml-options-only-flambda-fp
 	RUN opam pin add -k version ocaml-variants 4.13.1+options
@@ -1098,6 +1166,7 @@ ocurrent/opam-staging:alpine-3.21-ocaml-4.13-flambda-fp-amd64 -> ocaml/opam:alpi
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:alpine-3.21-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.13 --packages=ocaml-variants.4.13.1+options,ocaml-options-only-fp
 	RUN opam pin add -k version ocaml-variants 4.13.1+options
@@ -1112,6 +1181,7 @@ ocurrent/opam-staging:alpine-3.21-ocaml-4.13-fp-amd64 -> ocaml/opam:alpine-ocaml
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:alpine-3.21-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.13 --packages=ocaml-variants.4.13.1+options,ocaml-options-only-nnp
 	RUN opam pin add -k version ocaml-variants 4.13.1+options
@@ -1124,6 +1194,7 @@ ocurrent/opam-staging:alpine-3.21-ocaml-4.13-fp-amd64 -> ocaml/opam:alpine-ocaml
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:alpine-3.21-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.13 --packages=ocaml-variants.4.13.1+options,ocaml-options-only-nnp
 	RUN opam pin add -k version ocaml-variants 4.13.1+options
@@ -1138,6 +1209,7 @@ ocurrent/opam-staging:alpine-3.21-ocaml-4.13-nnp-arm64, ocurrent/opam-staging:al
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:alpine-3.21-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.13 --packages=ocaml-variants.4.13.1+options,ocaml-options-only-nnpchecker
 	RUN opam pin add -k version ocaml-variants 4.13.1+options
@@ -1152,6 +1224,7 @@ ocurrent/opam-staging:alpine-3.21-ocaml-4.13-nnpchecker-amd64 -> ocaml/opam:alpi
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:alpine-3.21-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.13 --packages=ocaml-variants.4.13.1+options,ocaml-options-only-no-flat-float-array
 	RUN opam pin add -k version ocaml-variants 4.13.1+options
@@ -1164,6 +1237,7 @@ ocurrent/opam-staging:alpine-3.21-ocaml-4.13-nnpchecker-amd64 -> ocaml/opam:alpi
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:alpine-3.21-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.13 --packages=ocaml-variants.4.13.1+options,ocaml-options-only-no-flat-float-array
 	RUN opam pin add -k version ocaml-variants 4.13.1+options
@@ -1178,6 +1252,7 @@ ocurrent/opam-staging:alpine-3.21-ocaml-4.13-no-flat-float-array-arm64, ocurrent
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:alpine-3.21-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.14 --packages=ocaml-base-compiler.4.14.2
 	RUN opam pin add -k version ocaml-base-compiler 4.14.2
@@ -1190,6 +1265,7 @@ ocurrent/opam-staging:alpine-3.21-ocaml-4.13-no-flat-float-array-arm64, ocurrent
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:alpine-3.21-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.14 --packages=ocaml-base-compiler.4.14.2
 	RUN opam pin add -k version ocaml-base-compiler 4.14.2
@@ -1204,6 +1280,7 @@ ocurrent/opam-staging:alpine-3.21-ocaml-4.14-arm64, ocurrent/opam-staging:alpine
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:alpine-3.21-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.14 --packages=ocaml-variants.4.14.2+options,ocaml-options-only-afl
 	RUN opam pin add -k version ocaml-variants 4.14.2+options
@@ -1216,6 +1293,7 @@ ocurrent/opam-staging:alpine-3.21-ocaml-4.14-arm64, ocurrent/opam-staging:alpine
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:alpine-3.21-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.14 --packages=ocaml-variants.4.14.2+options,ocaml-options-only-afl
 	RUN opam pin add -k version ocaml-variants 4.14.2+options
@@ -1230,6 +1308,7 @@ ocurrent/opam-staging:alpine-3.21-ocaml-4.14-afl-arm64, ocurrent/opam-staging:al
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:alpine-3.21-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.14 --packages=ocaml-variants.4.14.2+options,ocaml-options-only-flambda
 	RUN opam pin add -k version ocaml-variants 4.14.2+options
@@ -1242,6 +1321,7 @@ ocurrent/opam-staging:alpine-3.21-ocaml-4.14-afl-arm64, ocurrent/opam-staging:al
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:alpine-3.21-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.14 --packages=ocaml-variants.4.14.2+options,ocaml-options-only-flambda
 	RUN opam pin add -k version ocaml-variants 4.14.2+options
@@ -1256,6 +1336,7 @@ ocurrent/opam-staging:alpine-3.21-ocaml-4.14-flambda-arm64, ocurrent/opam-stagin
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:alpine-3.21-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.14 --packages=ocaml-variants.4.14.2+options,ocaml-options-only-flambda-fp
 	RUN opam pin add -k version ocaml-variants 4.14.2+options
@@ -1270,6 +1351,7 @@ ocurrent/opam-staging:alpine-3.21-ocaml-4.14-flambda-fp-amd64 -> ocaml/opam:alpi
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:alpine-3.21-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.14 --packages=ocaml-variants.4.14.2+options,ocaml-options-only-fp
 	RUN opam pin add -k version ocaml-variants 4.14.2+options
@@ -1284,6 +1366,7 @@ ocurrent/opam-staging:alpine-3.21-ocaml-4.14-fp-amd64 -> ocaml/opam:alpine-ocaml
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:alpine-3.21-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.14 --packages=ocaml-variants.4.14.2+options,ocaml-options-only-nnp
 	RUN opam pin add -k version ocaml-variants 4.14.2+options
@@ -1296,6 +1379,7 @@ ocurrent/opam-staging:alpine-3.21-ocaml-4.14-fp-amd64 -> ocaml/opam:alpine-ocaml
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:alpine-3.21-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.14 --packages=ocaml-variants.4.14.2+options,ocaml-options-only-nnp
 	RUN opam pin add -k version ocaml-variants 4.14.2+options
@@ -1310,6 +1394,7 @@ ocurrent/opam-staging:alpine-3.21-ocaml-4.14-nnp-arm64, ocurrent/opam-staging:al
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:alpine-3.21-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.14 --packages=ocaml-variants.4.14.2+options,ocaml-options-only-nnpchecker
 	RUN opam pin add -k version ocaml-variants 4.14.2+options
@@ -1324,6 +1409,7 @@ ocurrent/opam-staging:alpine-3.21-ocaml-4.14-nnpchecker-amd64 -> ocaml/opam:alpi
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:alpine-3.21-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.14 --packages=ocaml-variants.4.14.2+options,ocaml-options-only-no-flat-float-array
 	RUN opam pin add -k version ocaml-variants 4.14.2+options
@@ -1336,6 +1422,7 @@ ocurrent/opam-staging:alpine-3.21-ocaml-4.14-nnpchecker-amd64 -> ocaml/opam:alpi
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:alpine-3.21-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.14 --packages=ocaml-variants.4.14.2+options,ocaml-options-only-no-flat-float-array
 	RUN opam pin add -k version ocaml-variants 4.14.2+options
@@ -1350,6 +1437,7 @@ ocurrent/opam-staging:alpine-3.21-ocaml-4.14-no-flat-float-array-arm64, ocurrent
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:alpine-3.21-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 5.0 --packages=ocaml-base-compiler.5.0.0
 	RUN opam pin add -k version ocaml-base-compiler 5.0.0
@@ -1362,6 +1450,7 @@ ocurrent/opam-staging:alpine-3.21-ocaml-4.14-no-flat-float-array-arm64, ocurrent
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:alpine-3.21-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 5.0 --packages=ocaml-base-compiler.5.0.0
 	RUN opam pin add -k version ocaml-base-compiler 5.0.0
@@ -1376,6 +1465,7 @@ ocurrent/opam-staging:alpine-3.21-ocaml-5.0-arm64, ocurrent/opam-staging:alpine-
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:alpine-3.21-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 5.0 --packages=ocaml-variants.5.0.0+options,ocaml-options-only-afl
 	RUN opam pin add -k version ocaml-variants 5.0.0+options
@@ -1388,6 +1478,7 @@ ocurrent/opam-staging:alpine-3.21-ocaml-5.0-arm64, ocurrent/opam-staging:alpine-
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:alpine-3.21-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 5.0 --packages=ocaml-variants.5.0.0+options,ocaml-options-only-afl
 	RUN opam pin add -k version ocaml-variants 5.0.0+options
@@ -1402,6 +1493,7 @@ ocurrent/opam-staging:alpine-3.21-ocaml-5.0-afl-arm64, ocurrent/opam-staging:alp
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:alpine-3.21-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 5.0 --packages=ocaml-variants.5.0.0+options,ocaml-options-only-flambda
 	RUN opam pin add -k version ocaml-variants 5.0.0+options
@@ -1414,6 +1506,7 @@ ocurrent/opam-staging:alpine-3.21-ocaml-5.0-afl-arm64, ocurrent/opam-staging:alp
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:alpine-3.21-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 5.0 --packages=ocaml-variants.5.0.0+options,ocaml-options-only-flambda
 	RUN opam pin add -k version ocaml-variants 5.0.0+options
@@ -1428,6 +1521,7 @@ ocurrent/opam-staging:alpine-3.21-ocaml-5.0-flambda-arm64, ocurrent/opam-staging
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:alpine-3.21-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 5.0 --packages=ocaml-variants.5.0.0+options,ocaml-options-only-no-flat-float-array
 	RUN opam pin add -k version ocaml-variants 5.0.0+options
@@ -1440,6 +1534,7 @@ ocurrent/opam-staging:alpine-3.21-ocaml-5.0-flambda-arm64, ocurrent/opam-staging
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:alpine-3.21-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 5.0 --packages=ocaml-variants.5.0.0+options,ocaml-options-only-no-flat-float-array
 	RUN opam pin add -k version ocaml-variants 5.0.0+options
@@ -1454,6 +1549,7 @@ ocurrent/opam-staging:alpine-3.21-ocaml-5.0-no-flat-float-array-arm64, ocurrent/
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:alpine-3.21-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
 	RUN apk update && apk upgrade
@@ -1470,6 +1566,7 @@ ocurrent/opam-staging:alpine-3.21-ocaml-5.0-no-flat-float-array-arm64, ocurrent/
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:alpine-3.21-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
 	RUN apk update && apk upgrade
@@ -1488,6 +1585,7 @@ ocurrent/opam-staging:alpine-3.21-ocaml-5.1-arm64, ocurrent/opam-staging:alpine-
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:alpine-3.21-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
 	RUN apk update && apk upgrade
@@ -1504,6 +1602,7 @@ ocurrent/opam-staging:alpine-3.21-ocaml-5.1-arm64, ocurrent/opam-staging:alpine-
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:alpine-3.21-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
 	RUN apk update && apk upgrade
@@ -1522,6 +1621,7 @@ ocurrent/opam-staging:alpine-3.21-ocaml-5.1-afl-arm64, ocurrent/opam-staging:alp
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:alpine-3.21-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
 	RUN apk update && apk upgrade
@@ -1538,6 +1638,7 @@ ocurrent/opam-staging:alpine-3.21-ocaml-5.1-afl-arm64, ocurrent/opam-staging:alp
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:alpine-3.21-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
 	RUN apk update && apk upgrade
@@ -1556,6 +1657,7 @@ ocurrent/opam-staging:alpine-3.21-ocaml-5.1-flambda-arm64, ocurrent/opam-staging
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:alpine-3.21-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
 	RUN apk update && apk upgrade
@@ -1572,6 +1674,7 @@ ocurrent/opam-staging:alpine-3.21-ocaml-5.1-flambda-arm64, ocurrent/opam-staging
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:alpine-3.21-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
 	RUN apk update && apk upgrade
@@ -1590,6 +1693,7 @@ ocurrent/opam-staging:alpine-3.21-ocaml-5.1-no-flat-float-array-arm64, ocurrent/
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:alpine-3.21-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
 	RUN apk update && apk upgrade
@@ -1606,6 +1710,7 @@ ocurrent/opam-staging:alpine-3.21-ocaml-5.1-no-flat-float-array-arm64, ocurrent/
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:alpine-3.21-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
 	RUN apk update && apk upgrade
@@ -1624,6 +1729,7 @@ ocurrent/opam-staging:alpine-3.21-ocaml-5.2-arm64, ocurrent/opam-staging:alpine-
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:alpine-3.21-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
 	RUN apk update && apk upgrade
@@ -1640,6 +1746,7 @@ ocurrent/opam-staging:alpine-3.21-ocaml-5.2-arm64, ocurrent/opam-staging:alpine-
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:alpine-3.21-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
 	RUN apk update && apk upgrade
@@ -1658,6 +1765,7 @@ ocurrent/opam-staging:alpine-3.21-ocaml-5.2-afl-arm64, ocurrent/opam-staging:alp
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:alpine-3.21-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
 	RUN apk update && apk upgrade
@@ -1674,6 +1782,7 @@ ocurrent/opam-staging:alpine-3.21-ocaml-5.2-afl-arm64, ocurrent/opam-staging:alp
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:alpine-3.21-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
 	RUN apk update && apk upgrade
@@ -1692,6 +1801,7 @@ ocurrent/opam-staging:alpine-3.21-ocaml-5.2-flambda-arm64, ocurrent/opam-staging
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:alpine-3.21-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
 	RUN apk update && apk upgrade
@@ -1708,6 +1818,7 @@ ocurrent/opam-staging:alpine-3.21-ocaml-5.2-flambda-arm64, ocurrent/opam-staging
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:alpine-3.21-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
 	RUN apk update && apk upgrade
@@ -1726,6 +1837,7 @@ ocurrent/opam-staging:alpine-3.21-ocaml-5.2-no-flat-float-array-arm64, ocurrent/
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:alpine-3.21-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
 	RUN apk update && apk upgrade
@@ -1742,6 +1854,7 @@ ocurrent/opam-staging:alpine-3.21-ocaml-5.2-no-flat-float-array-arm64, ocurrent/
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:alpine-3.21-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
 	RUN apk update && apk upgrade
@@ -1762,6 +1875,7 @@ ocurrent/opam-staging:alpine-3.21-ocaml-5.3-arm64, ocurrent/opam-staging:alpine-
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:alpine-3.21-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
 	RUN apk update && apk upgrade
@@ -1778,6 +1892,7 @@ ocurrent/opam-staging:alpine-3.21-ocaml-5.3-arm64, ocurrent/opam-staging:alpine-
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:alpine-3.21-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
 	RUN apk update && apk upgrade
@@ -1796,6 +1911,7 @@ ocurrent/opam-staging:alpine-3.21-ocaml-5.3-afl-arm64, ocurrent/opam-staging:alp
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:alpine-3.21-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
 	RUN apk update && apk upgrade
@@ -1812,6 +1928,7 @@ ocurrent/opam-staging:alpine-3.21-ocaml-5.3-afl-arm64, ocurrent/opam-staging:alp
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:alpine-3.21-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
 	RUN apk update && apk upgrade
@@ -1830,6 +1947,7 @@ ocurrent/opam-staging:alpine-3.21-ocaml-5.3-flambda-arm64, ocurrent/opam-staging
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:alpine-3.21-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
 	RUN apk update && apk upgrade
@@ -1846,6 +1964,7 @@ ocurrent/opam-staging:alpine-3.21-ocaml-5.3-flambda-arm64, ocurrent/opam-staging
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:alpine-3.21-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
 	RUN apk update && apk upgrade
@@ -1864,6 +1983,7 @@ ocurrent/opam-staging:alpine-3.21-ocaml-5.3-no-flat-float-array-arm64, ocurrent/
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:alpine-3.21-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	RUN opam repo add beta git+https://github.com/ocaml/ocaml-beta-repository --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
@@ -1881,6 +2001,7 @@ ocurrent/opam-staging:alpine-3.21-ocaml-5.3-no-flat-float-array-arm64, ocurrent/
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:alpine-3.21-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	RUN opam repo add beta git+https://github.com/ocaml/ocaml-beta-repository --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
@@ -1900,6 +2021,7 @@ ocurrent/opam-staging:alpine-3.21-ocaml-5.4-arm64, ocurrent/opam-staging:alpine-
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:alpine-3.21-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	RUN opam repo add beta git+https://github.com/ocaml/ocaml-beta-repository --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
@@ -1917,6 +2039,7 @@ ocurrent/opam-staging:alpine-3.21-ocaml-5.4-arm64, ocurrent/opam-staging:alpine-
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:alpine-3.21-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	RUN opam repo add beta git+https://github.com/ocaml/ocaml-beta-repository --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
@@ -1936,6 +2059,7 @@ ocurrent/opam-staging:alpine-3.21-ocaml-5.4-afl-arm64, ocurrent/opam-staging:alp
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:alpine-3.21-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	RUN opam repo add beta git+https://github.com/ocaml/ocaml-beta-repository --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
@@ -1953,6 +2077,7 @@ ocurrent/opam-staging:alpine-3.21-ocaml-5.4-afl-arm64, ocurrent/opam-staging:alp
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:alpine-3.21-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	RUN opam repo add beta git+https://github.com/ocaml/ocaml-beta-repository --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
@@ -1972,6 +2097,7 @@ ocurrent/opam-staging:alpine-3.21-ocaml-5.4-flambda-arm64, ocurrent/opam-staging
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:alpine-3.21-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	RUN opam repo add beta git+https://github.com/ocaml/ocaml-beta-repository --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
@@ -1989,6 +2115,7 @@ ocurrent/opam-staging:alpine-3.21-ocaml-5.4-flambda-arm64, ocurrent/opam-staging
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:alpine-3.21-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	RUN opam repo add beta git+https://github.com/ocaml/ocaml-beta-repository --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
@@ -2078,6 +2205,7 @@ ocurrent/opam-staging:archlinux-opam-amd64 -> ocaml/opam:archlinux-opam
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:archlinux-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.02 --packages=ocaml-base-compiler.4.02.3
@@ -2093,6 +2221,7 @@ ocurrent/opam-staging:archlinux-ocaml-4.02-amd64 -> ocaml/opam:archlinux-ocaml-4
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:archlinux-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.03 --packages=ocaml-base-compiler.4.03.0
@@ -2108,6 +2237,7 @@ ocurrent/opam-staging:archlinux-ocaml-4.03-amd64 -> ocaml/opam:archlinux-ocaml-4
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:archlinux-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.04 --packages=ocaml-base-compiler.4.04.2
@@ -2123,6 +2253,7 @@ ocurrent/opam-staging:archlinux-ocaml-4.04-amd64 -> ocaml/opam:archlinux-ocaml-4
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:archlinux-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.05 --packages=ocaml-base-compiler.4.05.0
@@ -2138,6 +2269,7 @@ ocurrent/opam-staging:archlinux-ocaml-4.05-amd64 -> ocaml/opam:archlinux-ocaml-4
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:archlinux-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.06 --packages=ocaml-base-compiler.4.06.1
@@ -2153,6 +2285,7 @@ ocurrent/opam-staging:archlinux-ocaml-4.06-amd64 -> ocaml/opam:archlinux-ocaml-4
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:archlinux-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.07 --packages=ocaml-base-compiler.4.07.1
@@ -2168,6 +2301,7 @@ ocurrent/opam-staging:archlinux-ocaml-4.07-amd64 -> ocaml/opam:archlinux-ocaml-4
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:archlinux-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.08 --packages=ocaml-base-compiler.4.08.1
 	RUN opam pin add -k version ocaml-base-compiler 4.08.1
@@ -2181,6 +2315,7 @@ ocurrent/opam-staging:archlinux-ocaml-4.08-amd64 -> ocaml/opam:archlinux-ocaml-4
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:archlinux-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.09 --packages=ocaml-base-compiler.4.09.1
 	RUN opam pin add -k version ocaml-base-compiler 4.09.1
@@ -2194,6 +2329,7 @@ ocurrent/opam-staging:archlinux-ocaml-4.09-amd64 -> ocaml/opam:archlinux-ocaml-4
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:archlinux-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.10 --packages=ocaml-base-compiler.4.10.2
 	RUN opam pin add -k version ocaml-base-compiler 4.10.2
@@ -2207,6 +2343,7 @@ ocurrent/opam-staging:archlinux-ocaml-4.10-amd64 -> ocaml/opam:archlinux-ocaml-4
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:archlinux-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.11 --packages=ocaml-base-compiler.4.11.2
 	RUN opam pin add -k version ocaml-base-compiler 4.11.2
@@ -2220,6 +2357,7 @@ ocurrent/opam-staging:archlinux-ocaml-4.11-amd64 -> ocaml/opam:archlinux-ocaml-4
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:archlinux-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.12 --packages=ocaml-base-compiler.4.12.1
 	RUN opam pin add -k version ocaml-base-compiler 4.12.1
@@ -2233,6 +2371,7 @@ ocurrent/opam-staging:archlinux-ocaml-4.12-amd64 -> ocaml/opam:archlinux-ocaml-4
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:archlinux-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.13 --packages=ocaml-base-compiler.4.13.1
 	RUN opam pin add -k version ocaml-base-compiler 4.13.1
@@ -2246,6 +2385,7 @@ ocurrent/opam-staging:archlinux-ocaml-4.13-amd64 -> ocaml/opam:archlinux-ocaml-4
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:archlinux-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.14 --packages=ocaml-base-compiler.4.14.2
 	RUN opam pin add -k version ocaml-base-compiler 4.14.2
@@ -2259,6 +2399,7 @@ ocurrent/opam-staging:archlinux-ocaml-4.14-amd64 -> ocaml/opam:archlinux-ocaml-4
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:archlinux-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 5.0 --packages=ocaml-base-compiler.5.0.0
 	RUN opam pin add -k version ocaml-base-compiler 5.0.0
@@ -2272,6 +2413,7 @@ ocurrent/opam-staging:archlinux-ocaml-5.0-amd64 -> ocaml/opam:archlinux-ocaml-5.
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:archlinux-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
 	RUN pacman -Syu --noconfirm zstd && yes | pacman -Scc
@@ -2288,6 +2430,7 @@ ocurrent/opam-staging:archlinux-ocaml-5.1-amd64 -> ocaml/opam:archlinux-ocaml-5.
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:archlinux-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
 	RUN pacman -Syu --noconfirm zstd && yes | pacman -Scc
@@ -2304,6 +2447,7 @@ ocurrent/opam-staging:archlinux-ocaml-5.2-amd64 -> ocaml/opam:archlinux-ocaml-5.
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:archlinux-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
 	RUN pacman -Syu --noconfirm zstd && yes | pacman -Scc
@@ -2321,6 +2465,7 @@ ocurrent/opam-staging:archlinux-ocaml-5.3-amd64 -> ocaml/opam:archlinux-ocaml-5.
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:archlinux-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	RUN opam repo add beta git+https://github.com/ocaml/ocaml-beta-repository --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
@@ -2827,6 +2972,7 @@ ocurrent/opam-staging:debian-12-opam-s390x, ocurrent/opam-staging:debian-12-opam
 
 	FROM ocurrent/opam-staging:debian-12-opam-arm32v7
 	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.02 --packages=ocaml-base-compiler.4.02.3
 	RUN opam pin add -k version ocaml-base-compiler 4.02.3
@@ -2840,6 +2986,7 @@ ocurrent/opam-staging:debian-12-opam-s390x, ocurrent/opam-staging:debian-12-opam
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.02 --packages=ocaml-base-compiler.4.02.3
 	RUN opam pin add -k version ocaml-base-compiler 4.02.3
@@ -2853,6 +3000,7 @@ ocurrent/opam-staging:debian-12-opam-s390x, ocurrent/opam-staging:debian-12-opam
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.02 --packages=ocaml-base-compiler.4.02.3
 	RUN opam pin add -k version ocaml-base-compiler 4.02.3
@@ -2867,6 +3015,7 @@ ocurrent/opam-staging:debian-12-opam-s390x, ocurrent/opam-staging:debian-12-opam
 
 	FROM ocurrent/opam-staging:debian-12-opam-i386
 	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.02 --packages=ocaml-base-compiler.4.02.3
 	RUN opam pin add -k version ocaml-base-compiler 4.02.3
@@ -2883,6 +3032,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.02-arm32v7, ocurrent/opam-staging:debian
 
 	FROM ocurrent/opam-staging:debian-12-opam-arm32v7
 	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.03 --packages=ocaml-base-compiler.4.03.0
 	RUN opam pin add -k version ocaml-base-compiler 4.03.0
@@ -2896,6 +3046,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.02-arm32v7, ocurrent/opam-staging:debian
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.03 --packages=ocaml-base-compiler.4.03.0
 	RUN opam pin add -k version ocaml-base-compiler 4.03.0
@@ -2909,6 +3060,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.02-arm32v7, ocurrent/opam-staging:debian
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.03 --packages=ocaml-base-compiler.4.03.0
 	RUN opam pin add -k version ocaml-base-compiler 4.03.0
@@ -2923,6 +3075,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.02-arm32v7, ocurrent/opam-staging:debian
 
 	FROM ocurrent/opam-staging:debian-12-opam-i386
 	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.03 --packages=ocaml-base-compiler.4.03.0
 	RUN opam pin add -k version ocaml-base-compiler 4.03.0
@@ -2939,6 +3092,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.03-arm32v7, ocurrent/opam-staging:debian
 
 	FROM ocurrent/opam-staging:debian-12-opam-arm32v7
 	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.03 --packages=ocaml-variants.4.03.0+flambda
 	RUN opam pin add -k version ocaml-variants 4.03.0+flambda
@@ -2952,6 +3106,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.03-arm32v7, ocurrent/opam-staging:debian
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.03 --packages=ocaml-variants.4.03.0+flambda
 	RUN opam pin add -k version ocaml-variants 4.03.0+flambda
@@ -2965,6 +3120,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.03-arm32v7, ocurrent/opam-staging:debian
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.03 --packages=ocaml-variants.4.03.0+flambda
 	RUN opam pin add -k version ocaml-variants 4.03.0+flambda
@@ -2979,6 +3135,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.03-arm32v7, ocurrent/opam-staging:debian
 
 	FROM ocurrent/opam-staging:debian-12-opam-i386
 	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.03 --packages=ocaml-variants.4.03.0+flambda
 	RUN opam pin add -k version ocaml-variants 4.03.0+flambda
@@ -2994,6 +3151,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.03-flambda-arm32v7, ocurrent/opam-stagin
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-s390x
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.04 --packages=ocaml-base-compiler.4.04.2
 	RUN opam pin add -k version ocaml-base-compiler 4.04.2
@@ -3007,6 +3165,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.03-flambda-arm32v7, ocurrent/opam-stagin
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-ppc64le
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.04 --packages=ocaml-base-compiler.4.04.2
 	RUN opam pin add -k version ocaml-base-compiler 4.04.2
@@ -3021,6 +3180,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.03-flambda-arm32v7, ocurrent/opam-stagin
 
 	FROM ocurrent/opam-staging:debian-12-opam-arm32v7
 	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.04 --packages=ocaml-base-compiler.4.04.2
 	RUN opam pin add -k version ocaml-base-compiler 4.04.2
@@ -3034,6 +3194,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.03-flambda-arm32v7, ocurrent/opam-stagin
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.04 --packages=ocaml-base-compiler.4.04.2
 	RUN opam pin add -k version ocaml-base-compiler 4.04.2
@@ -3047,6 +3208,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.03-flambda-arm32v7, ocurrent/opam-stagin
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.04 --packages=ocaml-base-compiler.4.04.2
 	RUN opam pin add -k version ocaml-base-compiler 4.04.2
@@ -3061,6 +3223,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.03-flambda-arm32v7, ocurrent/opam-stagin
 
 	FROM ocurrent/opam-staging:debian-12-opam-i386
 	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.04 --packages=ocaml-base-compiler.4.04.2
 	RUN opam pin add -k version ocaml-base-compiler 4.04.2
@@ -3076,6 +3239,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.04-s390x, ocurrent/opam-staging:debian-1
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-s390x
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.04 --packages=ocaml-variants.4.04.2+flambda
 	RUN opam pin add -k version ocaml-variants 4.04.2+flambda
@@ -3089,6 +3253,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.04-s390x, ocurrent/opam-staging:debian-1
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-ppc64le
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.04 --packages=ocaml-variants.4.04.2+flambda
 	RUN opam pin add -k version ocaml-variants 4.04.2+flambda
@@ -3103,6 +3268,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.04-s390x, ocurrent/opam-staging:debian-1
 
 	FROM ocurrent/opam-staging:debian-12-opam-arm32v7
 	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.04 --packages=ocaml-variants.4.04.2+flambda
 	RUN opam pin add -k version ocaml-variants 4.04.2+flambda
@@ -3116,6 +3282,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.04-s390x, ocurrent/opam-staging:debian-1
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.04 --packages=ocaml-variants.4.04.2+flambda
 	RUN opam pin add -k version ocaml-variants 4.04.2+flambda
@@ -3129,6 +3296,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.04-s390x, ocurrent/opam-staging:debian-1
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.04 --packages=ocaml-variants.4.04.2+flambda
 	RUN opam pin add -k version ocaml-variants 4.04.2+flambda
@@ -3143,6 +3311,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.04-s390x, ocurrent/opam-staging:debian-1
 
 	FROM ocurrent/opam-staging:debian-12-opam-i386
 	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.04 --packages=ocaml-variants.4.04.2+flambda
 	RUN opam pin add -k version ocaml-variants 4.04.2+flambda
@@ -3158,6 +3327,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.04-flambda-s390x, ocurrent/opam-staging:
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-s390x
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.05 --packages=ocaml-base-compiler.4.05.0
 	RUN opam pin add -k version ocaml-base-compiler 4.05.0
@@ -3171,6 +3341,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.04-flambda-s390x, ocurrent/opam-staging:
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-ppc64le
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.05 --packages=ocaml-base-compiler.4.05.0
 	RUN opam pin add -k version ocaml-base-compiler 4.05.0
@@ -3185,6 +3356,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.04-flambda-s390x, ocurrent/opam-staging:
 
 	FROM ocurrent/opam-staging:debian-12-opam-arm32v7
 	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.05 --packages=ocaml-base-compiler.4.05.0
 	RUN opam pin add -k version ocaml-base-compiler 4.05.0
@@ -3198,6 +3370,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.04-flambda-s390x, ocurrent/opam-staging:
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.05 --packages=ocaml-base-compiler.4.05.0
 	RUN opam pin add -k version ocaml-base-compiler 4.05.0
@@ -3211,6 +3384,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.04-flambda-s390x, ocurrent/opam-staging:
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.05 --packages=ocaml-base-compiler.4.05.0
 	RUN opam pin add -k version ocaml-base-compiler 4.05.0
@@ -3225,6 +3399,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.04-flambda-s390x, ocurrent/opam-staging:
 
 	FROM ocurrent/opam-staging:debian-12-opam-i386
 	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.05 --packages=ocaml-base-compiler.4.05.0
 	RUN opam pin add -k version ocaml-base-compiler 4.05.0
@@ -3240,6 +3415,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.05-s390x, ocurrent/opam-staging:debian-1
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-s390x
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.05 --packages=ocaml-variants.4.05.0+afl
 	RUN opam pin add -k version ocaml-variants 4.05.0+afl
@@ -3253,6 +3429,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.05-s390x, ocurrent/opam-staging:debian-1
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-ppc64le
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.05 --packages=ocaml-variants.4.05.0+afl
 	RUN opam pin add -k version ocaml-variants 4.05.0+afl
@@ -3267,6 +3444,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.05-s390x, ocurrent/opam-staging:debian-1
 
 	FROM ocurrent/opam-staging:debian-12-opam-arm32v7
 	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.05 --packages=ocaml-variants.4.05.0+afl
 	RUN opam pin add -k version ocaml-variants 4.05.0+afl
@@ -3280,6 +3458,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.05-s390x, ocurrent/opam-staging:debian-1
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.05 --packages=ocaml-variants.4.05.0+afl
 	RUN opam pin add -k version ocaml-variants 4.05.0+afl
@@ -3293,6 +3472,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.05-s390x, ocurrent/opam-staging:debian-1
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.05 --packages=ocaml-variants.4.05.0+afl
 	RUN opam pin add -k version ocaml-variants 4.05.0+afl
@@ -3307,6 +3487,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.05-s390x, ocurrent/opam-staging:debian-1
 
 	FROM ocurrent/opam-staging:debian-12-opam-i386
 	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.05 --packages=ocaml-variants.4.05.0+afl
 	RUN opam pin add -k version ocaml-variants 4.05.0+afl
@@ -3322,6 +3503,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.05-afl-s390x, ocurrent/opam-staging:debi
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-s390x
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.05 --packages=ocaml-variants.4.05.0+flambda
 	RUN opam pin add -k version ocaml-variants 4.05.0+flambda
@@ -3335,6 +3517,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.05-afl-s390x, ocurrent/opam-staging:debi
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-ppc64le
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.05 --packages=ocaml-variants.4.05.0+flambda
 	RUN opam pin add -k version ocaml-variants 4.05.0+flambda
@@ -3349,6 +3532,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.05-afl-s390x, ocurrent/opam-staging:debi
 
 	FROM ocurrent/opam-staging:debian-12-opam-arm32v7
 	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.05 --packages=ocaml-variants.4.05.0+flambda
 	RUN opam pin add -k version ocaml-variants 4.05.0+flambda
@@ -3362,6 +3546,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.05-afl-s390x, ocurrent/opam-staging:debi
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.05 --packages=ocaml-variants.4.05.0+flambda
 	RUN opam pin add -k version ocaml-variants 4.05.0+flambda
@@ -3375,6 +3560,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.05-afl-s390x, ocurrent/opam-staging:debi
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.05 --packages=ocaml-variants.4.05.0+flambda
 	RUN opam pin add -k version ocaml-variants 4.05.0+flambda
@@ -3389,6 +3575,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.05-afl-s390x, ocurrent/opam-staging:debi
 
 	FROM ocurrent/opam-staging:debian-12-opam-i386
 	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.05 --packages=ocaml-variants.4.05.0+flambda
 	RUN opam pin add -k version ocaml-variants 4.05.0+flambda
@@ -3404,6 +3591,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.05-flambda-s390x, ocurrent/opam-staging:
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-s390x
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.06 --packages=ocaml-base-compiler.4.06.1
 	RUN opam pin add -k version ocaml-base-compiler 4.06.1
@@ -3417,6 +3605,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.05-flambda-s390x, ocurrent/opam-staging:
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-ppc64le
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.06 --packages=ocaml-base-compiler.4.06.1
 	RUN opam pin add -k version ocaml-base-compiler 4.06.1
@@ -3431,6 +3620,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.05-flambda-s390x, ocurrent/opam-staging:
 
 	FROM ocurrent/opam-staging:debian-12-opam-arm32v7
 	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.06 --packages=ocaml-base-compiler.4.06.1
 	RUN opam pin add -k version ocaml-base-compiler 4.06.1
@@ -3444,6 +3634,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.05-flambda-s390x, ocurrent/opam-staging:
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.06 --packages=ocaml-base-compiler.4.06.1
 	RUN opam pin add -k version ocaml-base-compiler 4.06.1
@@ -3457,6 +3648,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.05-flambda-s390x, ocurrent/opam-staging:
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.06 --packages=ocaml-base-compiler.4.06.1
 	RUN opam pin add -k version ocaml-base-compiler 4.06.1
@@ -3471,6 +3663,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.05-flambda-s390x, ocurrent/opam-staging:
 
 	FROM ocurrent/opam-staging:debian-12-opam-i386
 	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.06 --packages=ocaml-base-compiler.4.06.1
 	RUN opam pin add -k version ocaml-base-compiler 4.06.1
@@ -3486,6 +3679,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.06-s390x, ocurrent/opam-staging:debian-1
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-s390x
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.06 --packages=ocaml-variants.4.06.1+afl
 	RUN opam pin add -k version ocaml-variants 4.06.1+afl
@@ -3499,6 +3693,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.06-s390x, ocurrent/opam-staging:debian-1
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-ppc64le
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.06 --packages=ocaml-variants.4.06.1+afl
 	RUN opam pin add -k version ocaml-variants 4.06.1+afl
@@ -3513,6 +3708,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.06-s390x, ocurrent/opam-staging:debian-1
 
 	FROM ocurrent/opam-staging:debian-12-opam-arm32v7
 	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.06 --packages=ocaml-variants.4.06.1+afl
 	RUN opam pin add -k version ocaml-variants 4.06.1+afl
@@ -3526,6 +3722,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.06-s390x, ocurrent/opam-staging:debian-1
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.06 --packages=ocaml-variants.4.06.1+afl
 	RUN opam pin add -k version ocaml-variants 4.06.1+afl
@@ -3539,6 +3736,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.06-s390x, ocurrent/opam-staging:debian-1
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.06 --packages=ocaml-variants.4.06.1+afl
 	RUN opam pin add -k version ocaml-variants 4.06.1+afl
@@ -3553,6 +3751,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.06-s390x, ocurrent/opam-staging:debian-1
 
 	FROM ocurrent/opam-staging:debian-12-opam-i386
 	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.06 --packages=ocaml-variants.4.06.1+afl
 	RUN opam pin add -k version ocaml-variants 4.06.1+afl
@@ -3568,6 +3767,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.06-afl-s390x, ocurrent/opam-staging:debi
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-s390x
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.06 --packages=ocaml-variants.4.06.1+flambda
 	RUN opam pin add -k version ocaml-variants 4.06.1+flambda
@@ -3581,6 +3781,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.06-afl-s390x, ocurrent/opam-staging:debi
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-ppc64le
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.06 --packages=ocaml-variants.4.06.1+flambda
 	RUN opam pin add -k version ocaml-variants 4.06.1+flambda
@@ -3595,6 +3796,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.06-afl-s390x, ocurrent/opam-staging:debi
 
 	FROM ocurrent/opam-staging:debian-12-opam-arm32v7
 	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.06 --packages=ocaml-variants.4.06.1+flambda
 	RUN opam pin add -k version ocaml-variants 4.06.1+flambda
@@ -3608,6 +3810,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.06-afl-s390x, ocurrent/opam-staging:debi
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.06 --packages=ocaml-variants.4.06.1+flambda
 	RUN opam pin add -k version ocaml-variants 4.06.1+flambda
@@ -3621,6 +3824,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.06-afl-s390x, ocurrent/opam-staging:debi
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.06 --packages=ocaml-variants.4.06.1+flambda
 	RUN opam pin add -k version ocaml-variants 4.06.1+flambda
@@ -3635,6 +3839,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.06-afl-s390x, ocurrent/opam-staging:debi
 
 	FROM ocurrent/opam-staging:debian-12-opam-i386
 	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.06 --packages=ocaml-variants.4.06.1+flambda
 	RUN opam pin add -k version ocaml-variants 4.06.1+flambda
@@ -3650,6 +3855,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.06-flambda-s390x, ocurrent/opam-staging:
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-s390x
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.07 --packages=ocaml-base-compiler.4.07.1
 	RUN opam pin add -k version ocaml-base-compiler 4.07.1
@@ -3663,6 +3869,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.06-flambda-s390x, ocurrent/opam-staging:
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-ppc64le
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.07 --packages=ocaml-base-compiler.4.07.1
 	RUN opam pin add -k version ocaml-base-compiler 4.07.1
@@ -3677,6 +3884,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.06-flambda-s390x, ocurrent/opam-staging:
 
 	FROM ocurrent/opam-staging:debian-12-opam-arm32v7
 	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.07 --packages=ocaml-base-compiler.4.07.1
 	RUN opam pin add -k version ocaml-base-compiler 4.07.1
@@ -3690,6 +3898,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.06-flambda-s390x, ocurrent/opam-staging:
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.07 --packages=ocaml-base-compiler.4.07.1
 	RUN opam pin add -k version ocaml-base-compiler 4.07.1
@@ -3703,6 +3912,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.06-flambda-s390x, ocurrent/opam-staging:
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.07 --packages=ocaml-base-compiler.4.07.1
 	RUN opam pin add -k version ocaml-base-compiler 4.07.1
@@ -3717,6 +3927,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.06-flambda-s390x, ocurrent/opam-staging:
 
 	FROM ocurrent/opam-staging:debian-12-opam-i386
 	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.07 --packages=ocaml-base-compiler.4.07.1
 	RUN opam pin add -k version ocaml-base-compiler 4.07.1
@@ -3732,6 +3943,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.07-s390x, ocurrent/opam-staging:debian-1
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-s390x
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.07 --packages=ocaml-variants.4.07.1+afl
 	RUN opam pin add -k version ocaml-variants 4.07.1+afl
@@ -3745,6 +3957,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.07-s390x, ocurrent/opam-staging:debian-1
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-ppc64le
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.07 --packages=ocaml-variants.4.07.1+afl
 	RUN opam pin add -k version ocaml-variants 4.07.1+afl
@@ -3759,6 +3972,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.07-s390x, ocurrent/opam-staging:debian-1
 
 	FROM ocurrent/opam-staging:debian-12-opam-arm32v7
 	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.07 --packages=ocaml-variants.4.07.1+afl
 	RUN opam pin add -k version ocaml-variants 4.07.1+afl
@@ -3772,6 +3986,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.07-s390x, ocurrent/opam-staging:debian-1
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.07 --packages=ocaml-variants.4.07.1+afl
 	RUN opam pin add -k version ocaml-variants 4.07.1+afl
@@ -3785,6 +4000,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.07-s390x, ocurrent/opam-staging:debian-1
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.07 --packages=ocaml-variants.4.07.1+afl
 	RUN opam pin add -k version ocaml-variants 4.07.1+afl
@@ -3799,6 +4015,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.07-s390x, ocurrent/opam-staging:debian-1
 
 	FROM ocurrent/opam-staging:debian-12-opam-i386
 	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.07 --packages=ocaml-variants.4.07.1+afl
 	RUN opam pin add -k version ocaml-variants 4.07.1+afl
@@ -3814,6 +4031,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.07-afl-s390x, ocurrent/opam-staging:debi
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-s390x
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.07 --packages=ocaml-variants.4.07.1+flambda
 	RUN opam pin add -k version ocaml-variants 4.07.1+flambda
@@ -3827,6 +4045,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.07-afl-s390x, ocurrent/opam-staging:debi
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-ppc64le
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.07 --packages=ocaml-variants.4.07.1+flambda
 	RUN opam pin add -k version ocaml-variants 4.07.1+flambda
@@ -3841,6 +4060,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.07-afl-s390x, ocurrent/opam-staging:debi
 
 	FROM ocurrent/opam-staging:debian-12-opam-arm32v7
 	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.07 --packages=ocaml-variants.4.07.1+flambda
 	RUN opam pin add -k version ocaml-variants 4.07.1+flambda
@@ -3854,6 +4074,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.07-afl-s390x, ocurrent/opam-staging:debi
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.07 --packages=ocaml-variants.4.07.1+flambda
 	RUN opam pin add -k version ocaml-variants 4.07.1+flambda
@@ -3867,6 +4088,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.07-afl-s390x, ocurrent/opam-staging:debi
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.07 --packages=ocaml-variants.4.07.1+flambda
 	RUN opam pin add -k version ocaml-variants 4.07.1+flambda
@@ -3881,6 +4103,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.07-afl-s390x, ocurrent/opam-staging:debi
 
 	FROM ocurrent/opam-staging:debian-12-opam-i386
 	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.07 --packages=ocaml-variants.4.07.1+flambda
 	RUN opam pin add -k version ocaml-variants 4.07.1+flambda
@@ -3896,6 +4119,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.07-flambda-s390x, ocurrent/opam-staging:
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-s390x
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.08 --packages=ocaml-base-compiler.4.08.1
 	RUN opam pin add -k version ocaml-base-compiler 4.08.1
@@ -3908,6 +4132,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.07-flambda-s390x, ocurrent/opam-staging:
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-ppc64le
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.08 --packages=ocaml-base-compiler.4.08.1
 	RUN opam pin add -k version ocaml-base-compiler 4.08.1
@@ -3921,6 +4146,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.07-flambda-s390x, ocurrent/opam-staging:
 
 	FROM ocurrent/opam-staging:debian-12-opam-arm32v7
 	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.08 --packages=ocaml-base-compiler.4.08.1
 	RUN opam pin add -k version ocaml-base-compiler 4.08.1
@@ -3933,6 +4159,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.07-flambda-s390x, ocurrent/opam-staging:
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.08 --packages=ocaml-base-compiler.4.08.1
 	RUN opam pin add -k version ocaml-base-compiler 4.08.1
@@ -3945,6 +4172,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.07-flambda-s390x, ocurrent/opam-staging:
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.08 --packages=ocaml-base-compiler.4.08.1
 	RUN opam pin add -k version ocaml-base-compiler 4.08.1
@@ -3958,6 +4186,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.07-flambda-s390x, ocurrent/opam-staging:
 
 	FROM ocurrent/opam-staging:debian-12-opam-i386
 	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.08 --packages=ocaml-base-compiler.4.08.1
 	RUN opam pin add -k version ocaml-base-compiler 4.08.1
@@ -3972,6 +4201,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.08-s390x, ocurrent/opam-staging:debian-1
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-s390x
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.08 --packages=ocaml-variants.4.08.1+afl
 	RUN opam pin add -k version ocaml-variants 4.08.1+afl
@@ -3984,6 +4214,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.08-s390x, ocurrent/opam-staging:debian-1
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-ppc64le
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.08 --packages=ocaml-variants.4.08.1+afl
 	RUN opam pin add -k version ocaml-variants 4.08.1+afl
@@ -3997,6 +4228,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.08-s390x, ocurrent/opam-staging:debian-1
 
 	FROM ocurrent/opam-staging:debian-12-opam-arm32v7
 	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.08 --packages=ocaml-variants.4.08.1+afl
 	RUN opam pin add -k version ocaml-variants 4.08.1+afl
@@ -4009,6 +4241,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.08-s390x, ocurrent/opam-staging:debian-1
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.08 --packages=ocaml-variants.4.08.1+afl
 	RUN opam pin add -k version ocaml-variants 4.08.1+afl
@@ -4021,6 +4254,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.08-s390x, ocurrent/opam-staging:debian-1
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.08 --packages=ocaml-variants.4.08.1+afl
 	RUN opam pin add -k version ocaml-variants 4.08.1+afl
@@ -4034,6 +4268,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.08-s390x, ocurrent/opam-staging:debian-1
 
 	FROM ocurrent/opam-staging:debian-12-opam-i386
 	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.08 --packages=ocaml-variants.4.08.1+afl
 	RUN opam pin add -k version ocaml-variants 4.08.1+afl
@@ -4048,6 +4283,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.08-afl-s390x, ocurrent/opam-staging:debi
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-s390x
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.08 --packages=ocaml-variants.4.08.1+flambda
 	RUN opam pin add -k version ocaml-variants 4.08.1+flambda
@@ -4060,6 +4296,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.08-afl-s390x, ocurrent/opam-staging:debi
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-ppc64le
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.08 --packages=ocaml-variants.4.08.1+flambda
 	RUN opam pin add -k version ocaml-variants 4.08.1+flambda
@@ -4073,6 +4310,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.08-afl-s390x, ocurrent/opam-staging:debi
 
 	FROM ocurrent/opam-staging:debian-12-opam-arm32v7
 	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.08 --packages=ocaml-variants.4.08.1+flambda
 	RUN opam pin add -k version ocaml-variants 4.08.1+flambda
@@ -4085,6 +4323,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.08-afl-s390x, ocurrent/opam-staging:debi
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.08 --packages=ocaml-variants.4.08.1+flambda
 	RUN opam pin add -k version ocaml-variants 4.08.1+flambda
@@ -4097,6 +4336,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.08-afl-s390x, ocurrent/opam-staging:debi
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.08 --packages=ocaml-variants.4.08.1+flambda
 	RUN opam pin add -k version ocaml-variants 4.08.1+flambda
@@ -4110,6 +4350,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.08-afl-s390x, ocurrent/opam-staging:debi
 
 	FROM ocurrent/opam-staging:debian-12-opam-i386
 	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.08 --packages=ocaml-variants.4.08.1+flambda
 	RUN opam pin add -k version ocaml-variants 4.08.1+flambda
@@ -4124,6 +4365,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.08-flambda-s390x, ocurrent/opam-staging:
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.08 --packages=ocaml-variants.4.08.1+fp
 	RUN opam pin add -k version ocaml-variants 4.08.1+fp
@@ -4138,6 +4380,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.08-fp-amd64 -> ocaml/opam:debian-ocaml-4
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-s390x
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.09 --packages=ocaml-base-compiler.4.09.1
 	RUN opam pin add -k version ocaml-base-compiler 4.09.1
@@ -4150,6 +4393,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.08-fp-amd64 -> ocaml/opam:debian-ocaml-4
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-ppc64le
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.09 --packages=ocaml-base-compiler.4.09.1
 	RUN opam pin add -k version ocaml-base-compiler 4.09.1
@@ -4163,6 +4407,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.08-fp-amd64 -> ocaml/opam:debian-ocaml-4
 
 	FROM ocurrent/opam-staging:debian-12-opam-arm32v7
 	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.09 --packages=ocaml-base-compiler.4.09.1
 	RUN opam pin add -k version ocaml-base-compiler 4.09.1
@@ -4175,6 +4420,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.08-fp-amd64 -> ocaml/opam:debian-ocaml-4
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.09 --packages=ocaml-base-compiler.4.09.1
 	RUN opam pin add -k version ocaml-base-compiler 4.09.1
@@ -4187,6 +4433,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.08-fp-amd64 -> ocaml/opam:debian-ocaml-4
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.09 --packages=ocaml-base-compiler.4.09.1
 	RUN opam pin add -k version ocaml-base-compiler 4.09.1
@@ -4200,6 +4447,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.08-fp-amd64 -> ocaml/opam:debian-ocaml-4
 
 	FROM ocurrent/opam-staging:debian-12-opam-i386
 	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.09 --packages=ocaml-base-compiler.4.09.1
 	RUN opam pin add -k version ocaml-base-compiler 4.09.1
@@ -4214,6 +4462,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.09-s390x, ocurrent/opam-staging:debian-1
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-s390x
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.09 --packages=ocaml-variants.4.09.1+afl
 	RUN opam pin add -k version ocaml-variants 4.09.1+afl
@@ -4226,6 +4475,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.09-s390x, ocurrent/opam-staging:debian-1
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-ppc64le
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.09 --packages=ocaml-variants.4.09.1+afl
 	RUN opam pin add -k version ocaml-variants 4.09.1+afl
@@ -4239,6 +4489,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.09-s390x, ocurrent/opam-staging:debian-1
 
 	FROM ocurrent/opam-staging:debian-12-opam-arm32v7
 	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.09 --packages=ocaml-variants.4.09.1+afl
 	RUN opam pin add -k version ocaml-variants 4.09.1+afl
@@ -4251,6 +4502,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.09-s390x, ocurrent/opam-staging:debian-1
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.09 --packages=ocaml-variants.4.09.1+afl
 	RUN opam pin add -k version ocaml-variants 4.09.1+afl
@@ -4263,6 +4515,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.09-s390x, ocurrent/opam-staging:debian-1
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.09 --packages=ocaml-variants.4.09.1+afl
 	RUN opam pin add -k version ocaml-variants 4.09.1+afl
@@ -4276,6 +4529,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.09-s390x, ocurrent/opam-staging:debian-1
 
 	FROM ocurrent/opam-staging:debian-12-opam-i386
 	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.09 --packages=ocaml-variants.4.09.1+afl
 	RUN opam pin add -k version ocaml-variants 4.09.1+afl
@@ -4290,6 +4544,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.09-afl-s390x, ocurrent/opam-staging:debi
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-s390x
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.09 --packages=ocaml-variants.4.09.1+flambda
 	RUN opam pin add -k version ocaml-variants 4.09.1+flambda
@@ -4302,6 +4557,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.09-afl-s390x, ocurrent/opam-staging:debi
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-ppc64le
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.09 --packages=ocaml-variants.4.09.1+flambda
 	RUN opam pin add -k version ocaml-variants 4.09.1+flambda
@@ -4315,6 +4571,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.09-afl-s390x, ocurrent/opam-staging:debi
 
 	FROM ocurrent/opam-staging:debian-12-opam-arm32v7
 	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.09 --packages=ocaml-variants.4.09.1+flambda
 	RUN opam pin add -k version ocaml-variants 4.09.1+flambda
@@ -4327,6 +4584,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.09-afl-s390x, ocurrent/opam-staging:debi
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.09 --packages=ocaml-variants.4.09.1+flambda
 	RUN opam pin add -k version ocaml-variants 4.09.1+flambda
@@ -4339,6 +4597,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.09-afl-s390x, ocurrent/opam-staging:debi
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.09 --packages=ocaml-variants.4.09.1+flambda
 	RUN opam pin add -k version ocaml-variants 4.09.1+flambda
@@ -4352,6 +4611,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.09-afl-s390x, ocurrent/opam-staging:debi
 
 	FROM ocurrent/opam-staging:debian-12-opam-i386
 	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.09 --packages=ocaml-variants.4.09.1+flambda
 	RUN opam pin add -k version ocaml-variants 4.09.1+flambda
@@ -4366,6 +4626,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.09-flambda-s390x, ocurrent/opam-staging:
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.09 --packages=ocaml-variants.4.09.1+fp
 	RUN opam pin add -k version ocaml-variants 4.09.1+fp
@@ -4380,6 +4641,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.09-fp-amd64 -> ocaml/opam:debian-ocaml-4
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-s390x
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.10 --packages=ocaml-base-compiler.4.10.2
 	RUN opam pin add -k version ocaml-base-compiler 4.10.2
@@ -4392,6 +4654,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.09-fp-amd64 -> ocaml/opam:debian-ocaml-4
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-ppc64le
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.10 --packages=ocaml-base-compiler.4.10.2
 	RUN opam pin add -k version ocaml-base-compiler 4.10.2
@@ -4405,6 +4668,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.09-fp-amd64 -> ocaml/opam:debian-ocaml-4
 
 	FROM ocurrent/opam-staging:debian-12-opam-arm32v7
 	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.10 --packages=ocaml-base-compiler.4.10.2
 	RUN opam pin add -k version ocaml-base-compiler 4.10.2
@@ -4417,6 +4681,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.09-fp-amd64 -> ocaml/opam:debian-ocaml-4
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.10 --packages=ocaml-base-compiler.4.10.2
 	RUN opam pin add -k version ocaml-base-compiler 4.10.2
@@ -4429,6 +4694,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.09-fp-amd64 -> ocaml/opam:debian-ocaml-4
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.10 --packages=ocaml-base-compiler.4.10.2
 	RUN opam pin add -k version ocaml-base-compiler 4.10.2
@@ -4442,6 +4708,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.09-fp-amd64 -> ocaml/opam:debian-ocaml-4
 
 	FROM ocurrent/opam-staging:debian-12-opam-i386
 	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.10 --packages=ocaml-base-compiler.4.10.2
 	RUN opam pin add -k version ocaml-base-compiler 4.10.2
@@ -4456,6 +4723,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.10-s390x, ocurrent/opam-staging:debian-1
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-s390x
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.10 --packages=ocaml-variants.4.10.2+afl
 	RUN opam pin add -k version ocaml-variants 4.10.2+afl
@@ -4468,6 +4736,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.10-s390x, ocurrent/opam-staging:debian-1
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-ppc64le
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.10 --packages=ocaml-variants.4.10.2+afl
 	RUN opam pin add -k version ocaml-variants 4.10.2+afl
@@ -4481,6 +4750,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.10-s390x, ocurrent/opam-staging:debian-1
 
 	FROM ocurrent/opam-staging:debian-12-opam-arm32v7
 	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.10 --packages=ocaml-variants.4.10.2+afl
 	RUN opam pin add -k version ocaml-variants 4.10.2+afl
@@ -4493,6 +4763,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.10-s390x, ocurrent/opam-staging:debian-1
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.10 --packages=ocaml-variants.4.10.2+afl
 	RUN opam pin add -k version ocaml-variants 4.10.2+afl
@@ -4505,6 +4776,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.10-s390x, ocurrent/opam-staging:debian-1
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.10 --packages=ocaml-variants.4.10.2+afl
 	RUN opam pin add -k version ocaml-variants 4.10.2+afl
@@ -4518,6 +4790,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.10-s390x, ocurrent/opam-staging:debian-1
 
 	FROM ocurrent/opam-staging:debian-12-opam-i386
 	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.10 --packages=ocaml-variants.4.10.2+afl
 	RUN opam pin add -k version ocaml-variants 4.10.2+afl
@@ -4532,6 +4805,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.10-afl-s390x, ocurrent/opam-staging:debi
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-s390x
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.10 --packages=ocaml-variants.4.10.2+flambda
 	RUN opam pin add -k version ocaml-variants 4.10.2+flambda
@@ -4544,6 +4818,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.10-afl-s390x, ocurrent/opam-staging:debi
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-ppc64le
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.10 --packages=ocaml-variants.4.10.2+flambda
 	RUN opam pin add -k version ocaml-variants 4.10.2+flambda
@@ -4557,6 +4832,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.10-afl-s390x, ocurrent/opam-staging:debi
 
 	FROM ocurrent/opam-staging:debian-12-opam-arm32v7
 	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.10 --packages=ocaml-variants.4.10.2+flambda
 	RUN opam pin add -k version ocaml-variants 4.10.2+flambda
@@ -4569,6 +4845,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.10-afl-s390x, ocurrent/opam-staging:debi
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.10 --packages=ocaml-variants.4.10.2+flambda
 	RUN opam pin add -k version ocaml-variants 4.10.2+flambda
@@ -4581,6 +4858,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.10-afl-s390x, ocurrent/opam-staging:debi
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.10 --packages=ocaml-variants.4.10.2+flambda
 	RUN opam pin add -k version ocaml-variants 4.10.2+flambda
@@ -4594,6 +4872,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.10-afl-s390x, ocurrent/opam-staging:debi
 
 	FROM ocurrent/opam-staging:debian-12-opam-i386
 	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.10 --packages=ocaml-variants.4.10.2+flambda
 	RUN opam pin add -k version ocaml-variants 4.10.2+flambda
@@ -4608,6 +4887,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.10-flambda-s390x, ocurrent/opam-staging:
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.10 --packages=ocaml-variants.4.10.2+fp
 	RUN opam pin add -k version ocaml-variants 4.10.2+fp
@@ -4622,6 +4902,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.10-fp-amd64 -> ocaml/opam:debian-ocaml-4
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-s390x
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.11 --packages=ocaml-base-compiler.4.11.2
 	RUN opam pin add -k version ocaml-base-compiler 4.11.2
@@ -4634,6 +4915,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.10-fp-amd64 -> ocaml/opam:debian-ocaml-4
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-ppc64le
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.11 --packages=ocaml-base-compiler.4.11.2
 	RUN opam pin add -k version ocaml-base-compiler 4.11.2
@@ -4647,6 +4929,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.10-fp-amd64 -> ocaml/opam:debian-ocaml-4
 
 	FROM ocurrent/opam-staging:debian-12-opam-arm32v7
 	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.11 --packages=ocaml-base-compiler.4.11.2
 	RUN opam pin add -k version ocaml-base-compiler 4.11.2
@@ -4659,6 +4942,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.10-fp-amd64 -> ocaml/opam:debian-ocaml-4
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.11 --packages=ocaml-base-compiler.4.11.2
 	RUN opam pin add -k version ocaml-base-compiler 4.11.2
@@ -4671,6 +4955,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.10-fp-amd64 -> ocaml/opam:debian-ocaml-4
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.11 --packages=ocaml-base-compiler.4.11.2
 	RUN opam pin add -k version ocaml-base-compiler 4.11.2
@@ -4684,6 +4969,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.10-fp-amd64 -> ocaml/opam:debian-ocaml-4
 
 	FROM ocurrent/opam-staging:debian-12-opam-i386
 	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.11 --packages=ocaml-base-compiler.4.11.2
 	RUN opam pin add -k version ocaml-base-compiler 4.11.2
@@ -4698,6 +4984,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.11-s390x, ocurrent/opam-staging:debian-1
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-s390x
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.11 --packages=ocaml-variants.4.11.2+afl
 	RUN opam pin add -k version ocaml-variants 4.11.2+afl
@@ -4710,6 +4997,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.11-s390x, ocurrent/opam-staging:debian-1
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-ppc64le
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.11 --packages=ocaml-variants.4.11.2+afl
 	RUN opam pin add -k version ocaml-variants 4.11.2+afl
@@ -4723,6 +5011,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.11-s390x, ocurrent/opam-staging:debian-1
 
 	FROM ocurrent/opam-staging:debian-12-opam-arm32v7
 	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.11 --packages=ocaml-variants.4.11.2+afl
 	RUN opam pin add -k version ocaml-variants 4.11.2+afl
@@ -4735,6 +5024,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.11-s390x, ocurrent/opam-staging:debian-1
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.11 --packages=ocaml-variants.4.11.2+afl
 	RUN opam pin add -k version ocaml-variants 4.11.2+afl
@@ -4747,6 +5037,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.11-s390x, ocurrent/opam-staging:debian-1
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.11 --packages=ocaml-variants.4.11.2+afl
 	RUN opam pin add -k version ocaml-variants 4.11.2+afl
@@ -4760,6 +5051,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.11-s390x, ocurrent/opam-staging:debian-1
 
 	FROM ocurrent/opam-staging:debian-12-opam-i386
 	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.11 --packages=ocaml-variants.4.11.2+afl
 	RUN opam pin add -k version ocaml-variants 4.11.2+afl
@@ -4774,6 +5066,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.11-afl-s390x, ocurrent/opam-staging:debi
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-s390x
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.11 --packages=ocaml-variants.4.11.2+flambda
 	RUN opam pin add -k version ocaml-variants 4.11.2+flambda
@@ -4786,6 +5079,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.11-afl-s390x, ocurrent/opam-staging:debi
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-ppc64le
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.11 --packages=ocaml-variants.4.11.2+flambda
 	RUN opam pin add -k version ocaml-variants 4.11.2+flambda
@@ -4799,6 +5093,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.11-afl-s390x, ocurrent/opam-staging:debi
 
 	FROM ocurrent/opam-staging:debian-12-opam-arm32v7
 	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.11 --packages=ocaml-variants.4.11.2+flambda
 	RUN opam pin add -k version ocaml-variants 4.11.2+flambda
@@ -4811,6 +5106,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.11-afl-s390x, ocurrent/opam-staging:debi
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.11 --packages=ocaml-variants.4.11.2+flambda
 	RUN opam pin add -k version ocaml-variants 4.11.2+flambda
@@ -4823,6 +5119,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.11-afl-s390x, ocurrent/opam-staging:debi
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.11 --packages=ocaml-variants.4.11.2+flambda
 	RUN opam pin add -k version ocaml-variants 4.11.2+flambda
@@ -4836,6 +5133,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.11-afl-s390x, ocurrent/opam-staging:debi
 
 	FROM ocurrent/opam-staging:debian-12-opam-i386
 	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.11 --packages=ocaml-variants.4.11.2+flambda
 	RUN opam pin add -k version ocaml-variants 4.11.2+flambda
@@ -4850,6 +5148,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.11-flambda-s390x, ocurrent/opam-staging:
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.11 --packages=ocaml-variants.4.11.2+fp
 	RUN opam pin add -k version ocaml-variants 4.11.2+fp
@@ -4864,6 +5163,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.11-fp-amd64 -> ocaml/opam:debian-ocaml-4
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-s390x
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.12 --packages=ocaml-base-compiler.4.12.1
 	RUN opam pin add -k version ocaml-base-compiler 4.12.1
@@ -4876,6 +5176,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.11-fp-amd64 -> ocaml/opam:debian-ocaml-4
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-ppc64le
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.12 --packages=ocaml-base-compiler.4.12.1
 	RUN opam pin add -k version ocaml-base-compiler 4.12.1
@@ -4889,6 +5190,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.11-fp-amd64 -> ocaml/opam:debian-ocaml-4
 
 	FROM ocurrent/opam-staging:debian-12-opam-arm32v7
 	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.12 --packages=ocaml-base-compiler.4.12.1
 	RUN opam pin add -k version ocaml-base-compiler 4.12.1
@@ -4901,6 +5203,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.11-fp-amd64 -> ocaml/opam:debian-ocaml-4
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.12 --packages=ocaml-base-compiler.4.12.1
 	RUN opam pin add -k version ocaml-base-compiler 4.12.1
@@ -4913,6 +5216,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.11-fp-amd64 -> ocaml/opam:debian-ocaml-4
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.12 --packages=ocaml-base-compiler.4.12.1
 	RUN opam pin add -k version ocaml-base-compiler 4.12.1
@@ -4926,6 +5230,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.11-fp-amd64 -> ocaml/opam:debian-ocaml-4
 
 	FROM ocurrent/opam-staging:debian-12-opam-i386
 	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.12 --packages=ocaml-base-compiler.4.12.1
 	RUN opam pin add -k version ocaml-base-compiler 4.12.1
@@ -4940,6 +5245,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.12-s390x, ocurrent/opam-staging:debian-1
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-s390x
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.12 --packages=ocaml-variants.4.12.1+options,ocaml-options-only-afl
 	RUN opam pin add -k version ocaml-variants 4.12.1+options
@@ -4952,6 +5258,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.12-s390x, ocurrent/opam-staging:debian-1
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-ppc64le
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.12 --packages=ocaml-variants.4.12.1+options,ocaml-options-only-afl
 	RUN opam pin add -k version ocaml-variants 4.12.1+options
@@ -4965,6 +5272,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.12-s390x, ocurrent/opam-staging:debian-1
 
 	FROM ocurrent/opam-staging:debian-12-opam-arm32v7
 	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.12 --packages=ocaml-variants.4.12.1+options,ocaml-options-only-afl
 	RUN opam pin add -k version ocaml-variants 4.12.1+options
@@ -4977,6 +5285,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.12-s390x, ocurrent/opam-staging:debian-1
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.12 --packages=ocaml-variants.4.12.1+options,ocaml-options-only-afl
 	RUN opam pin add -k version ocaml-variants 4.12.1+options
@@ -4989,6 +5298,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.12-s390x, ocurrent/opam-staging:debian-1
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.12 --packages=ocaml-variants.4.12.1+options,ocaml-options-only-afl
 	RUN opam pin add -k version ocaml-variants 4.12.1+options
@@ -5002,6 +5312,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.12-s390x, ocurrent/opam-staging:debian-1
 
 	FROM ocurrent/opam-staging:debian-12-opam-i386
 	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.12 --packages=ocaml-variants.4.12.1+options,ocaml-options-only-afl
 	RUN opam pin add -k version ocaml-variants 4.12.1+options
@@ -5016,6 +5327,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.12-afl-s390x, ocurrent/opam-staging:debi
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-s390x
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.12 --packages=ocaml-variants.4.12.1+options,ocaml-options-only-flambda
 	RUN opam pin add -k version ocaml-variants 4.12.1+options
@@ -5028,6 +5340,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.12-afl-s390x, ocurrent/opam-staging:debi
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-ppc64le
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.12 --packages=ocaml-variants.4.12.1+options,ocaml-options-only-flambda
 	RUN opam pin add -k version ocaml-variants 4.12.1+options
@@ -5041,6 +5354,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.12-afl-s390x, ocurrent/opam-staging:debi
 
 	FROM ocurrent/opam-staging:debian-12-opam-arm32v7
 	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.12 --packages=ocaml-variants.4.12.1+options,ocaml-options-only-flambda
 	RUN opam pin add -k version ocaml-variants 4.12.1+options
@@ -5053,6 +5367,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.12-afl-s390x, ocurrent/opam-staging:debi
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.12 --packages=ocaml-variants.4.12.1+options,ocaml-options-only-flambda
 	RUN opam pin add -k version ocaml-variants 4.12.1+options
@@ -5065,6 +5380,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.12-afl-s390x, ocurrent/opam-staging:debi
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.12 --packages=ocaml-variants.4.12.1+options,ocaml-options-only-flambda
 	RUN opam pin add -k version ocaml-variants 4.12.1+options
@@ -5078,6 +5394,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.12-afl-s390x, ocurrent/opam-staging:debi
 
 	FROM ocurrent/opam-staging:debian-12-opam-i386
 	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.12 --packages=ocaml-variants.4.12.1+options,ocaml-options-only-flambda
 	RUN opam pin add -k version ocaml-variants 4.12.1+options
@@ -5092,6 +5409,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.12-flambda-s390x, ocurrent/opam-staging:
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.12 --packages=ocaml-variants.4.12.1+options,ocaml-options-only-flambda-fp
 	RUN opam pin add -k version ocaml-variants 4.12.1+options
@@ -5106,6 +5424,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.12-flambda-fp-amd64 -> ocaml/opam:debian
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.12 --packages=ocaml-variants.4.12.1+options,ocaml-options-only-fp
 	RUN opam pin add -k version ocaml-variants 4.12.1+options
@@ -5120,6 +5439,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.12-fp-amd64 -> ocaml/opam:debian-ocaml-4
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-s390x
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.12 --packages=ocaml-variants.4.12.1+options,ocaml-options-only-nnp
 	RUN opam pin add -k version ocaml-variants 4.12.1+options
@@ -5132,6 +5452,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.12-fp-amd64 -> ocaml/opam:debian-ocaml-4
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-ppc64le
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.12 --packages=ocaml-variants.4.12.1+options,ocaml-options-only-nnp
 	RUN opam pin add -k version ocaml-variants 4.12.1+options
@@ -5145,6 +5466,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.12-fp-amd64 -> ocaml/opam:debian-ocaml-4
 
 	FROM ocurrent/opam-staging:debian-12-opam-arm32v7
 	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.12 --packages=ocaml-variants.4.12.1+options,ocaml-options-only-nnp
 	RUN opam pin add -k version ocaml-variants 4.12.1+options
@@ -5157,6 +5479,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.12-fp-amd64 -> ocaml/opam:debian-ocaml-4
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.12 --packages=ocaml-variants.4.12.1+options,ocaml-options-only-nnp
 	RUN opam pin add -k version ocaml-variants 4.12.1+options
@@ -5169,6 +5492,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.12-fp-amd64 -> ocaml/opam:debian-ocaml-4
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.12 --packages=ocaml-variants.4.12.1+options,ocaml-options-only-nnp
 	RUN opam pin add -k version ocaml-variants 4.12.1+options
@@ -5182,6 +5506,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.12-fp-amd64 -> ocaml/opam:debian-ocaml-4
 
 	FROM ocurrent/opam-staging:debian-12-opam-i386
 	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.12 --packages=ocaml-variants.4.12.1+options,ocaml-options-only-nnp
 	RUN opam pin add -k version ocaml-variants 4.12.1+options
@@ -5196,6 +5521,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.12-nnp-s390x, ocurrent/opam-staging:debi
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.12 --packages=ocaml-variants.4.12.1+options,ocaml-options-only-nnpchecker
 	RUN opam pin add -k version ocaml-variants 4.12.1+options
@@ -5210,6 +5536,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.12-nnpchecker-amd64 -> ocaml/opam:debian
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-s390x
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.12 --packages=ocaml-variants.4.12.1+options,ocaml-options-only-no-flat-float-array
 	RUN opam pin add -k version ocaml-variants 4.12.1+options
@@ -5222,6 +5549,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.12-nnpchecker-amd64 -> ocaml/opam:debian
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-ppc64le
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.12 --packages=ocaml-variants.4.12.1+options,ocaml-options-only-no-flat-float-array
 	RUN opam pin add -k version ocaml-variants 4.12.1+options
@@ -5235,6 +5563,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.12-nnpchecker-amd64 -> ocaml/opam:debian
 
 	FROM ocurrent/opam-staging:debian-12-opam-arm32v7
 	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.12 --packages=ocaml-variants.4.12.1+options,ocaml-options-only-no-flat-float-array
 	RUN opam pin add -k version ocaml-variants 4.12.1+options
@@ -5247,6 +5576,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.12-nnpchecker-amd64 -> ocaml/opam:debian
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.12 --packages=ocaml-variants.4.12.1+options,ocaml-options-only-no-flat-float-array
 	RUN opam pin add -k version ocaml-variants 4.12.1+options
@@ -5259,6 +5589,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.12-nnpchecker-amd64 -> ocaml/opam:debian
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.12 --packages=ocaml-variants.4.12.1+options,ocaml-options-only-no-flat-float-array
 	RUN opam pin add -k version ocaml-variants 4.12.1+options
@@ -5272,6 +5603,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.12-nnpchecker-amd64 -> ocaml/opam:debian
 
 	FROM ocurrent/opam-staging:debian-12-opam-i386
 	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.12 --packages=ocaml-variants.4.12.1+options,ocaml-options-only-no-flat-float-array
 	RUN opam pin add -k version ocaml-variants 4.12.1+options
@@ -5286,6 +5618,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.12-no-flat-float-array-s390x, ocurrent/o
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-s390x
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.13 --packages=ocaml-base-compiler.4.13.1
 	RUN opam pin add -k version ocaml-base-compiler 4.13.1
@@ -5298,6 +5631,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.12-no-flat-float-array-s390x, ocurrent/o
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-ppc64le
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.13 --packages=ocaml-base-compiler.4.13.1
 	RUN opam pin add -k version ocaml-base-compiler 4.13.1
@@ -5311,6 +5645,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.12-no-flat-float-array-s390x, ocurrent/o
 
 	FROM ocurrent/opam-staging:debian-12-opam-arm32v7
 	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.13 --packages=ocaml-base-compiler.4.13.1
 	RUN opam pin add -k version ocaml-base-compiler 4.13.1
@@ -5323,6 +5658,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.12-no-flat-float-array-s390x, ocurrent/o
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.13 --packages=ocaml-base-compiler.4.13.1
 	RUN opam pin add -k version ocaml-base-compiler 4.13.1
@@ -5335,6 +5671,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.12-no-flat-float-array-s390x, ocurrent/o
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.13 --packages=ocaml-base-compiler.4.13.1
 	RUN opam pin add -k version ocaml-base-compiler 4.13.1
@@ -5348,6 +5685,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.12-no-flat-float-array-s390x, ocurrent/o
 
 	FROM ocurrent/opam-staging:debian-12-opam-i386
 	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.13 --packages=ocaml-base-compiler.4.13.1
 	RUN opam pin add -k version ocaml-base-compiler 4.13.1
@@ -5362,6 +5700,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.13-s390x, ocurrent/opam-staging:debian-1
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-s390x
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.13 --packages=ocaml-variants.4.13.1+options,ocaml-options-only-afl
 	RUN opam pin add -k version ocaml-variants 4.13.1+options
@@ -5374,6 +5713,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.13-s390x, ocurrent/opam-staging:debian-1
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-ppc64le
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.13 --packages=ocaml-variants.4.13.1+options,ocaml-options-only-afl
 	RUN opam pin add -k version ocaml-variants 4.13.1+options
@@ -5387,6 +5727,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.13-s390x, ocurrent/opam-staging:debian-1
 
 	FROM ocurrent/opam-staging:debian-12-opam-arm32v7
 	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.13 --packages=ocaml-variants.4.13.1+options,ocaml-options-only-afl
 	RUN opam pin add -k version ocaml-variants 4.13.1+options
@@ -5399,6 +5740,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.13-s390x, ocurrent/opam-staging:debian-1
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.13 --packages=ocaml-variants.4.13.1+options,ocaml-options-only-afl
 	RUN opam pin add -k version ocaml-variants 4.13.1+options
@@ -5411,6 +5753,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.13-s390x, ocurrent/opam-staging:debian-1
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.13 --packages=ocaml-variants.4.13.1+options,ocaml-options-only-afl
 	RUN opam pin add -k version ocaml-variants 4.13.1+options
@@ -5424,6 +5767,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.13-s390x, ocurrent/opam-staging:debian-1
 
 	FROM ocurrent/opam-staging:debian-12-opam-i386
 	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.13 --packages=ocaml-variants.4.13.1+options,ocaml-options-only-afl
 	RUN opam pin add -k version ocaml-variants 4.13.1+options
@@ -5438,6 +5782,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.13-afl-s390x, ocurrent/opam-staging:debi
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-s390x
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.13 --packages=ocaml-variants.4.13.1+options,ocaml-options-only-flambda
 	RUN opam pin add -k version ocaml-variants 4.13.1+options
@@ -5450,6 +5795,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.13-afl-s390x, ocurrent/opam-staging:debi
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-ppc64le
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.13 --packages=ocaml-variants.4.13.1+options,ocaml-options-only-flambda
 	RUN opam pin add -k version ocaml-variants 4.13.1+options
@@ -5463,6 +5809,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.13-afl-s390x, ocurrent/opam-staging:debi
 
 	FROM ocurrent/opam-staging:debian-12-opam-arm32v7
 	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.13 --packages=ocaml-variants.4.13.1+options,ocaml-options-only-flambda
 	RUN opam pin add -k version ocaml-variants 4.13.1+options
@@ -5475,6 +5822,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.13-afl-s390x, ocurrent/opam-staging:debi
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.13 --packages=ocaml-variants.4.13.1+options,ocaml-options-only-flambda
 	RUN opam pin add -k version ocaml-variants 4.13.1+options
@@ -5487,6 +5835,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.13-afl-s390x, ocurrent/opam-staging:debi
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.13 --packages=ocaml-variants.4.13.1+options,ocaml-options-only-flambda
 	RUN opam pin add -k version ocaml-variants 4.13.1+options
@@ -5500,6 +5849,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.13-afl-s390x, ocurrent/opam-staging:debi
 
 	FROM ocurrent/opam-staging:debian-12-opam-i386
 	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.13 --packages=ocaml-variants.4.13.1+options,ocaml-options-only-flambda
 	RUN opam pin add -k version ocaml-variants 4.13.1+options
@@ -5514,6 +5864,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.13-flambda-s390x, ocurrent/opam-staging:
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.13 --packages=ocaml-variants.4.13.1+options,ocaml-options-only-flambda-fp
 	RUN opam pin add -k version ocaml-variants 4.13.1+options
@@ -5528,6 +5879,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.13-flambda-fp-amd64 -> ocaml/opam:debian
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.13 --packages=ocaml-variants.4.13.1+options,ocaml-options-only-fp
 	RUN opam pin add -k version ocaml-variants 4.13.1+options
@@ -5542,6 +5894,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.13-fp-amd64 -> ocaml/opam:debian-ocaml-4
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-s390x
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.13 --packages=ocaml-variants.4.13.1+options,ocaml-options-only-nnp
 	RUN opam pin add -k version ocaml-variants 4.13.1+options
@@ -5554,6 +5907,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.13-fp-amd64 -> ocaml/opam:debian-ocaml-4
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-ppc64le
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.13 --packages=ocaml-variants.4.13.1+options,ocaml-options-only-nnp
 	RUN opam pin add -k version ocaml-variants 4.13.1+options
@@ -5567,6 +5921,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.13-fp-amd64 -> ocaml/opam:debian-ocaml-4
 
 	FROM ocurrent/opam-staging:debian-12-opam-arm32v7
 	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.13 --packages=ocaml-variants.4.13.1+options,ocaml-options-only-nnp
 	RUN opam pin add -k version ocaml-variants 4.13.1+options
@@ -5579,6 +5934,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.13-fp-amd64 -> ocaml/opam:debian-ocaml-4
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.13 --packages=ocaml-variants.4.13.1+options,ocaml-options-only-nnp
 	RUN opam pin add -k version ocaml-variants 4.13.1+options
@@ -5591,6 +5947,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.13-fp-amd64 -> ocaml/opam:debian-ocaml-4
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.13 --packages=ocaml-variants.4.13.1+options,ocaml-options-only-nnp
 	RUN opam pin add -k version ocaml-variants 4.13.1+options
@@ -5604,6 +5961,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.13-fp-amd64 -> ocaml/opam:debian-ocaml-4
 
 	FROM ocurrent/opam-staging:debian-12-opam-i386
 	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.13 --packages=ocaml-variants.4.13.1+options,ocaml-options-only-nnp
 	RUN opam pin add -k version ocaml-variants 4.13.1+options
@@ -5618,6 +5976,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.13-nnp-s390x, ocurrent/opam-staging:debi
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.13 --packages=ocaml-variants.4.13.1+options,ocaml-options-only-nnpchecker
 	RUN opam pin add -k version ocaml-variants 4.13.1+options
@@ -5632,6 +5991,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.13-nnpchecker-amd64 -> ocaml/opam:debian
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-s390x
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.13 --packages=ocaml-variants.4.13.1+options,ocaml-options-only-no-flat-float-array
 	RUN opam pin add -k version ocaml-variants 4.13.1+options
@@ -5644,6 +6004,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.13-nnpchecker-amd64 -> ocaml/opam:debian
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-ppc64le
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.13 --packages=ocaml-variants.4.13.1+options,ocaml-options-only-no-flat-float-array
 	RUN opam pin add -k version ocaml-variants 4.13.1+options
@@ -5657,6 +6018,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.13-nnpchecker-amd64 -> ocaml/opam:debian
 
 	FROM ocurrent/opam-staging:debian-12-opam-arm32v7
 	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.13 --packages=ocaml-variants.4.13.1+options,ocaml-options-only-no-flat-float-array
 	RUN opam pin add -k version ocaml-variants 4.13.1+options
@@ -5669,6 +6031,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.13-nnpchecker-amd64 -> ocaml/opam:debian
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.13 --packages=ocaml-variants.4.13.1+options,ocaml-options-only-no-flat-float-array
 	RUN opam pin add -k version ocaml-variants 4.13.1+options
@@ -5681,6 +6044,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.13-nnpchecker-amd64 -> ocaml/opam:debian
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.13 --packages=ocaml-variants.4.13.1+options,ocaml-options-only-no-flat-float-array
 	RUN opam pin add -k version ocaml-variants 4.13.1+options
@@ -5694,6 +6058,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.13-nnpchecker-amd64 -> ocaml/opam:debian
 
 	FROM ocurrent/opam-staging:debian-12-opam-i386
 	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.13 --packages=ocaml-variants.4.13.1+options,ocaml-options-only-no-flat-float-array
 	RUN opam pin add -k version ocaml-variants 4.13.1+options
@@ -5708,6 +6073,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.13-no-flat-float-array-s390x, ocurrent/o
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-s390x
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.14 --packages=ocaml-base-compiler.4.14.2
 	RUN opam pin add -k version ocaml-base-compiler 4.14.2
@@ -5720,6 +6086,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.13-no-flat-float-array-s390x, ocurrent/o
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-ppc64le
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.14 --packages=ocaml-base-compiler.4.14.2
 	RUN opam pin add -k version ocaml-base-compiler 4.14.2
@@ -5733,6 +6100,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.13-no-flat-float-array-s390x, ocurrent/o
 
 	FROM ocurrent/opam-staging:debian-12-opam-arm32v7
 	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.14 --packages=ocaml-base-compiler.4.14.2
 	RUN opam pin add -k version ocaml-base-compiler 4.14.2
@@ -5745,6 +6113,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.13-no-flat-float-array-s390x, ocurrent/o
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.14 --packages=ocaml-base-compiler.4.14.2
 	RUN opam pin add -k version ocaml-base-compiler 4.14.2
@@ -5757,6 +6126,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.13-no-flat-float-array-s390x, ocurrent/o
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.14 --packages=ocaml-base-compiler.4.14.2
 	RUN opam pin add -k version ocaml-base-compiler 4.14.2
@@ -5770,6 +6140,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.13-no-flat-float-array-s390x, ocurrent/o
 
 	FROM ocurrent/opam-staging:debian-12-opam-i386
 	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.14 --packages=ocaml-base-compiler.4.14.2
 	RUN opam pin add -k version ocaml-base-compiler 4.14.2
@@ -5784,6 +6155,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.14-s390x, ocurrent/opam-staging:debian-1
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-s390x
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.14 --packages=ocaml-variants.4.14.2+options,ocaml-options-only-afl
 	RUN opam pin add -k version ocaml-variants 4.14.2+options
@@ -5796,6 +6168,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.14-s390x, ocurrent/opam-staging:debian-1
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-ppc64le
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.14 --packages=ocaml-variants.4.14.2+options,ocaml-options-only-afl
 	RUN opam pin add -k version ocaml-variants 4.14.2+options
@@ -5809,6 +6182,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.14-s390x, ocurrent/opam-staging:debian-1
 
 	FROM ocurrent/opam-staging:debian-12-opam-arm32v7
 	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.14 --packages=ocaml-variants.4.14.2+options,ocaml-options-only-afl
 	RUN opam pin add -k version ocaml-variants 4.14.2+options
@@ -5821,6 +6195,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.14-s390x, ocurrent/opam-staging:debian-1
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.14 --packages=ocaml-variants.4.14.2+options,ocaml-options-only-afl
 	RUN opam pin add -k version ocaml-variants 4.14.2+options
@@ -5833,6 +6208,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.14-s390x, ocurrent/opam-staging:debian-1
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.14 --packages=ocaml-variants.4.14.2+options,ocaml-options-only-afl
 	RUN opam pin add -k version ocaml-variants 4.14.2+options
@@ -5846,6 +6222,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.14-s390x, ocurrent/opam-staging:debian-1
 
 	FROM ocurrent/opam-staging:debian-12-opam-i386
 	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.14 --packages=ocaml-variants.4.14.2+options,ocaml-options-only-afl
 	RUN opam pin add -k version ocaml-variants 4.14.2+options
@@ -5860,6 +6237,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.14-afl-s390x, ocurrent/opam-staging:debi
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-s390x
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.14 --packages=ocaml-variants.4.14.2+options,ocaml-options-only-flambda
 	RUN opam pin add -k version ocaml-variants 4.14.2+options
@@ -5872,6 +6250,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.14-afl-s390x, ocurrent/opam-staging:debi
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-ppc64le
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.14 --packages=ocaml-variants.4.14.2+options,ocaml-options-only-flambda
 	RUN opam pin add -k version ocaml-variants 4.14.2+options
@@ -5885,6 +6264,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.14-afl-s390x, ocurrent/opam-staging:debi
 
 	FROM ocurrent/opam-staging:debian-12-opam-arm32v7
 	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.14 --packages=ocaml-variants.4.14.2+options,ocaml-options-only-flambda
 	RUN opam pin add -k version ocaml-variants 4.14.2+options
@@ -5897,6 +6277,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.14-afl-s390x, ocurrent/opam-staging:debi
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.14 --packages=ocaml-variants.4.14.2+options,ocaml-options-only-flambda
 	RUN opam pin add -k version ocaml-variants 4.14.2+options
@@ -5909,6 +6290,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.14-afl-s390x, ocurrent/opam-staging:debi
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.14 --packages=ocaml-variants.4.14.2+options,ocaml-options-only-flambda
 	RUN opam pin add -k version ocaml-variants 4.14.2+options
@@ -5922,6 +6304,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.14-afl-s390x, ocurrent/opam-staging:debi
 
 	FROM ocurrent/opam-staging:debian-12-opam-i386
 	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.14 --packages=ocaml-variants.4.14.2+options,ocaml-options-only-flambda
 	RUN opam pin add -k version ocaml-variants 4.14.2+options
@@ -5936,6 +6319,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.14-flambda-s390x, ocurrent/opam-staging:
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.14 --packages=ocaml-variants.4.14.2+options,ocaml-options-only-flambda-fp
 	RUN opam pin add -k version ocaml-variants 4.14.2+options
@@ -5950,6 +6334,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.14-flambda-fp-amd64 -> ocaml/opam:debian
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.14 --packages=ocaml-variants.4.14.2+options,ocaml-options-only-fp
 	RUN opam pin add -k version ocaml-variants 4.14.2+options
@@ -5964,6 +6349,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.14-fp-amd64 -> ocaml/opam:debian-ocaml-4
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-s390x
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.14 --packages=ocaml-variants.4.14.2+options,ocaml-options-only-nnp
 	RUN opam pin add -k version ocaml-variants 4.14.2+options
@@ -5976,6 +6362,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.14-fp-amd64 -> ocaml/opam:debian-ocaml-4
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-ppc64le
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.14 --packages=ocaml-variants.4.14.2+options,ocaml-options-only-nnp
 	RUN opam pin add -k version ocaml-variants 4.14.2+options
@@ -5989,6 +6376,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.14-fp-amd64 -> ocaml/opam:debian-ocaml-4
 
 	FROM ocurrent/opam-staging:debian-12-opam-arm32v7
 	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.14 --packages=ocaml-variants.4.14.2+options,ocaml-options-only-nnp
 	RUN opam pin add -k version ocaml-variants 4.14.2+options
@@ -6001,6 +6389,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.14-fp-amd64 -> ocaml/opam:debian-ocaml-4
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.14 --packages=ocaml-variants.4.14.2+options,ocaml-options-only-nnp
 	RUN opam pin add -k version ocaml-variants 4.14.2+options
@@ -6013,6 +6402,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.14-fp-amd64 -> ocaml/opam:debian-ocaml-4
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.14 --packages=ocaml-variants.4.14.2+options,ocaml-options-only-nnp
 	RUN opam pin add -k version ocaml-variants 4.14.2+options
@@ -6026,6 +6416,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.14-fp-amd64 -> ocaml/opam:debian-ocaml-4
 
 	FROM ocurrent/opam-staging:debian-12-opam-i386
 	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.14 --packages=ocaml-variants.4.14.2+options,ocaml-options-only-nnp
 	RUN opam pin add -k version ocaml-variants 4.14.2+options
@@ -6040,6 +6431,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.14-nnp-s390x, ocurrent/opam-staging:debi
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.14 --packages=ocaml-variants.4.14.2+options,ocaml-options-only-nnpchecker
 	RUN opam pin add -k version ocaml-variants 4.14.2+options
@@ -6054,6 +6446,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.14-nnpchecker-amd64 -> ocaml/opam:debian
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-s390x
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.14 --packages=ocaml-variants.4.14.2+options,ocaml-options-only-no-flat-float-array
 	RUN opam pin add -k version ocaml-variants 4.14.2+options
@@ -6066,6 +6459,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.14-nnpchecker-amd64 -> ocaml/opam:debian
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-ppc64le
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.14 --packages=ocaml-variants.4.14.2+options,ocaml-options-only-no-flat-float-array
 	RUN opam pin add -k version ocaml-variants 4.14.2+options
@@ -6079,6 +6473,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.14-nnpchecker-amd64 -> ocaml/opam:debian
 
 	FROM ocurrent/opam-staging:debian-12-opam-arm32v7
 	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.14 --packages=ocaml-variants.4.14.2+options,ocaml-options-only-no-flat-float-array
 	RUN opam pin add -k version ocaml-variants 4.14.2+options
@@ -6091,6 +6486,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.14-nnpchecker-amd64 -> ocaml/opam:debian
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.14 --packages=ocaml-variants.4.14.2+options,ocaml-options-only-no-flat-float-array
 	RUN opam pin add -k version ocaml-variants 4.14.2+options
@@ -6103,6 +6499,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.14-nnpchecker-amd64 -> ocaml/opam:debian
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.14 --packages=ocaml-variants.4.14.2+options,ocaml-options-only-no-flat-float-array
 	RUN opam pin add -k version ocaml-variants 4.14.2+options
@@ -6116,6 +6513,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.14-nnpchecker-amd64 -> ocaml/opam:debian
 
 	FROM ocurrent/opam-staging:debian-12-opam-i386
 	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.14 --packages=ocaml-variants.4.14.2+options,ocaml-options-only-no-flat-float-array
 	RUN opam pin add -k version ocaml-variants 4.14.2+options
@@ -6130,6 +6528,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.14-no-flat-float-array-s390x, ocurrent/o
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-s390x
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 5.0 --packages=ocaml-base-compiler.5.0.0
 	RUN opam pin add -k version ocaml-base-compiler 5.0.0
@@ -6142,6 +6541,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.14-no-flat-float-array-s390x, ocurrent/o
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-ppc64le
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 5.0 --packages=ocaml-base-compiler.5.0.0
 	RUN opam pin add -k version ocaml-base-compiler 5.0.0
@@ -6155,6 +6555,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.14-no-flat-float-array-s390x, ocurrent/o
 
 	FROM ocurrent/opam-staging:debian-12-opam-arm32v7
 	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 5.0 --packages=ocaml-base-compiler.5.0.0
 	RUN opam pin add -k version ocaml-base-compiler 5.0.0
@@ -6167,6 +6568,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.14-no-flat-float-array-s390x, ocurrent/o
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 5.0 --packages=ocaml-base-compiler.5.0.0
 	RUN opam pin add -k version ocaml-base-compiler 5.0.0
@@ -6179,6 +6581,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.14-no-flat-float-array-s390x, ocurrent/o
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 5.0 --packages=ocaml-base-compiler.5.0.0
 	RUN opam pin add -k version ocaml-base-compiler 5.0.0
@@ -6192,6 +6595,7 @@ ocurrent/opam-staging:debian-12-ocaml-4.14-no-flat-float-array-s390x, ocurrent/o
 
 	FROM ocurrent/opam-staging:debian-12-opam-i386
 	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 5.0 --packages=ocaml-base-compiler.5.0.0
 	RUN opam pin add -k version ocaml-base-compiler 5.0.0
@@ -6206,6 +6610,7 @@ ocurrent/opam-staging:debian-12-ocaml-5.0-s390x, ocurrent/opam-staging:debian-12
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 5.0 --packages=ocaml-variants.5.0.0+options,ocaml-options-only-afl
 	RUN opam pin add -k version ocaml-variants 5.0.0+options
@@ -6218,6 +6623,7 @@ ocurrent/opam-staging:debian-12-ocaml-5.0-s390x, ocurrent/opam-staging:debian-12
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 5.0 --packages=ocaml-variants.5.0.0+options,ocaml-options-only-afl
 	RUN opam pin add -k version ocaml-variants 5.0.0+options
@@ -6232,6 +6638,7 @@ ocurrent/opam-staging:debian-12-ocaml-5.0-afl-arm64, ocurrent/opam-staging:debia
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 5.0 --packages=ocaml-variants.5.0.0+options,ocaml-options-only-flambda
 	RUN opam pin add -k version ocaml-variants 5.0.0+options
@@ -6244,6 +6651,7 @@ ocurrent/opam-staging:debian-12-ocaml-5.0-afl-arm64, ocurrent/opam-staging:debia
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 5.0 --packages=ocaml-variants.5.0.0+options,ocaml-options-only-flambda
 	RUN opam pin add -k version ocaml-variants 5.0.0+options
@@ -6258,6 +6666,7 @@ ocurrent/opam-staging:debian-12-ocaml-5.0-flambda-arm64, ocurrent/opam-staging:d
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-s390x
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 5.0 --packages=ocaml-variants.5.0.0+options,ocaml-options-only-no-flat-float-array
 	RUN opam pin add -k version ocaml-variants 5.0.0+options
@@ -6270,6 +6679,7 @@ ocurrent/opam-staging:debian-12-ocaml-5.0-flambda-arm64, ocurrent/opam-staging:d
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-ppc64le
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 5.0 --packages=ocaml-variants.5.0.0+options,ocaml-options-only-no-flat-float-array
 	RUN opam pin add -k version ocaml-variants 5.0.0+options
@@ -6283,6 +6693,7 @@ ocurrent/opam-staging:debian-12-ocaml-5.0-flambda-arm64, ocurrent/opam-staging:d
 
 	FROM ocurrent/opam-staging:debian-12-opam-arm32v7
 	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 5.0 --packages=ocaml-variants.5.0.0+options,ocaml-options-only-no-flat-float-array
 	RUN opam pin add -k version ocaml-variants 5.0.0+options
@@ -6295,6 +6706,7 @@ ocurrent/opam-staging:debian-12-ocaml-5.0-flambda-arm64, ocurrent/opam-staging:d
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 5.0 --packages=ocaml-variants.5.0.0+options,ocaml-options-only-no-flat-float-array
 	RUN opam pin add -k version ocaml-variants 5.0.0+options
@@ -6307,6 +6719,7 @@ ocurrent/opam-staging:debian-12-ocaml-5.0-flambda-arm64, ocurrent/opam-staging:d
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 5.0 --packages=ocaml-variants.5.0.0+options,ocaml-options-only-no-flat-float-array
 	RUN opam pin add -k version ocaml-variants 5.0.0+options
@@ -6320,6 +6733,7 @@ ocurrent/opam-staging:debian-12-ocaml-5.0-flambda-arm64, ocurrent/opam-staging:d
 
 	FROM ocurrent/opam-staging:debian-12-opam-i386
 	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 5.0 --packages=ocaml-variants.5.0.0+options,ocaml-options-only-no-flat-float-array
 	RUN opam pin add -k version ocaml-variants 5.0.0+options
@@ -6334,6 +6748,7 @@ ocurrent/opam-staging:debian-12-ocaml-5.0-no-flat-float-array-s390x, ocurrent/op
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-s390x
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
 	RUN apt-get -y update
@@ -6351,6 +6766,7 @@ ocurrent/opam-staging:debian-12-ocaml-5.0-no-flat-float-array-s390x, ocurrent/op
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-ppc64le
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
 	RUN apt-get -y update
@@ -6369,6 +6785,7 @@ ocurrent/opam-staging:debian-12-ocaml-5.0-no-flat-float-array-s390x, ocurrent/op
 
 	FROM ocurrent/opam-staging:debian-12-opam-arm32v7
 	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
 	RUN apt-get -y update
@@ -6386,6 +6803,7 @@ ocurrent/opam-staging:debian-12-ocaml-5.0-no-flat-float-array-s390x, ocurrent/op
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
 	RUN apt-get -y update
@@ -6403,6 +6821,7 @@ ocurrent/opam-staging:debian-12-ocaml-5.0-no-flat-float-array-s390x, ocurrent/op
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
 	RUN apt-get -y update
@@ -6421,6 +6840,7 @@ ocurrent/opam-staging:debian-12-ocaml-5.0-no-flat-float-array-s390x, ocurrent/op
 
 	FROM ocurrent/opam-staging:debian-12-opam-i386
 	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
 	RUN apt-get -y update
@@ -6440,6 +6860,7 @@ ocurrent/opam-staging:debian-12-ocaml-5.1-s390x, ocurrent/opam-staging:debian-12
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
 	RUN apt-get -y update
@@ -6457,6 +6878,7 @@ ocurrent/opam-staging:debian-12-ocaml-5.1-s390x, ocurrent/opam-staging:debian-12
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
 	RUN apt-get -y update
@@ -6476,6 +6898,7 @@ ocurrent/opam-staging:debian-12-ocaml-5.1-afl-arm64, ocurrent/opam-staging:debia
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
 	RUN apt-get -y update
@@ -6493,6 +6916,7 @@ ocurrent/opam-staging:debian-12-ocaml-5.1-afl-arm64, ocurrent/opam-staging:debia
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
 	RUN apt-get -y update
@@ -6512,6 +6936,7 @@ ocurrent/opam-staging:debian-12-ocaml-5.1-flambda-arm64, ocurrent/opam-staging:d
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-s390x
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
 	RUN apt-get -y update
@@ -6529,6 +6954,7 @@ ocurrent/opam-staging:debian-12-ocaml-5.1-flambda-arm64, ocurrent/opam-staging:d
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-ppc64le
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
 	RUN apt-get -y update
@@ -6547,6 +6973,7 @@ ocurrent/opam-staging:debian-12-ocaml-5.1-flambda-arm64, ocurrent/opam-staging:d
 
 	FROM ocurrent/opam-staging:debian-12-opam-arm32v7
 	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
 	RUN apt-get -y update
@@ -6564,6 +6991,7 @@ ocurrent/opam-staging:debian-12-ocaml-5.1-flambda-arm64, ocurrent/opam-staging:d
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
 	RUN apt-get -y update
@@ -6581,6 +7009,7 @@ ocurrent/opam-staging:debian-12-ocaml-5.1-flambda-arm64, ocurrent/opam-staging:d
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
 	RUN apt-get -y update
@@ -6599,6 +7028,7 @@ ocurrent/opam-staging:debian-12-ocaml-5.1-flambda-arm64, ocurrent/opam-staging:d
 
 	FROM ocurrent/opam-staging:debian-12-opam-i386
 	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
 	RUN apt-get -y update
@@ -6618,6 +7048,7 @@ ocurrent/opam-staging:debian-12-ocaml-5.1-no-flat-float-array-s390x, ocurrent/op
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-s390x
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
 	RUN apt-get -y update
@@ -6635,6 +7066,7 @@ ocurrent/opam-staging:debian-12-ocaml-5.1-no-flat-float-array-s390x, ocurrent/op
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-ppc64le
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
 	RUN apt-get -y update
@@ -6653,6 +7085,7 @@ ocurrent/opam-staging:debian-12-ocaml-5.1-no-flat-float-array-s390x, ocurrent/op
 
 	FROM ocurrent/opam-staging:debian-12-opam-arm32v7
 	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
 	RUN apt-get -y update
@@ -6670,6 +7103,7 @@ ocurrent/opam-staging:debian-12-ocaml-5.1-no-flat-float-array-s390x, ocurrent/op
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
 	RUN apt-get -y update
@@ -6687,6 +7121,7 @@ ocurrent/opam-staging:debian-12-ocaml-5.1-no-flat-float-array-s390x, ocurrent/op
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
 	RUN apt-get -y update
@@ -6705,6 +7140,7 @@ ocurrent/opam-staging:debian-12-ocaml-5.1-no-flat-float-array-s390x, ocurrent/op
 
 	FROM ocurrent/opam-staging:debian-12-opam-i386
 	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
 	RUN apt-get -y update
@@ -6724,6 +7160,7 @@ ocurrent/opam-staging:debian-12-ocaml-5.2-s390x, ocurrent/opam-staging:debian-12
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
 	RUN apt-get -y update
@@ -6741,6 +7178,7 @@ ocurrent/opam-staging:debian-12-ocaml-5.2-s390x, ocurrent/opam-staging:debian-12
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
 	RUN apt-get -y update
@@ -6760,6 +7198,7 @@ ocurrent/opam-staging:debian-12-ocaml-5.2-afl-arm64, ocurrent/opam-staging:debia
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
 	RUN apt-get -y update
@@ -6777,6 +7216,7 @@ ocurrent/opam-staging:debian-12-ocaml-5.2-afl-arm64, ocurrent/opam-staging:debia
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
 	RUN apt-get -y update
@@ -6796,6 +7236,7 @@ ocurrent/opam-staging:debian-12-ocaml-5.2-flambda-arm64, ocurrent/opam-staging:d
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-s390x
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
 	RUN apt-get -y update
@@ -6813,6 +7254,7 @@ ocurrent/opam-staging:debian-12-ocaml-5.2-flambda-arm64, ocurrent/opam-staging:d
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-ppc64le
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
 	RUN apt-get -y update
@@ -6831,6 +7273,7 @@ ocurrent/opam-staging:debian-12-ocaml-5.2-flambda-arm64, ocurrent/opam-staging:d
 
 	FROM ocurrent/opam-staging:debian-12-opam-arm32v7
 	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
 	RUN apt-get -y update
@@ -6848,6 +7291,7 @@ ocurrent/opam-staging:debian-12-ocaml-5.2-flambda-arm64, ocurrent/opam-staging:d
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
 	RUN apt-get -y update
@@ -6865,6 +7309,7 @@ ocurrent/opam-staging:debian-12-ocaml-5.2-flambda-arm64, ocurrent/opam-staging:d
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
 	RUN apt-get -y update
@@ -6883,6 +7328,7 @@ ocurrent/opam-staging:debian-12-ocaml-5.2-flambda-arm64, ocurrent/opam-staging:d
 
 	FROM ocurrent/opam-staging:debian-12-opam-i386
 	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
 	RUN apt-get -y update
@@ -6902,6 +7348,7 @@ ocurrent/opam-staging:debian-12-ocaml-5.2-no-flat-float-array-s390x, ocurrent/op
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-s390x
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
 	RUN apt-get -y update
@@ -6919,6 +7366,7 @@ ocurrent/opam-staging:debian-12-ocaml-5.2-no-flat-float-array-s390x, ocurrent/op
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-ppc64le
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
 	RUN apt-get -y update
@@ -6937,6 +7385,7 @@ ocurrent/opam-staging:debian-12-ocaml-5.2-no-flat-float-array-s390x, ocurrent/op
 
 	FROM ocurrent/opam-staging:debian-12-opam-arm32v7
 	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
 	RUN apt-get -y update
@@ -6954,6 +7403,7 @@ ocurrent/opam-staging:debian-12-ocaml-5.2-no-flat-float-array-s390x, ocurrent/op
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
 	RUN apt-get -y update
@@ -6971,6 +7421,7 @@ ocurrent/opam-staging:debian-12-ocaml-5.2-no-flat-float-array-s390x, ocurrent/op
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
 	RUN apt-get -y update
@@ -6989,6 +7440,7 @@ ocurrent/opam-staging:debian-12-ocaml-5.2-no-flat-float-array-s390x, ocurrent/op
 
 	FROM ocurrent/opam-staging:debian-12-opam-i386
 	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
 	RUN apt-get -y update
@@ -7011,6 +7463,7 @@ ocurrent/opam-staging:debian-12-ocaml-5.3-s390x, ocurrent/opam-staging:debian-12
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
 	RUN apt-get -y update
@@ -7028,6 +7481,7 @@ ocurrent/opam-staging:debian-12-ocaml-5.3-s390x, ocurrent/opam-staging:debian-12
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
 	RUN apt-get -y update
@@ -7047,6 +7501,7 @@ ocurrent/opam-staging:debian-12-ocaml-5.3-afl-arm64, ocurrent/opam-staging:debia
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
 	RUN apt-get -y update
@@ -7064,6 +7519,7 @@ ocurrent/opam-staging:debian-12-ocaml-5.3-afl-arm64, ocurrent/opam-staging:debia
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
 	RUN apt-get -y update
@@ -7083,6 +7539,7 @@ ocurrent/opam-staging:debian-12-ocaml-5.3-flambda-arm64, ocurrent/opam-staging:d
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-s390x
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
 	RUN apt-get -y update
@@ -7100,6 +7557,7 @@ ocurrent/opam-staging:debian-12-ocaml-5.3-flambda-arm64, ocurrent/opam-staging:d
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-ppc64le
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
 	RUN apt-get -y update
@@ -7118,6 +7576,7 @@ ocurrent/opam-staging:debian-12-ocaml-5.3-flambda-arm64, ocurrent/opam-staging:d
 
 	FROM ocurrent/opam-staging:debian-12-opam-arm32v7
 	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
 	RUN apt-get -y update
@@ -7135,6 +7594,7 @@ ocurrent/opam-staging:debian-12-ocaml-5.3-flambda-arm64, ocurrent/opam-staging:d
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
 	RUN apt-get -y update
@@ -7152,6 +7612,7 @@ ocurrent/opam-staging:debian-12-ocaml-5.3-flambda-arm64, ocurrent/opam-staging:d
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
 	RUN apt-get -y update
@@ -7170,6 +7631,7 @@ ocurrent/opam-staging:debian-12-ocaml-5.3-flambda-arm64, ocurrent/opam-staging:d
 
 	FROM ocurrent/opam-staging:debian-12-opam-i386
 	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
 	RUN apt-get -y update
@@ -7189,6 +7651,7 @@ ocurrent/opam-staging:debian-12-ocaml-5.3-no-flat-float-array-s390x, ocurrent/op
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-s390x
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	RUN opam repo add beta git+https://github.com/ocaml/ocaml-beta-repository --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
@@ -7207,6 +7670,7 @@ ocurrent/opam-staging:debian-12-ocaml-5.3-no-flat-float-array-s390x, ocurrent/op
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-ppc64le
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	RUN opam repo add beta git+https://github.com/ocaml/ocaml-beta-repository --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
@@ -7226,6 +7690,7 @@ ocurrent/opam-staging:debian-12-ocaml-5.3-no-flat-float-array-s390x, ocurrent/op
 
 	FROM ocurrent/opam-staging:debian-12-opam-arm32v7
 	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	RUN opam repo add beta git+https://github.com/ocaml/ocaml-beta-repository --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
@@ -7244,6 +7709,7 @@ ocurrent/opam-staging:debian-12-ocaml-5.3-no-flat-float-array-s390x, ocurrent/op
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	RUN opam repo add beta git+https://github.com/ocaml/ocaml-beta-repository --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
@@ -7262,6 +7728,7 @@ ocurrent/opam-staging:debian-12-ocaml-5.3-no-flat-float-array-s390x, ocurrent/op
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	RUN opam repo add beta git+https://github.com/ocaml/ocaml-beta-repository --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
@@ -7281,6 +7748,7 @@ ocurrent/opam-staging:debian-12-ocaml-5.3-no-flat-float-array-s390x, ocurrent/op
 
 	FROM ocurrent/opam-staging:debian-12-opam-i386
 	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	RUN opam repo add beta git+https://github.com/ocaml/ocaml-beta-repository --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
@@ -7301,6 +7769,7 @@ ocurrent/opam-staging:debian-12-ocaml-5.4-s390x, ocurrent/opam-staging:debian-12
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	RUN opam repo add beta git+https://github.com/ocaml/ocaml-beta-repository --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
@@ -7319,6 +7788,7 @@ ocurrent/opam-staging:debian-12-ocaml-5.4-s390x, ocurrent/opam-staging:debian-12
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	RUN opam repo add beta git+https://github.com/ocaml/ocaml-beta-repository --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
@@ -7339,6 +7809,7 @@ ocurrent/opam-staging:debian-12-ocaml-5.4-afl-arm64, ocurrent/opam-staging:debia
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	RUN opam repo add beta git+https://github.com/ocaml/ocaml-beta-repository --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
@@ -7357,6 +7828,7 @@ ocurrent/opam-staging:debian-12-ocaml-5.4-afl-arm64, ocurrent/opam-staging:debia
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	RUN opam repo add beta git+https://github.com/ocaml/ocaml-beta-repository --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
@@ -7377,6 +7849,7 @@ ocurrent/opam-staging:debian-12-ocaml-5.4-flambda-arm64, ocurrent/opam-staging:d
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-s390x
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	RUN opam repo add beta git+https://github.com/ocaml/ocaml-beta-repository --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
@@ -7395,6 +7868,7 @@ ocurrent/opam-staging:debian-12-ocaml-5.4-flambda-arm64, ocurrent/opam-staging:d
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-ppc64le
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	RUN opam repo add beta git+https://github.com/ocaml/ocaml-beta-repository --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
@@ -7414,6 +7888,7 @@ ocurrent/opam-staging:debian-12-ocaml-5.4-flambda-arm64, ocurrent/opam-staging:d
 
 	FROM ocurrent/opam-staging:debian-12-opam-arm32v7
 	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	RUN opam repo add beta git+https://github.com/ocaml/ocaml-beta-repository --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
@@ -7432,6 +7907,7 @@ ocurrent/opam-staging:debian-12-ocaml-5.4-flambda-arm64, ocurrent/opam-staging:d
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	RUN opam repo add beta git+https://github.com/ocaml/ocaml-beta-repository --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
@@ -7450,6 +7926,7 @@ ocurrent/opam-staging:debian-12-ocaml-5.4-flambda-arm64, ocurrent/opam-staging:d
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	RUN opam repo add beta git+https://github.com/ocaml/ocaml-beta-repository --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
@@ -7469,6 +7946,7 @@ ocurrent/opam-staging:debian-12-ocaml-5.4-flambda-arm64, ocurrent/opam-staging:d
 
 	FROM ocurrent/opam-staging:debian-12-opam-i386
 	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	RUN opam repo add beta git+https://github.com/ocaml/ocaml-beta-repository --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
@@ -7827,6 +8305,7 @@ ocurrent/opam-staging:debian-11-opam-arm32v7, ocurrent/opam-staging:debian-11-op
 
 	FROM ocurrent/opam-staging:debian-11-opam-arm32v7
 	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.02 --packages=ocaml-base-compiler.4.02.3
 	RUN opam pin add -k version ocaml-base-compiler 4.02.3
@@ -7840,6 +8319,7 @@ ocurrent/opam-staging:debian-11-opam-arm32v7, ocurrent/opam-staging:debian-11-op
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-11-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.02 --packages=ocaml-base-compiler.4.02.3
 	RUN opam pin add -k version ocaml-base-compiler 4.02.3
@@ -7853,6 +8333,7 @@ ocurrent/opam-staging:debian-11-opam-arm32v7, ocurrent/opam-staging:debian-11-op
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-11-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.02 --packages=ocaml-base-compiler.4.02.3
 	RUN opam pin add -k version ocaml-base-compiler 4.02.3
@@ -7867,6 +8348,7 @@ ocurrent/opam-staging:debian-11-opam-arm32v7, ocurrent/opam-staging:debian-11-op
 
 	FROM ocurrent/opam-staging:debian-11-opam-i386
 	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.02 --packages=ocaml-base-compiler.4.02.3
 	RUN opam pin add -k version ocaml-base-compiler 4.02.3
@@ -7882,6 +8364,7 @@ ocurrent/opam-staging:debian-11-ocaml-4.02-arm32v7, ocurrent/opam-staging:debian
 
 	FROM ocurrent/opam-staging:debian-11-opam-arm32v7
 	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.03 --packages=ocaml-base-compiler.4.03.0
 	RUN opam pin add -k version ocaml-base-compiler 4.03.0
@@ -7895,6 +8378,7 @@ ocurrent/opam-staging:debian-11-ocaml-4.02-arm32v7, ocurrent/opam-staging:debian
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-11-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.03 --packages=ocaml-base-compiler.4.03.0
 	RUN opam pin add -k version ocaml-base-compiler 4.03.0
@@ -7908,6 +8392,7 @@ ocurrent/opam-staging:debian-11-ocaml-4.02-arm32v7, ocurrent/opam-staging:debian
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-11-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.03 --packages=ocaml-base-compiler.4.03.0
 	RUN opam pin add -k version ocaml-base-compiler 4.03.0
@@ -7922,6 +8407,7 @@ ocurrent/opam-staging:debian-11-ocaml-4.02-arm32v7, ocurrent/opam-staging:debian
 
 	FROM ocurrent/opam-staging:debian-11-opam-i386
 	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.03 --packages=ocaml-base-compiler.4.03.0
 	RUN opam pin add -k version ocaml-base-compiler 4.03.0
@@ -7937,6 +8423,7 @@ ocurrent/opam-staging:debian-11-ocaml-4.03-arm32v7, ocurrent/opam-staging:debian
 
 	FROM ocurrent/opam-staging:debian-11-opam-arm32v7
 	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.04 --packages=ocaml-base-compiler.4.04.2
 	RUN opam pin add -k version ocaml-base-compiler 4.04.2
@@ -7950,6 +8437,7 @@ ocurrent/opam-staging:debian-11-ocaml-4.03-arm32v7, ocurrent/opam-staging:debian
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-11-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.04 --packages=ocaml-base-compiler.4.04.2
 	RUN opam pin add -k version ocaml-base-compiler 4.04.2
@@ -7963,6 +8451,7 @@ ocurrent/opam-staging:debian-11-ocaml-4.03-arm32v7, ocurrent/opam-staging:debian
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-11-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.04 --packages=ocaml-base-compiler.4.04.2
 	RUN opam pin add -k version ocaml-base-compiler 4.04.2
@@ -7977,6 +8466,7 @@ ocurrent/opam-staging:debian-11-ocaml-4.03-arm32v7, ocurrent/opam-staging:debian
 
 	FROM ocurrent/opam-staging:debian-11-opam-i386
 	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.04 --packages=ocaml-base-compiler.4.04.2
 	RUN opam pin add -k version ocaml-base-compiler 4.04.2
@@ -7992,6 +8482,7 @@ ocurrent/opam-staging:debian-11-ocaml-4.04-arm32v7, ocurrent/opam-staging:debian
 
 	FROM ocurrent/opam-staging:debian-11-opam-arm32v7
 	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.05 --packages=ocaml-base-compiler.4.05.0
 	RUN opam pin add -k version ocaml-base-compiler 4.05.0
@@ -8005,6 +8496,7 @@ ocurrent/opam-staging:debian-11-ocaml-4.04-arm32v7, ocurrent/opam-staging:debian
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-11-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.05 --packages=ocaml-base-compiler.4.05.0
 	RUN opam pin add -k version ocaml-base-compiler 4.05.0
@@ -8018,6 +8510,7 @@ ocurrent/opam-staging:debian-11-ocaml-4.04-arm32v7, ocurrent/opam-staging:debian
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-11-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.05 --packages=ocaml-base-compiler.4.05.0
 	RUN opam pin add -k version ocaml-base-compiler 4.05.0
@@ -8032,6 +8525,7 @@ ocurrent/opam-staging:debian-11-ocaml-4.04-arm32v7, ocurrent/opam-staging:debian
 
 	FROM ocurrent/opam-staging:debian-11-opam-i386
 	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.05 --packages=ocaml-base-compiler.4.05.0
 	RUN opam pin add -k version ocaml-base-compiler 4.05.0
@@ -8047,6 +8541,7 @@ ocurrent/opam-staging:debian-11-ocaml-4.05-arm32v7, ocurrent/opam-staging:debian
 
 	FROM ocurrent/opam-staging:debian-11-opam-arm32v7
 	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.06 --packages=ocaml-base-compiler.4.06.1
 	RUN opam pin add -k version ocaml-base-compiler 4.06.1
@@ -8060,6 +8555,7 @@ ocurrent/opam-staging:debian-11-ocaml-4.05-arm32v7, ocurrent/opam-staging:debian
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-11-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.06 --packages=ocaml-base-compiler.4.06.1
 	RUN opam pin add -k version ocaml-base-compiler 4.06.1
@@ -8073,6 +8569,7 @@ ocurrent/opam-staging:debian-11-ocaml-4.05-arm32v7, ocurrent/opam-staging:debian
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-11-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.06 --packages=ocaml-base-compiler.4.06.1
 	RUN opam pin add -k version ocaml-base-compiler 4.06.1
@@ -8087,6 +8584,7 @@ ocurrent/opam-staging:debian-11-ocaml-4.05-arm32v7, ocurrent/opam-staging:debian
 
 	FROM ocurrent/opam-staging:debian-11-opam-i386
 	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.06 --packages=ocaml-base-compiler.4.06.1
 	RUN opam pin add -k version ocaml-base-compiler 4.06.1
@@ -8102,6 +8600,7 @@ ocurrent/opam-staging:debian-11-ocaml-4.06-arm32v7, ocurrent/opam-staging:debian
 
 	FROM ocurrent/opam-staging:debian-11-opam-arm32v7
 	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.07 --packages=ocaml-base-compiler.4.07.1
 	RUN opam pin add -k version ocaml-base-compiler 4.07.1
@@ -8115,6 +8614,7 @@ ocurrent/opam-staging:debian-11-ocaml-4.06-arm32v7, ocurrent/opam-staging:debian
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-11-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.07 --packages=ocaml-base-compiler.4.07.1
 	RUN opam pin add -k version ocaml-base-compiler 4.07.1
@@ -8128,6 +8628,7 @@ ocurrent/opam-staging:debian-11-ocaml-4.06-arm32v7, ocurrent/opam-staging:debian
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-11-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.07 --packages=ocaml-base-compiler.4.07.1
 	RUN opam pin add -k version ocaml-base-compiler 4.07.1
@@ -8142,6 +8643,7 @@ ocurrent/opam-staging:debian-11-ocaml-4.06-arm32v7, ocurrent/opam-staging:debian
 
 	FROM ocurrent/opam-staging:debian-11-opam-i386
 	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.07 --packages=ocaml-base-compiler.4.07.1
 	RUN opam pin add -k version ocaml-base-compiler 4.07.1
@@ -8157,6 +8659,7 @@ ocurrent/opam-staging:debian-11-ocaml-4.07-arm32v7, ocurrent/opam-staging:debian
 
 	FROM ocurrent/opam-staging:debian-11-opam-arm32v7
 	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.08 --packages=ocaml-base-compiler.4.08.1
 	RUN opam pin add -k version ocaml-base-compiler 4.08.1
@@ -8169,6 +8672,7 @@ ocurrent/opam-staging:debian-11-ocaml-4.07-arm32v7, ocurrent/opam-staging:debian
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-11-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.08 --packages=ocaml-base-compiler.4.08.1
 	RUN opam pin add -k version ocaml-base-compiler 4.08.1
@@ -8181,6 +8685,7 @@ ocurrent/opam-staging:debian-11-ocaml-4.07-arm32v7, ocurrent/opam-staging:debian
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-11-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.08 --packages=ocaml-base-compiler.4.08.1
 	RUN opam pin add -k version ocaml-base-compiler 4.08.1
@@ -8194,6 +8699,7 @@ ocurrent/opam-staging:debian-11-ocaml-4.07-arm32v7, ocurrent/opam-staging:debian
 
 	FROM ocurrent/opam-staging:debian-11-opam-i386
 	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.08 --packages=ocaml-base-compiler.4.08.1
 	RUN opam pin add -k version ocaml-base-compiler 4.08.1
@@ -8208,6 +8714,7 @@ ocurrent/opam-staging:debian-11-ocaml-4.08-arm32v7, ocurrent/opam-staging:debian
 
 	FROM ocurrent/opam-staging:debian-11-opam-arm32v7
 	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.09 --packages=ocaml-base-compiler.4.09.1
 	RUN opam pin add -k version ocaml-base-compiler 4.09.1
@@ -8220,6 +8727,7 @@ ocurrent/opam-staging:debian-11-ocaml-4.08-arm32v7, ocurrent/opam-staging:debian
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-11-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.09 --packages=ocaml-base-compiler.4.09.1
 	RUN opam pin add -k version ocaml-base-compiler 4.09.1
@@ -8232,6 +8740,7 @@ ocurrent/opam-staging:debian-11-ocaml-4.08-arm32v7, ocurrent/opam-staging:debian
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-11-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.09 --packages=ocaml-base-compiler.4.09.1
 	RUN opam pin add -k version ocaml-base-compiler 4.09.1
@@ -8245,6 +8754,7 @@ ocurrent/opam-staging:debian-11-ocaml-4.08-arm32v7, ocurrent/opam-staging:debian
 
 	FROM ocurrent/opam-staging:debian-11-opam-i386
 	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.09 --packages=ocaml-base-compiler.4.09.1
 	RUN opam pin add -k version ocaml-base-compiler 4.09.1
@@ -8259,6 +8769,7 @@ ocurrent/opam-staging:debian-11-ocaml-4.09-arm32v7, ocurrent/opam-staging:debian
 
 	FROM ocurrent/opam-staging:debian-11-opam-arm32v7
 	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.10 --packages=ocaml-base-compiler.4.10.2
 	RUN opam pin add -k version ocaml-base-compiler 4.10.2
@@ -8271,6 +8782,7 @@ ocurrent/opam-staging:debian-11-ocaml-4.09-arm32v7, ocurrent/opam-staging:debian
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-11-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.10 --packages=ocaml-base-compiler.4.10.2
 	RUN opam pin add -k version ocaml-base-compiler 4.10.2
@@ -8283,6 +8795,7 @@ ocurrent/opam-staging:debian-11-ocaml-4.09-arm32v7, ocurrent/opam-staging:debian
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-11-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.10 --packages=ocaml-base-compiler.4.10.2
 	RUN opam pin add -k version ocaml-base-compiler 4.10.2
@@ -8296,6 +8809,7 @@ ocurrent/opam-staging:debian-11-ocaml-4.09-arm32v7, ocurrent/opam-staging:debian
 
 	FROM ocurrent/opam-staging:debian-11-opam-i386
 	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.10 --packages=ocaml-base-compiler.4.10.2
 	RUN opam pin add -k version ocaml-base-compiler 4.10.2
@@ -8310,6 +8824,7 @@ ocurrent/opam-staging:debian-11-ocaml-4.10-arm32v7, ocurrent/opam-staging:debian
 
 	FROM ocurrent/opam-staging:debian-11-opam-arm32v7
 	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.11 --packages=ocaml-base-compiler.4.11.2
 	RUN opam pin add -k version ocaml-base-compiler 4.11.2
@@ -8322,6 +8837,7 @@ ocurrent/opam-staging:debian-11-ocaml-4.10-arm32v7, ocurrent/opam-staging:debian
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-11-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.11 --packages=ocaml-base-compiler.4.11.2
 	RUN opam pin add -k version ocaml-base-compiler 4.11.2
@@ -8334,6 +8850,7 @@ ocurrent/opam-staging:debian-11-ocaml-4.10-arm32v7, ocurrent/opam-staging:debian
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-11-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.11 --packages=ocaml-base-compiler.4.11.2
 	RUN opam pin add -k version ocaml-base-compiler 4.11.2
@@ -8347,6 +8864,7 @@ ocurrent/opam-staging:debian-11-ocaml-4.10-arm32v7, ocurrent/opam-staging:debian
 
 	FROM ocurrent/opam-staging:debian-11-opam-i386
 	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.11 --packages=ocaml-base-compiler.4.11.2
 	RUN opam pin add -k version ocaml-base-compiler 4.11.2
@@ -8361,6 +8879,7 @@ ocurrent/opam-staging:debian-11-ocaml-4.11-arm32v7, ocurrent/opam-staging:debian
 
 	FROM ocurrent/opam-staging:debian-11-opam-arm32v7
 	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.12 --packages=ocaml-base-compiler.4.12.1
 	RUN opam pin add -k version ocaml-base-compiler 4.12.1
@@ -8373,6 +8892,7 @@ ocurrent/opam-staging:debian-11-ocaml-4.11-arm32v7, ocurrent/opam-staging:debian
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-11-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.12 --packages=ocaml-base-compiler.4.12.1
 	RUN opam pin add -k version ocaml-base-compiler 4.12.1
@@ -8385,6 +8905,7 @@ ocurrent/opam-staging:debian-11-ocaml-4.11-arm32v7, ocurrent/opam-staging:debian
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-11-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.12 --packages=ocaml-base-compiler.4.12.1
 	RUN opam pin add -k version ocaml-base-compiler 4.12.1
@@ -8398,6 +8919,7 @@ ocurrent/opam-staging:debian-11-ocaml-4.11-arm32v7, ocurrent/opam-staging:debian
 
 	FROM ocurrent/opam-staging:debian-11-opam-i386
 	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.12 --packages=ocaml-base-compiler.4.12.1
 	RUN opam pin add -k version ocaml-base-compiler 4.12.1
@@ -8412,6 +8934,7 @@ ocurrent/opam-staging:debian-11-ocaml-4.12-arm32v7, ocurrent/opam-staging:debian
 
 	FROM ocurrent/opam-staging:debian-11-opam-arm32v7
 	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.13 --packages=ocaml-base-compiler.4.13.1
 	RUN opam pin add -k version ocaml-base-compiler 4.13.1
@@ -8424,6 +8947,7 @@ ocurrent/opam-staging:debian-11-ocaml-4.12-arm32v7, ocurrent/opam-staging:debian
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-11-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.13 --packages=ocaml-base-compiler.4.13.1
 	RUN opam pin add -k version ocaml-base-compiler 4.13.1
@@ -8436,6 +8960,7 @@ ocurrent/opam-staging:debian-11-ocaml-4.12-arm32v7, ocurrent/opam-staging:debian
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-11-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.13 --packages=ocaml-base-compiler.4.13.1
 	RUN opam pin add -k version ocaml-base-compiler 4.13.1
@@ -8449,6 +8974,7 @@ ocurrent/opam-staging:debian-11-ocaml-4.12-arm32v7, ocurrent/opam-staging:debian
 
 	FROM ocurrent/opam-staging:debian-11-opam-i386
 	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.13 --packages=ocaml-base-compiler.4.13.1
 	RUN opam pin add -k version ocaml-base-compiler 4.13.1
@@ -8463,6 +8989,7 @@ ocurrent/opam-staging:debian-11-ocaml-4.13-arm32v7, ocurrent/opam-staging:debian
 
 	FROM ocurrent/opam-staging:debian-11-opam-arm32v7
 	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.14 --packages=ocaml-base-compiler.4.14.2
 	RUN opam pin add -k version ocaml-base-compiler 4.14.2
@@ -8475,6 +9002,7 @@ ocurrent/opam-staging:debian-11-ocaml-4.13-arm32v7, ocurrent/opam-staging:debian
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-11-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.14 --packages=ocaml-base-compiler.4.14.2
 	RUN opam pin add -k version ocaml-base-compiler 4.14.2
@@ -8487,6 +9015,7 @@ ocurrent/opam-staging:debian-11-ocaml-4.13-arm32v7, ocurrent/opam-staging:debian
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-11-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.14 --packages=ocaml-base-compiler.4.14.2
 	RUN opam pin add -k version ocaml-base-compiler 4.14.2
@@ -8500,6 +9029,7 @@ ocurrent/opam-staging:debian-11-ocaml-4.13-arm32v7, ocurrent/opam-staging:debian
 
 	FROM ocurrent/opam-staging:debian-11-opam-i386
 	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.14 --packages=ocaml-base-compiler.4.14.2
 	RUN opam pin add -k version ocaml-base-compiler 4.14.2
@@ -8514,6 +9044,7 @@ ocurrent/opam-staging:debian-11-ocaml-4.14-arm32v7, ocurrent/opam-staging:debian
 
 	FROM ocurrent/opam-staging:debian-11-opam-arm32v7
 	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 5.0 --packages=ocaml-base-compiler.5.0.0
 	RUN opam pin add -k version ocaml-base-compiler 5.0.0
@@ -8526,6 +9057,7 @@ ocurrent/opam-staging:debian-11-ocaml-4.14-arm32v7, ocurrent/opam-staging:debian
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-11-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 5.0 --packages=ocaml-base-compiler.5.0.0
 	RUN opam pin add -k version ocaml-base-compiler 5.0.0
@@ -8538,6 +9070,7 @@ ocurrent/opam-staging:debian-11-ocaml-4.14-arm32v7, ocurrent/opam-staging:debian
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-11-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 5.0 --packages=ocaml-base-compiler.5.0.0
 	RUN opam pin add -k version ocaml-base-compiler 5.0.0
@@ -8551,6 +9084,7 @@ ocurrent/opam-staging:debian-11-ocaml-4.14-arm32v7, ocurrent/opam-staging:debian
 
 	FROM ocurrent/opam-staging:debian-11-opam-i386
 	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 5.0 --packages=ocaml-base-compiler.5.0.0
 	RUN opam pin add -k version ocaml-base-compiler 5.0.0
@@ -8565,6 +9099,7 @@ ocurrent/opam-staging:debian-11-ocaml-5.0-arm32v7, ocurrent/opam-staging:debian-
 
 	FROM ocurrent/opam-staging:debian-11-opam-arm32v7
 	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
 	RUN apt-get -y update
@@ -8582,6 +9117,7 @@ ocurrent/opam-staging:debian-11-ocaml-5.0-arm32v7, ocurrent/opam-staging:debian-
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-11-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
 	RUN apt-get -y update
@@ -8599,6 +9135,7 @@ ocurrent/opam-staging:debian-11-ocaml-5.0-arm32v7, ocurrent/opam-staging:debian-
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-11-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
 	RUN apt-get -y update
@@ -8617,6 +9154,7 @@ ocurrent/opam-staging:debian-11-ocaml-5.0-arm32v7, ocurrent/opam-staging:debian-
 
 	FROM ocurrent/opam-staging:debian-11-opam-i386
 	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
 	RUN apt-get -y update
@@ -8636,6 +9174,7 @@ ocurrent/opam-staging:debian-11-ocaml-5.1-arm32v7, ocurrent/opam-staging:debian-
 
 	FROM ocurrent/opam-staging:debian-11-opam-arm32v7
 	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
 	RUN apt-get -y update
@@ -8653,6 +9192,7 @@ ocurrent/opam-staging:debian-11-ocaml-5.1-arm32v7, ocurrent/opam-staging:debian-
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-11-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
 	RUN apt-get -y update
@@ -8670,6 +9210,7 @@ ocurrent/opam-staging:debian-11-ocaml-5.1-arm32v7, ocurrent/opam-staging:debian-
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-11-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
 	RUN apt-get -y update
@@ -8688,6 +9229,7 @@ ocurrent/opam-staging:debian-11-ocaml-5.1-arm32v7, ocurrent/opam-staging:debian-
 
 	FROM ocurrent/opam-staging:debian-11-opam-i386
 	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
 	RUN apt-get -y update
@@ -8707,6 +9249,7 @@ ocurrent/opam-staging:debian-11-ocaml-5.2-arm32v7, ocurrent/opam-staging:debian-
 
 	FROM ocurrent/opam-staging:debian-11-opam-arm32v7
 	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
 	RUN apt-get -y update
@@ -8724,6 +9267,7 @@ ocurrent/opam-staging:debian-11-ocaml-5.2-arm32v7, ocurrent/opam-staging:debian-
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-11-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
 	RUN apt-get -y update
@@ -8741,6 +9285,7 @@ ocurrent/opam-staging:debian-11-ocaml-5.2-arm32v7, ocurrent/opam-staging:debian-
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-11-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
 	RUN apt-get -y update
@@ -8759,6 +9304,7 @@ ocurrent/opam-staging:debian-11-ocaml-5.2-arm32v7, ocurrent/opam-staging:debian-
 
 	FROM ocurrent/opam-staging:debian-11-opam-i386
 	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
 	RUN apt-get -y update
@@ -8779,6 +9325,7 @@ ocurrent/opam-staging:debian-11-ocaml-5.3-arm32v7, ocurrent/opam-staging:debian-
 
 	FROM ocurrent/opam-staging:debian-11-opam-arm32v7
 	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	RUN opam repo add beta git+https://github.com/ocaml/ocaml-beta-repository --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
@@ -8797,6 +9344,7 @@ ocurrent/opam-staging:debian-11-ocaml-5.3-arm32v7, ocurrent/opam-staging:debian-
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-11-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	RUN opam repo add beta git+https://github.com/ocaml/ocaml-beta-repository --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
@@ -8815,6 +9363,7 @@ ocurrent/opam-staging:debian-11-ocaml-5.3-arm32v7, ocurrent/opam-staging:debian-
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-11-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	RUN opam repo add beta git+https://github.com/ocaml/ocaml-beta-repository --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
@@ -8834,6 +9383,7 @@ ocurrent/opam-staging:debian-11-ocaml-5.3-arm32v7, ocurrent/opam-staging:debian-
 
 	FROM ocurrent/opam-staging:debian-11-opam-i386
 	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	RUN opam repo add beta git+https://github.com/ocaml/ocaml-beta-repository --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
@@ -8935,6 +9485,7 @@ ocurrent/opam-staging:debian-testing-opam-amd64 -> ocaml/opam:debian-testing-opa
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-testing-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.02 --packages=ocaml-base-compiler.4.02.3
@@ -8950,6 +9501,7 @@ ocurrent/opam-staging:debian-testing-ocaml-4.02-amd64 -> ocaml/opam:debian-testi
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-testing-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.03 --packages=ocaml-base-compiler.4.03.0
@@ -8965,6 +9517,7 @@ ocurrent/opam-staging:debian-testing-ocaml-4.03-amd64 -> ocaml/opam:debian-testi
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-testing-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.04 --packages=ocaml-base-compiler.4.04.2
@@ -8980,6 +9533,7 @@ ocurrent/opam-staging:debian-testing-ocaml-4.04-amd64 -> ocaml/opam:debian-testi
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-testing-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.05 --packages=ocaml-base-compiler.4.05.0
@@ -8995,6 +9549,7 @@ ocurrent/opam-staging:debian-testing-ocaml-4.05-amd64 -> ocaml/opam:debian-testi
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-testing-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.06 --packages=ocaml-base-compiler.4.06.1
@@ -9010,6 +9565,7 @@ ocurrent/opam-staging:debian-testing-ocaml-4.06-amd64 -> ocaml/opam:debian-testi
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-testing-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.07 --packages=ocaml-base-compiler.4.07.1
@@ -9025,6 +9581,7 @@ ocurrent/opam-staging:debian-testing-ocaml-4.07-amd64 -> ocaml/opam:debian-testi
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-testing-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.08 --packages=ocaml-base-compiler.4.08.1
 	RUN opam pin add -k version ocaml-base-compiler 4.08.1
@@ -9038,6 +9595,7 @@ ocurrent/opam-staging:debian-testing-ocaml-4.08-amd64 -> ocaml/opam:debian-testi
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-testing-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.09 --packages=ocaml-base-compiler.4.09.1
 	RUN opam pin add -k version ocaml-base-compiler 4.09.1
@@ -9051,6 +9609,7 @@ ocurrent/opam-staging:debian-testing-ocaml-4.09-amd64 -> ocaml/opam:debian-testi
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-testing-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.10 --packages=ocaml-base-compiler.4.10.2
 	RUN opam pin add -k version ocaml-base-compiler 4.10.2
@@ -9064,6 +9623,7 @@ ocurrent/opam-staging:debian-testing-ocaml-4.10-amd64 -> ocaml/opam:debian-testi
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-testing-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.11 --packages=ocaml-base-compiler.4.11.2
 	RUN opam pin add -k version ocaml-base-compiler 4.11.2
@@ -9077,6 +9637,7 @@ ocurrent/opam-staging:debian-testing-ocaml-4.11-amd64 -> ocaml/opam:debian-testi
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-testing-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.12 --packages=ocaml-base-compiler.4.12.1
 	RUN opam pin add -k version ocaml-base-compiler 4.12.1
@@ -9090,6 +9651,7 @@ ocurrent/opam-staging:debian-testing-ocaml-4.12-amd64 -> ocaml/opam:debian-testi
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-testing-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.13 --packages=ocaml-base-compiler.4.13.1
 	RUN opam pin add -k version ocaml-base-compiler 4.13.1
@@ -9103,6 +9665,7 @@ ocurrent/opam-staging:debian-testing-ocaml-4.13-amd64 -> ocaml/opam:debian-testi
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-testing-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.14 --packages=ocaml-base-compiler.4.14.2
 	RUN opam pin add -k version ocaml-base-compiler 4.14.2
@@ -9116,6 +9679,7 @@ ocurrent/opam-staging:debian-testing-ocaml-4.14-amd64 -> ocaml/opam:debian-testi
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-testing-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 5.0 --packages=ocaml-base-compiler.5.0.0
 	RUN opam pin add -k version ocaml-base-compiler 5.0.0
@@ -9129,6 +9693,7 @@ ocurrent/opam-staging:debian-testing-ocaml-5.0-amd64 -> ocaml/opam:debian-testin
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-testing-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
 	RUN apt-get -y update
@@ -9147,6 +9712,7 @@ ocurrent/opam-staging:debian-testing-ocaml-5.1-amd64 -> ocaml/opam:debian-testin
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-testing-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
 	RUN apt-get -y update
@@ -9165,6 +9731,7 @@ ocurrent/opam-staging:debian-testing-ocaml-5.2-amd64 -> ocaml/opam:debian-testin
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-testing-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
 	RUN apt-get -y update
@@ -9184,6 +9751,7 @@ ocurrent/opam-staging:debian-testing-ocaml-5.3-amd64 -> ocaml/opam:debian-testin
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-testing-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	RUN opam repo add beta git+https://github.com/ocaml/ocaml-beta-repository --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
@@ -9285,6 +9853,7 @@ ocurrent/opam-staging:debian-unstable-opam-amd64 -> ocaml/opam:debian-unstable-o
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-unstable-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.02 --packages=ocaml-base-compiler.4.02.3
@@ -9300,6 +9869,7 @@ ocurrent/opam-staging:debian-unstable-ocaml-4.02-amd64 -> ocaml/opam:debian-unst
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-unstable-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.03 --packages=ocaml-base-compiler.4.03.0
@@ -9315,6 +9885,7 @@ ocurrent/opam-staging:debian-unstable-ocaml-4.03-amd64 -> ocaml/opam:debian-unst
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-unstable-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.04 --packages=ocaml-base-compiler.4.04.2
@@ -9330,6 +9901,7 @@ ocurrent/opam-staging:debian-unstable-ocaml-4.04-amd64 -> ocaml/opam:debian-unst
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-unstable-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.05 --packages=ocaml-base-compiler.4.05.0
@@ -9345,6 +9917,7 @@ ocurrent/opam-staging:debian-unstable-ocaml-4.05-amd64 -> ocaml/opam:debian-unst
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-unstable-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.06 --packages=ocaml-base-compiler.4.06.1
@@ -9360,6 +9933,7 @@ ocurrent/opam-staging:debian-unstable-ocaml-4.06-amd64 -> ocaml/opam:debian-unst
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-unstable-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.07 --packages=ocaml-base-compiler.4.07.1
@@ -9375,6 +9949,7 @@ ocurrent/opam-staging:debian-unstable-ocaml-4.07-amd64 -> ocaml/opam:debian-unst
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-unstable-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.08 --packages=ocaml-base-compiler.4.08.1
 	RUN opam pin add -k version ocaml-base-compiler 4.08.1
@@ -9388,6 +9963,7 @@ ocurrent/opam-staging:debian-unstable-ocaml-4.08-amd64 -> ocaml/opam:debian-unst
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-unstable-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.09 --packages=ocaml-base-compiler.4.09.1
 	RUN opam pin add -k version ocaml-base-compiler 4.09.1
@@ -9401,6 +9977,7 @@ ocurrent/opam-staging:debian-unstable-ocaml-4.09-amd64 -> ocaml/opam:debian-unst
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-unstable-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.10 --packages=ocaml-base-compiler.4.10.2
 	RUN opam pin add -k version ocaml-base-compiler 4.10.2
@@ -9414,6 +9991,7 @@ ocurrent/opam-staging:debian-unstable-ocaml-4.10-amd64 -> ocaml/opam:debian-unst
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-unstable-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.11 --packages=ocaml-base-compiler.4.11.2
 	RUN opam pin add -k version ocaml-base-compiler 4.11.2
@@ -9427,6 +10005,7 @@ ocurrent/opam-staging:debian-unstable-ocaml-4.11-amd64 -> ocaml/opam:debian-unst
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-unstable-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.12 --packages=ocaml-base-compiler.4.12.1
 	RUN opam pin add -k version ocaml-base-compiler 4.12.1
@@ -9440,6 +10019,7 @@ ocurrent/opam-staging:debian-unstable-ocaml-4.12-amd64 -> ocaml/opam:debian-unst
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-unstable-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.13 --packages=ocaml-base-compiler.4.13.1
 	RUN opam pin add -k version ocaml-base-compiler 4.13.1
@@ -9453,6 +10033,7 @@ ocurrent/opam-staging:debian-unstable-ocaml-4.13-amd64 -> ocaml/opam:debian-unst
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-unstable-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.14 --packages=ocaml-base-compiler.4.14.2
 	RUN opam pin add -k version ocaml-base-compiler 4.14.2
@@ -9466,6 +10047,7 @@ ocurrent/opam-staging:debian-unstable-ocaml-4.14-amd64 -> ocaml/opam:debian-unst
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-unstable-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 5.0 --packages=ocaml-base-compiler.5.0.0
 	RUN opam pin add -k version ocaml-base-compiler 5.0.0
@@ -9479,6 +10061,7 @@ ocurrent/opam-staging:debian-unstable-ocaml-5.0-amd64 -> ocaml/opam:debian-unsta
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-unstable-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
 	RUN apt-get -y update
@@ -9497,6 +10080,7 @@ ocurrent/opam-staging:debian-unstable-ocaml-5.1-amd64 -> ocaml/opam:debian-unsta
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-unstable-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
 	RUN apt-get -y update
@@ -9515,6 +10099,7 @@ ocurrent/opam-staging:debian-unstable-ocaml-5.2-amd64 -> ocaml/opam:debian-unsta
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-unstable-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
 	RUN apt-get -y update
@@ -9534,6 +10119,7 @@ ocurrent/opam-staging:debian-unstable-ocaml-5.3-amd64 -> ocaml/opam:debian-unsta
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-unstable-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	RUN opam repo add beta git+https://github.com/ocaml/ocaml-beta-repository --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
@@ -9711,6 +10297,7 @@ ocurrent/opam-staging:fedora-40-opam-arm64, ocurrent/opam-staging:fedora-40-opam
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:fedora-40-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.02 --packages=ocaml-base-compiler.4.02.3
@@ -9726,6 +10313,7 @@ ocurrent/opam-staging:fedora-40-ocaml-4.02-amd64 -> ocaml/opam:fedora-40-ocaml-4
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:fedora-40-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.03 --packages=ocaml-base-compiler.4.03.0
@@ -9741,6 +10329,7 @@ ocurrent/opam-staging:fedora-40-ocaml-4.03-amd64 -> ocaml/opam:fedora-40-ocaml-4
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:fedora-40-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.04 --packages=ocaml-base-compiler.4.04.2
@@ -9756,6 +10345,7 @@ ocurrent/opam-staging:fedora-40-ocaml-4.04-amd64 -> ocaml/opam:fedora-40-ocaml-4
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:fedora-40-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.05 --packages=ocaml-base-compiler.4.05.0
@@ -9771,6 +10361,7 @@ ocurrent/opam-staging:fedora-40-ocaml-4.05-amd64 -> ocaml/opam:fedora-40-ocaml-4
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:fedora-40-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.06 --packages=ocaml-base-compiler.4.06.1
@@ -9786,6 +10377,7 @@ ocurrent/opam-staging:fedora-40-ocaml-4.06-amd64 -> ocaml/opam:fedora-40-ocaml-4
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:fedora-40-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.07 --packages=ocaml-base-compiler.4.07.1
@@ -9801,6 +10393,7 @@ ocurrent/opam-staging:fedora-40-ocaml-4.07-amd64 -> ocaml/opam:fedora-40-ocaml-4
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:fedora-40-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.08 --packages=ocaml-base-compiler.4.08.1
 	RUN opam pin add -k version ocaml-base-compiler 4.08.1
@@ -9813,6 +10406,7 @@ ocurrent/opam-staging:fedora-40-ocaml-4.07-amd64 -> ocaml/opam:fedora-40-ocaml-4
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:fedora-40-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.08 --packages=ocaml-base-compiler.4.08.1
 	RUN opam pin add -k version ocaml-base-compiler 4.08.1
@@ -9826,6 +10420,7 @@ ocurrent/opam-staging:fedora-40-ocaml-4.08-arm64, ocurrent/opam-staging:fedora-4
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:fedora-40-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.09 --packages=ocaml-base-compiler.4.09.1
 	RUN opam pin add -k version ocaml-base-compiler 4.09.1
@@ -9838,6 +10433,7 @@ ocurrent/opam-staging:fedora-40-ocaml-4.08-arm64, ocurrent/opam-staging:fedora-4
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:fedora-40-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.09 --packages=ocaml-base-compiler.4.09.1
 	RUN opam pin add -k version ocaml-base-compiler 4.09.1
@@ -9851,6 +10447,7 @@ ocurrent/opam-staging:fedora-40-ocaml-4.09-arm64, ocurrent/opam-staging:fedora-4
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:fedora-40-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.10 --packages=ocaml-base-compiler.4.10.2
 	RUN opam pin add -k version ocaml-base-compiler 4.10.2
@@ -9863,6 +10460,7 @@ ocurrent/opam-staging:fedora-40-ocaml-4.09-arm64, ocurrent/opam-staging:fedora-4
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:fedora-40-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.10 --packages=ocaml-base-compiler.4.10.2
 	RUN opam pin add -k version ocaml-base-compiler 4.10.2
@@ -9876,6 +10474,7 @@ ocurrent/opam-staging:fedora-40-ocaml-4.10-arm64, ocurrent/opam-staging:fedora-4
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:fedora-40-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.11 --packages=ocaml-base-compiler.4.11.2
 	RUN opam pin add -k version ocaml-base-compiler 4.11.2
@@ -9888,6 +10487,7 @@ ocurrent/opam-staging:fedora-40-ocaml-4.10-arm64, ocurrent/opam-staging:fedora-4
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:fedora-40-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.11 --packages=ocaml-base-compiler.4.11.2
 	RUN opam pin add -k version ocaml-base-compiler 4.11.2
@@ -9901,6 +10501,7 @@ ocurrent/opam-staging:fedora-40-ocaml-4.11-arm64, ocurrent/opam-staging:fedora-4
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:fedora-40-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.12 --packages=ocaml-base-compiler.4.12.1
 	RUN opam pin add -k version ocaml-base-compiler 4.12.1
@@ -9913,6 +10514,7 @@ ocurrent/opam-staging:fedora-40-ocaml-4.11-arm64, ocurrent/opam-staging:fedora-4
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:fedora-40-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.12 --packages=ocaml-base-compiler.4.12.1
 	RUN opam pin add -k version ocaml-base-compiler 4.12.1
@@ -9926,6 +10528,7 @@ ocurrent/opam-staging:fedora-40-ocaml-4.12-arm64, ocurrent/opam-staging:fedora-4
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:fedora-40-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.13 --packages=ocaml-base-compiler.4.13.1
 	RUN opam pin add -k version ocaml-base-compiler 4.13.1
@@ -9938,6 +10541,7 @@ ocurrent/opam-staging:fedora-40-ocaml-4.12-arm64, ocurrent/opam-staging:fedora-4
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:fedora-40-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.13 --packages=ocaml-base-compiler.4.13.1
 	RUN opam pin add -k version ocaml-base-compiler 4.13.1
@@ -9951,6 +10555,7 @@ ocurrent/opam-staging:fedora-40-ocaml-4.13-arm64, ocurrent/opam-staging:fedora-4
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:fedora-40-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.14 --packages=ocaml-base-compiler.4.14.2
 	RUN opam pin add -k version ocaml-base-compiler 4.14.2
@@ -9963,6 +10568,7 @@ ocurrent/opam-staging:fedora-40-ocaml-4.13-arm64, ocurrent/opam-staging:fedora-4
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:fedora-40-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.14 --packages=ocaml-base-compiler.4.14.2
 	RUN opam pin add -k version ocaml-base-compiler 4.14.2
@@ -9976,6 +10582,7 @@ ocurrent/opam-staging:fedora-40-ocaml-4.14-arm64, ocurrent/opam-staging:fedora-4
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:fedora-40-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 5.0 --packages=ocaml-base-compiler.5.0.0
 	RUN opam pin add -k version ocaml-base-compiler 5.0.0
@@ -9988,6 +10595,7 @@ ocurrent/opam-staging:fedora-40-ocaml-4.14-arm64, ocurrent/opam-staging:fedora-4
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:fedora-40-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 5.0 --packages=ocaml-base-compiler.5.0.0
 	RUN opam pin add -k version ocaml-base-compiler 5.0.0
@@ -10001,6 +10609,7 @@ ocurrent/opam-staging:fedora-40-ocaml-5.0-arm64, ocurrent/opam-staging:fedora-40
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:fedora-40-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
 	RUN yum install -y zstd && yum clean packages
@@ -10016,6 +10625,7 @@ ocurrent/opam-staging:fedora-40-ocaml-5.0-arm64, ocurrent/opam-staging:fedora-40
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:fedora-40-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
 	RUN yum install -y zstd && yum clean packages
@@ -10032,6 +10642,7 @@ ocurrent/opam-staging:fedora-40-ocaml-5.1-arm64, ocurrent/opam-staging:fedora-40
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:fedora-40-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
 	RUN yum install -y zstd && yum clean packages
@@ -10047,6 +10658,7 @@ ocurrent/opam-staging:fedora-40-ocaml-5.1-arm64, ocurrent/opam-staging:fedora-40
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:fedora-40-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
 	RUN yum install -y zstd && yum clean packages
@@ -10063,6 +10675,7 @@ ocurrent/opam-staging:fedora-40-ocaml-5.2-arm64, ocurrent/opam-staging:fedora-40
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:fedora-40-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
 	RUN yum install -y zstd && yum clean packages
@@ -10078,6 +10691,7 @@ ocurrent/opam-staging:fedora-40-ocaml-5.2-arm64, ocurrent/opam-staging:fedora-40
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:fedora-40-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
 	RUN yum install -y zstd && yum clean packages
@@ -10095,6 +10709,7 @@ ocurrent/opam-staging:fedora-40-ocaml-5.3-arm64, ocurrent/opam-staging:fedora-40
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:fedora-40-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	RUN opam repo add beta git+https://github.com/ocaml/ocaml-beta-repository --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
@@ -10111,6 +10726,7 @@ ocurrent/opam-staging:fedora-40-ocaml-5.3-arm64, ocurrent/opam-staging:fedora-40
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:fedora-40-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	RUN opam repo add beta git+https://github.com/ocaml/ocaml-beta-repository --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
@@ -10286,6 +10902,7 @@ ocurrent/opam-staging:fedora-41-opam-arm64, ocurrent/opam-staging:fedora-41-opam
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:fedora-41-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.02 --packages=ocaml-base-compiler.4.02.3
@@ -10302,6 +10919,7 @@ ocurrent/opam-staging:fedora-41-ocaml-4.02-amd64 -> ocaml/opam:fedora-ocaml-4.02
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:fedora-41-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.03 --packages=ocaml-base-compiler.4.03.0
@@ -10318,6 +10936,7 @@ ocurrent/opam-staging:fedora-41-ocaml-4.03-amd64 -> ocaml/opam:fedora-ocaml-4.03
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:fedora-41-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.04 --packages=ocaml-base-compiler.4.04.2
@@ -10334,6 +10953,7 @@ ocurrent/opam-staging:fedora-41-ocaml-4.04-amd64 -> ocaml/opam:fedora-ocaml-4.04
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:fedora-41-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.05 --packages=ocaml-base-compiler.4.05.0
@@ -10350,6 +10970,7 @@ ocurrent/opam-staging:fedora-41-ocaml-4.05-amd64 -> ocaml/opam:fedora-ocaml-4.05
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:fedora-41-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.06 --packages=ocaml-base-compiler.4.06.1
@@ -10366,6 +10987,7 @@ ocurrent/opam-staging:fedora-41-ocaml-4.06-amd64 -> ocaml/opam:fedora-ocaml-4.06
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:fedora-41-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.07 --packages=ocaml-base-compiler.4.07.1
@@ -10382,6 +11004,7 @@ ocurrent/opam-staging:fedora-41-ocaml-4.07-amd64 -> ocaml/opam:fedora-ocaml-4.07
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:fedora-41-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.08 --packages=ocaml-base-compiler.4.08.1
 	RUN opam pin add -k version ocaml-base-compiler 4.08.1
@@ -10394,6 +11017,7 @@ ocurrent/opam-staging:fedora-41-ocaml-4.07-amd64 -> ocaml/opam:fedora-ocaml-4.07
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:fedora-41-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.08 --packages=ocaml-base-compiler.4.08.1
 	RUN opam pin add -k version ocaml-base-compiler 4.08.1
@@ -10408,6 +11032,7 @@ ocurrent/opam-staging:fedora-41-ocaml-4.08-arm64, ocurrent/opam-staging:fedora-4
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:fedora-41-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.09 --packages=ocaml-base-compiler.4.09.1
 	RUN opam pin add -k version ocaml-base-compiler 4.09.1
@@ -10420,6 +11045,7 @@ ocurrent/opam-staging:fedora-41-ocaml-4.08-arm64, ocurrent/opam-staging:fedora-4
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:fedora-41-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.09 --packages=ocaml-base-compiler.4.09.1
 	RUN opam pin add -k version ocaml-base-compiler 4.09.1
@@ -10434,6 +11060,7 @@ ocurrent/opam-staging:fedora-41-ocaml-4.09-arm64, ocurrent/opam-staging:fedora-4
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:fedora-41-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.10 --packages=ocaml-base-compiler.4.10.2
 	RUN opam pin add -k version ocaml-base-compiler 4.10.2
@@ -10446,6 +11073,7 @@ ocurrent/opam-staging:fedora-41-ocaml-4.09-arm64, ocurrent/opam-staging:fedora-4
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:fedora-41-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.10 --packages=ocaml-base-compiler.4.10.2
 	RUN opam pin add -k version ocaml-base-compiler 4.10.2
@@ -10460,6 +11088,7 @@ ocurrent/opam-staging:fedora-41-ocaml-4.10-arm64, ocurrent/opam-staging:fedora-4
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:fedora-41-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.11 --packages=ocaml-base-compiler.4.11.2
 	RUN opam pin add -k version ocaml-base-compiler 4.11.2
@@ -10472,6 +11101,7 @@ ocurrent/opam-staging:fedora-41-ocaml-4.10-arm64, ocurrent/opam-staging:fedora-4
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:fedora-41-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.11 --packages=ocaml-base-compiler.4.11.2
 	RUN opam pin add -k version ocaml-base-compiler 4.11.2
@@ -10486,6 +11116,7 @@ ocurrent/opam-staging:fedora-41-ocaml-4.11-arm64, ocurrent/opam-staging:fedora-4
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:fedora-41-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.12 --packages=ocaml-base-compiler.4.12.1
 	RUN opam pin add -k version ocaml-base-compiler 4.12.1
@@ -10498,6 +11129,7 @@ ocurrent/opam-staging:fedora-41-ocaml-4.11-arm64, ocurrent/opam-staging:fedora-4
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:fedora-41-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.12 --packages=ocaml-base-compiler.4.12.1
 	RUN opam pin add -k version ocaml-base-compiler 4.12.1
@@ -10512,6 +11144,7 @@ ocurrent/opam-staging:fedora-41-ocaml-4.12-arm64, ocurrent/opam-staging:fedora-4
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:fedora-41-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.13 --packages=ocaml-base-compiler.4.13.1
 	RUN opam pin add -k version ocaml-base-compiler 4.13.1
@@ -10524,6 +11157,7 @@ ocurrent/opam-staging:fedora-41-ocaml-4.12-arm64, ocurrent/opam-staging:fedora-4
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:fedora-41-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.13 --packages=ocaml-base-compiler.4.13.1
 	RUN opam pin add -k version ocaml-base-compiler 4.13.1
@@ -10538,6 +11172,7 @@ ocurrent/opam-staging:fedora-41-ocaml-4.13-arm64, ocurrent/opam-staging:fedora-4
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:fedora-41-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.14 --packages=ocaml-base-compiler.4.14.2
 	RUN opam pin add -k version ocaml-base-compiler 4.14.2
@@ -10550,6 +11185,7 @@ ocurrent/opam-staging:fedora-41-ocaml-4.13-arm64, ocurrent/opam-staging:fedora-4
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:fedora-41-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.14 --packages=ocaml-base-compiler.4.14.2
 	RUN opam pin add -k version ocaml-base-compiler 4.14.2
@@ -10564,6 +11200,7 @@ ocurrent/opam-staging:fedora-41-ocaml-4.14-arm64, ocurrent/opam-staging:fedora-4
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:fedora-41-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 5.0 --packages=ocaml-base-compiler.5.0.0
 	RUN opam pin add -k version ocaml-base-compiler 5.0.0
@@ -10576,6 +11213,7 @@ ocurrent/opam-staging:fedora-41-ocaml-4.14-arm64, ocurrent/opam-staging:fedora-4
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:fedora-41-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 5.0 --packages=ocaml-base-compiler.5.0.0
 	RUN opam pin add -k version ocaml-base-compiler 5.0.0
@@ -10590,6 +11228,7 @@ ocurrent/opam-staging:fedora-41-ocaml-5.0-arm64, ocurrent/opam-staging:fedora-41
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:fedora-41-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
 	RUN yum install -y zstd && yum clean packages
@@ -10605,6 +11244,7 @@ ocurrent/opam-staging:fedora-41-ocaml-5.0-arm64, ocurrent/opam-staging:fedora-41
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:fedora-41-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
 	RUN yum install -y zstd && yum clean packages
@@ -10622,6 +11262,7 @@ ocurrent/opam-staging:fedora-41-ocaml-5.1-arm64, ocurrent/opam-staging:fedora-41
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:fedora-41-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
 	RUN yum install -y zstd && yum clean packages
@@ -10637,6 +11278,7 @@ ocurrent/opam-staging:fedora-41-ocaml-5.1-arm64, ocurrent/opam-staging:fedora-41
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:fedora-41-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
 	RUN yum install -y zstd && yum clean packages
@@ -10654,6 +11296,7 @@ ocurrent/opam-staging:fedora-41-ocaml-5.2-arm64, ocurrent/opam-staging:fedora-41
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:fedora-41-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
 	RUN yum install -y zstd && yum clean packages
@@ -10669,6 +11312,7 @@ ocurrent/opam-staging:fedora-41-ocaml-5.2-arm64, ocurrent/opam-staging:fedora-41
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:fedora-41-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
 	RUN yum install -y zstd && yum clean packages
@@ -10688,6 +11332,7 @@ ocurrent/opam-staging:fedora-41-ocaml-5.3-arm64, ocurrent/opam-staging:fedora-41
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:fedora-41-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	RUN opam repo add beta git+https://github.com/ocaml/ocaml-beta-repository --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
@@ -10704,6 +11349,7 @@ ocurrent/opam-staging:fedora-41-ocaml-5.3-arm64, ocurrent/opam-staging:fedora-41
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:fedora-41-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	RUN opam repo add beta git+https://github.com/ocaml/ocaml-beta-repository --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
@@ -10807,6 +11453,7 @@ ocurrent/opam-staging:oraclelinux-8-opam-amd64 -> ocaml/opam:oraclelinux-8-opam
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:oraclelinux-8-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.02 --packages=ocaml-base-compiler.4.02.3
 	RUN opam pin add -k version ocaml-base-compiler 4.02.3
@@ -10821,6 +11468,7 @@ ocurrent/opam-staging:oraclelinux-8-ocaml-4.02-amd64 -> ocaml/opam:oraclelinux-8
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:oraclelinux-8-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.03 --packages=ocaml-base-compiler.4.03.0
 	RUN opam pin add -k version ocaml-base-compiler 4.03.0
@@ -10835,6 +11483,7 @@ ocurrent/opam-staging:oraclelinux-8-ocaml-4.03-amd64 -> ocaml/opam:oraclelinux-8
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:oraclelinux-8-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.04 --packages=ocaml-base-compiler.4.04.2
 	RUN opam pin add -k version ocaml-base-compiler 4.04.2
@@ -10849,6 +11498,7 @@ ocurrent/opam-staging:oraclelinux-8-ocaml-4.04-amd64 -> ocaml/opam:oraclelinux-8
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:oraclelinux-8-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.05 --packages=ocaml-base-compiler.4.05.0
 	RUN opam pin add -k version ocaml-base-compiler 4.05.0
@@ -10863,6 +11513,7 @@ ocurrent/opam-staging:oraclelinux-8-ocaml-4.05-amd64 -> ocaml/opam:oraclelinux-8
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:oraclelinux-8-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.06 --packages=ocaml-base-compiler.4.06.1
 	RUN opam pin add -k version ocaml-base-compiler 4.06.1
@@ -10877,6 +11528,7 @@ ocurrent/opam-staging:oraclelinux-8-ocaml-4.06-amd64 -> ocaml/opam:oraclelinux-8
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:oraclelinux-8-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.07 --packages=ocaml-base-compiler.4.07.1
 	RUN opam pin add -k version ocaml-base-compiler 4.07.1
@@ -10891,6 +11543,7 @@ ocurrent/opam-staging:oraclelinux-8-ocaml-4.07-amd64 -> ocaml/opam:oraclelinux-8
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:oraclelinux-8-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.08 --packages=ocaml-base-compiler.4.08.1
 	RUN opam pin add -k version ocaml-base-compiler 4.08.1
@@ -10904,6 +11557,7 @@ ocurrent/opam-staging:oraclelinux-8-ocaml-4.08-amd64 -> ocaml/opam:oraclelinux-8
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:oraclelinux-8-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.09 --packages=ocaml-base-compiler.4.09.1
 	RUN opam pin add -k version ocaml-base-compiler 4.09.1
@@ -10917,6 +11571,7 @@ ocurrent/opam-staging:oraclelinux-8-ocaml-4.09-amd64 -> ocaml/opam:oraclelinux-8
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:oraclelinux-8-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.10 --packages=ocaml-base-compiler.4.10.2
 	RUN opam pin add -k version ocaml-base-compiler 4.10.2
@@ -10930,6 +11585,7 @@ ocurrent/opam-staging:oraclelinux-8-ocaml-4.10-amd64 -> ocaml/opam:oraclelinux-8
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:oraclelinux-8-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.11 --packages=ocaml-base-compiler.4.11.2
 	RUN opam pin add -k version ocaml-base-compiler 4.11.2
@@ -10943,6 +11599,7 @@ ocurrent/opam-staging:oraclelinux-8-ocaml-4.11-amd64 -> ocaml/opam:oraclelinux-8
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:oraclelinux-8-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.12 --packages=ocaml-base-compiler.4.12.1
 	RUN opam pin add -k version ocaml-base-compiler 4.12.1
@@ -10956,6 +11613,7 @@ ocurrent/opam-staging:oraclelinux-8-ocaml-4.12-amd64 -> ocaml/opam:oraclelinux-8
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:oraclelinux-8-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.13 --packages=ocaml-base-compiler.4.13.1
 	RUN opam pin add -k version ocaml-base-compiler 4.13.1
@@ -10969,6 +11627,7 @@ ocurrent/opam-staging:oraclelinux-8-ocaml-4.13-amd64 -> ocaml/opam:oraclelinux-8
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:oraclelinux-8-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.14 --packages=ocaml-base-compiler.4.14.2
 	RUN opam pin add -k version ocaml-base-compiler 4.14.2
@@ -10982,6 +11641,7 @@ ocurrent/opam-staging:oraclelinux-8-ocaml-4.14-amd64 -> ocaml/opam:oraclelinux-8
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:oraclelinux-8-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 5.0 --packages=ocaml-base-compiler.5.0.0
 	RUN opam pin add -k version ocaml-base-compiler 5.0.0
@@ -10995,6 +11655,7 @@ ocurrent/opam-staging:oraclelinux-8-ocaml-5.0-amd64 -> ocaml/opam:oraclelinux-8-
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:oraclelinux-8-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
 	RUN yum install -y zstd && yum clean packages
@@ -11011,6 +11672,7 @@ ocurrent/opam-staging:oraclelinux-8-ocaml-5.1-amd64 -> ocaml/opam:oraclelinux-8-
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:oraclelinux-8-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
 	RUN yum install -y zstd && yum clean packages
@@ -11027,6 +11689,7 @@ ocurrent/opam-staging:oraclelinux-8-ocaml-5.2-amd64 -> ocaml/opam:oraclelinux-8-
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:oraclelinux-8-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
 	RUN yum install -y zstd && yum clean packages
@@ -11044,6 +11707,7 @@ ocurrent/opam-staging:oraclelinux-8-ocaml-5.3-amd64 -> ocaml/opam:oraclelinux-8-
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:oraclelinux-8-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	RUN opam repo add beta git+https://github.com/ocaml/ocaml-beta-repository --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
@@ -11141,6 +11805,7 @@ ocurrent/opam-staging:oraclelinux-9-opam-amd64 -> ocaml/opam:oraclelinux-9-opam
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:oraclelinux-9-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.02 --packages=ocaml-base-compiler.4.02.3
 	RUN opam pin add -k version ocaml-base-compiler 4.02.3
@@ -11156,6 +11821,7 @@ ocurrent/opam-staging:oraclelinux-9-ocaml-4.02-amd64 -> ocaml/opam:oraclelinux-o
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:oraclelinux-9-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.03 --packages=ocaml-base-compiler.4.03.0
 	RUN opam pin add -k version ocaml-base-compiler 4.03.0
@@ -11171,6 +11837,7 @@ ocurrent/opam-staging:oraclelinux-9-ocaml-4.03-amd64 -> ocaml/opam:oraclelinux-o
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:oraclelinux-9-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.04 --packages=ocaml-base-compiler.4.04.2
 	RUN opam pin add -k version ocaml-base-compiler 4.04.2
@@ -11186,6 +11853,7 @@ ocurrent/opam-staging:oraclelinux-9-ocaml-4.04-amd64 -> ocaml/opam:oraclelinux-o
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:oraclelinux-9-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.05 --packages=ocaml-base-compiler.4.05.0
 	RUN opam pin add -k version ocaml-base-compiler 4.05.0
@@ -11201,6 +11869,7 @@ ocurrent/opam-staging:oraclelinux-9-ocaml-4.05-amd64 -> ocaml/opam:oraclelinux-o
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:oraclelinux-9-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.06 --packages=ocaml-base-compiler.4.06.1
 	RUN opam pin add -k version ocaml-base-compiler 4.06.1
@@ -11216,6 +11885,7 @@ ocurrent/opam-staging:oraclelinux-9-ocaml-4.06-amd64 -> ocaml/opam:oraclelinux-o
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:oraclelinux-9-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.07 --packages=ocaml-base-compiler.4.07.1
 	RUN opam pin add -k version ocaml-base-compiler 4.07.1
@@ -11231,6 +11901,7 @@ ocurrent/opam-staging:oraclelinux-9-ocaml-4.07-amd64 -> ocaml/opam:oraclelinux-o
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:oraclelinux-9-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.08 --packages=ocaml-base-compiler.4.08.1
 	RUN opam pin add -k version ocaml-base-compiler 4.08.1
@@ -11245,6 +11916,7 @@ ocurrent/opam-staging:oraclelinux-9-ocaml-4.08-amd64 -> ocaml/opam:oraclelinux-o
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:oraclelinux-9-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.09 --packages=ocaml-base-compiler.4.09.1
 	RUN opam pin add -k version ocaml-base-compiler 4.09.1
@@ -11259,6 +11931,7 @@ ocurrent/opam-staging:oraclelinux-9-ocaml-4.09-amd64 -> ocaml/opam:oraclelinux-o
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:oraclelinux-9-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.10 --packages=ocaml-base-compiler.4.10.2
 	RUN opam pin add -k version ocaml-base-compiler 4.10.2
@@ -11273,6 +11946,7 @@ ocurrent/opam-staging:oraclelinux-9-ocaml-4.10-amd64 -> ocaml/opam:oraclelinux-o
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:oraclelinux-9-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.11 --packages=ocaml-base-compiler.4.11.2
 	RUN opam pin add -k version ocaml-base-compiler 4.11.2
@@ -11287,6 +11961,7 @@ ocurrent/opam-staging:oraclelinux-9-ocaml-4.11-amd64 -> ocaml/opam:oraclelinux-o
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:oraclelinux-9-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.12 --packages=ocaml-base-compiler.4.12.1
 	RUN opam pin add -k version ocaml-base-compiler 4.12.1
@@ -11301,6 +11976,7 @@ ocurrent/opam-staging:oraclelinux-9-ocaml-4.12-amd64 -> ocaml/opam:oraclelinux-o
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:oraclelinux-9-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.13 --packages=ocaml-base-compiler.4.13.1
 	RUN opam pin add -k version ocaml-base-compiler 4.13.1
@@ -11315,6 +11991,7 @@ ocurrent/opam-staging:oraclelinux-9-ocaml-4.13-amd64 -> ocaml/opam:oraclelinux-o
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:oraclelinux-9-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.14 --packages=ocaml-base-compiler.4.14.2
 	RUN opam pin add -k version ocaml-base-compiler 4.14.2
@@ -11329,6 +12006,7 @@ ocurrent/opam-staging:oraclelinux-9-ocaml-4.14-amd64 -> ocaml/opam:oraclelinux-o
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:oraclelinux-9-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 5.0 --packages=ocaml-base-compiler.5.0.0
 	RUN opam pin add -k version ocaml-base-compiler 5.0.0
@@ -11343,6 +12021,7 @@ ocurrent/opam-staging:oraclelinux-9-ocaml-5.0-amd64 -> ocaml/opam:oraclelinux-oc
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:oraclelinux-9-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
 	RUN yum install -y zstd && yum clean packages
@@ -11360,6 +12039,7 @@ ocurrent/opam-staging:oraclelinux-9-ocaml-5.1-amd64 -> ocaml/opam:oraclelinux-oc
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:oraclelinux-9-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
 	RUN yum install -y zstd && yum clean packages
@@ -11377,6 +12057,7 @@ ocurrent/opam-staging:oraclelinux-9-ocaml-5.2-amd64 -> ocaml/opam:oraclelinux-oc
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:oraclelinux-9-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
 	RUN yum install -y zstd && yum clean packages
@@ -11396,6 +12077,7 @@ ocurrent/opam-staging:oraclelinux-9-ocaml-5.3-amd64 -> ocaml/opam:oraclelinux-oc
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:oraclelinux-9-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	RUN opam repo add beta git+https://github.com/ocaml/ocaml-beta-repository --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
@@ -11570,6 +12252,7 @@ ocurrent/opam-staging:opensuse-15.6-opam-arm64, ocurrent/opam-staging:opensuse-1
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:opensuse-15.6-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.02 --packages=ocaml-base-compiler.4.02.3
 	RUN opam pin add -k version ocaml-base-compiler 4.02.3
@@ -11583,6 +12266,7 @@ ocurrent/opam-staging:opensuse-15.6-opam-arm64, ocurrent/opam-staging:opensuse-1
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:opensuse-15.6-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.02 --packages=ocaml-base-compiler.4.02.3
 	RUN opam pin add -k version ocaml-base-compiler 4.02.3
@@ -11598,6 +12282,7 @@ ocurrent/opam-staging:opensuse-15.6-ocaml-4.02-arm64, ocurrent/opam-staging:open
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:opensuse-15.6-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.03 --packages=ocaml-base-compiler.4.03.0
 	RUN opam pin add -k version ocaml-base-compiler 4.03.0
@@ -11611,6 +12296,7 @@ ocurrent/opam-staging:opensuse-15.6-ocaml-4.02-arm64, ocurrent/opam-staging:open
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:opensuse-15.6-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.03 --packages=ocaml-base-compiler.4.03.0
 	RUN opam pin add -k version ocaml-base-compiler 4.03.0
@@ -11626,6 +12312,7 @@ ocurrent/opam-staging:opensuse-15.6-ocaml-4.03-arm64, ocurrent/opam-staging:open
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:opensuse-15.6-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.04 --packages=ocaml-base-compiler.4.04.2
 	RUN opam pin add -k version ocaml-base-compiler 4.04.2
@@ -11639,6 +12326,7 @@ ocurrent/opam-staging:opensuse-15.6-ocaml-4.03-arm64, ocurrent/opam-staging:open
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:opensuse-15.6-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.04 --packages=ocaml-base-compiler.4.04.2
 	RUN opam pin add -k version ocaml-base-compiler 4.04.2
@@ -11654,6 +12342,7 @@ ocurrent/opam-staging:opensuse-15.6-ocaml-4.04-arm64, ocurrent/opam-staging:open
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:opensuse-15.6-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.05 --packages=ocaml-base-compiler.4.05.0
 	RUN opam pin add -k version ocaml-base-compiler 4.05.0
@@ -11667,6 +12356,7 @@ ocurrent/opam-staging:opensuse-15.6-ocaml-4.04-arm64, ocurrent/opam-staging:open
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:opensuse-15.6-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.05 --packages=ocaml-base-compiler.4.05.0
 	RUN opam pin add -k version ocaml-base-compiler 4.05.0
@@ -11682,6 +12372,7 @@ ocurrent/opam-staging:opensuse-15.6-ocaml-4.05-arm64, ocurrent/opam-staging:open
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:opensuse-15.6-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.06 --packages=ocaml-base-compiler.4.06.1
 	RUN opam pin add -k version ocaml-base-compiler 4.06.1
@@ -11695,6 +12386,7 @@ ocurrent/opam-staging:opensuse-15.6-ocaml-4.05-arm64, ocurrent/opam-staging:open
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:opensuse-15.6-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.06 --packages=ocaml-base-compiler.4.06.1
 	RUN opam pin add -k version ocaml-base-compiler 4.06.1
@@ -11710,6 +12402,7 @@ ocurrent/opam-staging:opensuse-15.6-ocaml-4.06-arm64, ocurrent/opam-staging:open
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:opensuse-15.6-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.07 --packages=ocaml-base-compiler.4.07.1
 	RUN opam pin add -k version ocaml-base-compiler 4.07.1
@@ -11723,6 +12416,7 @@ ocurrent/opam-staging:opensuse-15.6-ocaml-4.06-arm64, ocurrent/opam-staging:open
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:opensuse-15.6-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.07 --packages=ocaml-base-compiler.4.07.1
 	RUN opam pin add -k version ocaml-base-compiler 4.07.1
@@ -11738,6 +12432,7 @@ ocurrent/opam-staging:opensuse-15.6-ocaml-4.07-arm64, ocurrent/opam-staging:open
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:opensuse-15.6-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.08 --packages=ocaml-base-compiler.4.08.1
 	RUN opam pin add -k version ocaml-base-compiler 4.08.1
@@ -11750,6 +12445,7 @@ ocurrent/opam-staging:opensuse-15.6-ocaml-4.07-arm64, ocurrent/opam-staging:open
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:opensuse-15.6-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.08 --packages=ocaml-base-compiler.4.08.1
 	RUN opam pin add -k version ocaml-base-compiler 4.08.1
@@ -11764,6 +12460,7 @@ ocurrent/opam-staging:opensuse-15.6-ocaml-4.08-arm64, ocurrent/opam-staging:open
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:opensuse-15.6-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.09 --packages=ocaml-base-compiler.4.09.1
 	RUN opam pin add -k version ocaml-base-compiler 4.09.1
@@ -11776,6 +12473,7 @@ ocurrent/opam-staging:opensuse-15.6-ocaml-4.08-arm64, ocurrent/opam-staging:open
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:opensuse-15.6-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.09 --packages=ocaml-base-compiler.4.09.1
 	RUN opam pin add -k version ocaml-base-compiler 4.09.1
@@ -11790,6 +12488,7 @@ ocurrent/opam-staging:opensuse-15.6-ocaml-4.09-arm64, ocurrent/opam-staging:open
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:opensuse-15.6-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.10 --packages=ocaml-base-compiler.4.10.2
 	RUN opam pin add -k version ocaml-base-compiler 4.10.2
@@ -11802,6 +12501,7 @@ ocurrent/opam-staging:opensuse-15.6-ocaml-4.09-arm64, ocurrent/opam-staging:open
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:opensuse-15.6-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.10 --packages=ocaml-base-compiler.4.10.2
 	RUN opam pin add -k version ocaml-base-compiler 4.10.2
@@ -11816,6 +12516,7 @@ ocurrent/opam-staging:opensuse-15.6-ocaml-4.10-arm64, ocurrent/opam-staging:open
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:opensuse-15.6-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.11 --packages=ocaml-base-compiler.4.11.2
 	RUN opam pin add -k version ocaml-base-compiler 4.11.2
@@ -11828,6 +12529,7 @@ ocurrent/opam-staging:opensuse-15.6-ocaml-4.10-arm64, ocurrent/opam-staging:open
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:opensuse-15.6-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.11 --packages=ocaml-base-compiler.4.11.2
 	RUN opam pin add -k version ocaml-base-compiler 4.11.2
@@ -11842,6 +12544,7 @@ ocurrent/opam-staging:opensuse-15.6-ocaml-4.11-arm64, ocurrent/opam-staging:open
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:opensuse-15.6-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.12 --packages=ocaml-base-compiler.4.12.1
 	RUN opam pin add -k version ocaml-base-compiler 4.12.1
@@ -11854,6 +12557,7 @@ ocurrent/opam-staging:opensuse-15.6-ocaml-4.11-arm64, ocurrent/opam-staging:open
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:opensuse-15.6-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.12 --packages=ocaml-base-compiler.4.12.1
 	RUN opam pin add -k version ocaml-base-compiler 4.12.1
@@ -11868,6 +12572,7 @@ ocurrent/opam-staging:opensuse-15.6-ocaml-4.12-arm64, ocurrent/opam-staging:open
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:opensuse-15.6-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.13 --packages=ocaml-base-compiler.4.13.1
 	RUN opam pin add -k version ocaml-base-compiler 4.13.1
@@ -11880,6 +12585,7 @@ ocurrent/opam-staging:opensuse-15.6-ocaml-4.12-arm64, ocurrent/opam-staging:open
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:opensuse-15.6-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.13 --packages=ocaml-base-compiler.4.13.1
 	RUN opam pin add -k version ocaml-base-compiler 4.13.1
@@ -11894,6 +12600,7 @@ ocurrent/opam-staging:opensuse-15.6-ocaml-4.13-arm64, ocurrent/opam-staging:open
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:opensuse-15.6-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.14 --packages=ocaml-base-compiler.4.14.2
 	RUN opam pin add -k version ocaml-base-compiler 4.14.2
@@ -11906,6 +12613,7 @@ ocurrent/opam-staging:opensuse-15.6-ocaml-4.13-arm64, ocurrent/opam-staging:open
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:opensuse-15.6-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.14 --packages=ocaml-base-compiler.4.14.2
 	RUN opam pin add -k version ocaml-base-compiler 4.14.2
@@ -11920,6 +12628,7 @@ ocurrent/opam-staging:opensuse-15.6-ocaml-4.14-arm64, ocurrent/opam-staging:open
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:opensuse-15.6-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 5.0 --packages=ocaml-base-compiler.5.0.0
 	RUN opam pin add -k version ocaml-base-compiler 5.0.0
@@ -11932,6 +12641,7 @@ ocurrent/opam-staging:opensuse-15.6-ocaml-4.14-arm64, ocurrent/opam-staging:open
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:opensuse-15.6-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 5.0 --packages=ocaml-base-compiler.5.0.0
 	RUN opam pin add -k version ocaml-base-compiler 5.0.0
@@ -11946,6 +12656,7 @@ ocurrent/opam-staging:opensuse-15.6-ocaml-5.0-arm64, ocurrent/opam-staging:opens
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:opensuse-15.6-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
 	RUN zypper repos repo-openh264 && zypper removerepo repo-openh264 || true
@@ -11963,6 +12674,7 @@ ocurrent/opam-staging:opensuse-15.6-ocaml-5.0-arm64, ocurrent/opam-staging:opens
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:opensuse-15.6-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
 	RUN zypper repos repo-openh264 && zypper removerepo repo-openh264 || true
@@ -11982,6 +12694,7 @@ ocurrent/opam-staging:opensuse-15.6-ocaml-5.1-arm64, ocurrent/opam-staging:opens
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:opensuse-15.6-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
 	RUN zypper repos repo-openh264 && zypper removerepo repo-openh264 || true
@@ -11999,6 +12712,7 @@ ocurrent/opam-staging:opensuse-15.6-ocaml-5.1-arm64, ocurrent/opam-staging:opens
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:opensuse-15.6-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
 	RUN zypper repos repo-openh264 && zypper removerepo repo-openh264 || true
@@ -12018,6 +12732,7 @@ ocurrent/opam-staging:opensuse-15.6-ocaml-5.2-arm64, ocurrent/opam-staging:opens
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:opensuse-15.6-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
 	RUN zypper repos repo-openh264 && zypper removerepo repo-openh264 || true
@@ -12035,6 +12750,7 @@ ocurrent/opam-staging:opensuse-15.6-ocaml-5.2-arm64, ocurrent/opam-staging:opens
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:opensuse-15.6-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
 	RUN zypper repos repo-openh264 && zypper removerepo repo-openh264 || true
@@ -12056,6 +12772,7 @@ ocurrent/opam-staging:opensuse-15.6-ocaml-5.3-arm64, ocurrent/opam-staging:opens
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:opensuse-15.6-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	RUN opam repo add beta git+https://github.com/ocaml/ocaml-beta-repository --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
@@ -12074,6 +12791,7 @@ ocurrent/opam-staging:opensuse-15.6-ocaml-5.3-arm64, ocurrent/opam-staging:opens
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:opensuse-15.6-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	RUN opam repo add beta git+https://github.com/ocaml/ocaml-beta-repository --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
@@ -12173,6 +12891,7 @@ ocurrent/opam-staging:opensuse-tumbleweed-opam-amd64 -> ocaml/opam:opensuse-tumb
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:opensuse-tumbleweed-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.02 --packages=ocaml-base-compiler.4.02.3
@@ -12188,6 +12907,7 @@ ocurrent/opam-staging:opensuse-tumbleweed-ocaml-4.02-amd64 -> ocaml/opam:opensus
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:opensuse-tumbleweed-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.03 --packages=ocaml-base-compiler.4.03.0
@@ -12203,6 +12923,7 @@ ocurrent/opam-staging:opensuse-tumbleweed-ocaml-4.03-amd64 -> ocaml/opam:opensus
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:opensuse-tumbleweed-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.04 --packages=ocaml-base-compiler.4.04.2
@@ -12218,6 +12939,7 @@ ocurrent/opam-staging:opensuse-tumbleweed-ocaml-4.04-amd64 -> ocaml/opam:opensus
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:opensuse-tumbleweed-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.05 --packages=ocaml-base-compiler.4.05.0
@@ -12233,6 +12955,7 @@ ocurrent/opam-staging:opensuse-tumbleweed-ocaml-4.05-amd64 -> ocaml/opam:opensus
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:opensuse-tumbleweed-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.06 --packages=ocaml-base-compiler.4.06.1
@@ -12248,6 +12971,7 @@ ocurrent/opam-staging:opensuse-tumbleweed-ocaml-4.06-amd64 -> ocaml/opam:opensus
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:opensuse-tumbleweed-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.07 --packages=ocaml-base-compiler.4.07.1
@@ -12263,6 +12987,7 @@ ocurrent/opam-staging:opensuse-tumbleweed-ocaml-4.07-amd64 -> ocaml/opam:opensus
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:opensuse-tumbleweed-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.08 --packages=ocaml-base-compiler.4.08.1
 	RUN opam pin add -k version ocaml-base-compiler 4.08.1
@@ -12276,6 +13001,7 @@ ocurrent/opam-staging:opensuse-tumbleweed-ocaml-4.08-amd64 -> ocaml/opam:opensus
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:opensuse-tumbleweed-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.09 --packages=ocaml-base-compiler.4.09.1
 	RUN opam pin add -k version ocaml-base-compiler 4.09.1
@@ -12289,6 +13015,7 @@ ocurrent/opam-staging:opensuse-tumbleweed-ocaml-4.09-amd64 -> ocaml/opam:opensus
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:opensuse-tumbleweed-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.10 --packages=ocaml-base-compiler.4.10.2
 	RUN opam pin add -k version ocaml-base-compiler 4.10.2
@@ -12302,6 +13029,7 @@ ocurrent/opam-staging:opensuse-tumbleweed-ocaml-4.10-amd64 -> ocaml/opam:opensus
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:opensuse-tumbleweed-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.11 --packages=ocaml-base-compiler.4.11.2
 	RUN opam pin add -k version ocaml-base-compiler 4.11.2
@@ -12315,6 +13043,7 @@ ocurrent/opam-staging:opensuse-tumbleweed-ocaml-4.11-amd64 -> ocaml/opam:opensus
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:opensuse-tumbleweed-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.12 --packages=ocaml-base-compiler.4.12.1
 	RUN opam pin add -k version ocaml-base-compiler 4.12.1
@@ -12328,6 +13057,7 @@ ocurrent/opam-staging:opensuse-tumbleweed-ocaml-4.12-amd64 -> ocaml/opam:opensus
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:opensuse-tumbleweed-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.13 --packages=ocaml-base-compiler.4.13.1
 	RUN opam pin add -k version ocaml-base-compiler 4.13.1
@@ -12341,6 +13071,7 @@ ocurrent/opam-staging:opensuse-tumbleweed-ocaml-4.13-amd64 -> ocaml/opam:opensus
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:opensuse-tumbleweed-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.14 --packages=ocaml-base-compiler.4.14.2
 	RUN opam pin add -k version ocaml-base-compiler 4.14.2
@@ -12354,6 +13085,7 @@ ocurrent/opam-staging:opensuse-tumbleweed-ocaml-4.14-amd64 -> ocaml/opam:opensus
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:opensuse-tumbleweed-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 5.0 --packages=ocaml-base-compiler.5.0.0
 	RUN opam pin add -k version ocaml-base-compiler 5.0.0
@@ -12367,6 +13099,7 @@ ocurrent/opam-staging:opensuse-tumbleweed-ocaml-5.0-amd64 -> ocaml/opam:opensuse
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:opensuse-tumbleweed-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
 	RUN zypper repos repo-openh264 && zypper removerepo repo-openh264 || true
@@ -12385,6 +13118,7 @@ ocurrent/opam-staging:opensuse-tumbleweed-ocaml-5.1-amd64 -> ocaml/opam:opensuse
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:opensuse-tumbleweed-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
 	RUN zypper repos repo-openh264 && zypper removerepo repo-openh264 || true
@@ -12403,6 +13137,7 @@ ocurrent/opam-staging:opensuse-tumbleweed-ocaml-5.2-amd64 -> ocaml/opam:opensuse
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:opensuse-tumbleweed-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
 	RUN zypper repos repo-openh264 && zypper removerepo repo-openh264 || true
@@ -12422,6 +13157,7 @@ ocurrent/opam-staging:opensuse-tumbleweed-ocaml-5.3-amd64 -> ocaml/opam:opensuse
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:opensuse-tumbleweed-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	RUN opam repo add beta git+https://github.com/ocaml/ocaml-beta-repository --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
@@ -12868,6 +13604,7 @@ ocurrent/opam-staging:ubuntu-20.04-opam-s390x, ocurrent/opam-staging:ubuntu-20.0
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-20.04-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.02 --packages=ocaml-base-compiler.4.02.3
 	RUN opam pin add -k version ocaml-base-compiler 4.02.3
@@ -12882,6 +13619,7 @@ ocurrent/opam-staging:ubuntu-20.04-ocaml-4.02-amd64 -> ocaml/opam:ubuntu-20.04-o
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-20.04-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.03 --packages=ocaml-base-compiler.4.03.0
 	RUN opam pin add -k version ocaml-base-compiler 4.03.0
@@ -12896,6 +13634,7 @@ ocurrent/opam-staging:ubuntu-20.04-ocaml-4.03-amd64 -> ocaml/opam:ubuntu-20.04-o
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-20.04-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.04 --packages=ocaml-base-compiler.4.04.2
 	RUN opam pin add -k version ocaml-base-compiler 4.04.2
@@ -12910,6 +13649,7 @@ ocurrent/opam-staging:ubuntu-20.04-ocaml-4.04-amd64 -> ocaml/opam:ubuntu-20.04-o
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-20.04-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.05 --packages=ocaml-base-compiler.4.05.0
 	RUN opam pin add -k version ocaml-base-compiler 4.05.0
@@ -12924,6 +13664,7 @@ ocurrent/opam-staging:ubuntu-20.04-ocaml-4.05-amd64 -> ocaml/opam:ubuntu-20.04-o
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-20.04-opam-s390x
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.06 --packages=ocaml-base-compiler.4.06.1
 	RUN opam pin add -k version ocaml-base-compiler 4.06.1
@@ -12937,6 +13678,7 @@ ocurrent/opam-staging:ubuntu-20.04-ocaml-4.05-amd64 -> ocaml/opam:ubuntu-20.04-o
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-20.04-opam-ppc64le
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.06 --packages=ocaml-base-compiler.4.06.1
 	RUN opam pin add -k version ocaml-base-compiler 4.06.1
@@ -12950,6 +13692,7 @@ ocurrent/opam-staging:ubuntu-20.04-ocaml-4.05-amd64 -> ocaml/opam:ubuntu-20.04-o
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-20.04-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.06 --packages=ocaml-base-compiler.4.06.1
 	RUN opam pin add -k version ocaml-base-compiler 4.06.1
@@ -12963,6 +13706,7 @@ ocurrent/opam-staging:ubuntu-20.04-ocaml-4.05-amd64 -> ocaml/opam:ubuntu-20.04-o
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-20.04-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.06 --packages=ocaml-base-compiler.4.06.1
 	RUN opam pin add -k version ocaml-base-compiler 4.06.1
@@ -12977,6 +13721,7 @@ ocurrent/opam-staging:ubuntu-20.04-ocaml-4.06-s390x, ocurrent/opam-staging:ubunt
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-20.04-opam-s390x
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.07 --packages=ocaml-base-compiler.4.07.1
 	RUN opam pin add -k version ocaml-base-compiler 4.07.1
@@ -12990,6 +13735,7 @@ ocurrent/opam-staging:ubuntu-20.04-ocaml-4.06-s390x, ocurrent/opam-staging:ubunt
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-20.04-opam-ppc64le
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.07 --packages=ocaml-base-compiler.4.07.1
 	RUN opam pin add -k version ocaml-base-compiler 4.07.1
@@ -13003,6 +13749,7 @@ ocurrent/opam-staging:ubuntu-20.04-ocaml-4.06-s390x, ocurrent/opam-staging:ubunt
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-20.04-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.07 --packages=ocaml-base-compiler.4.07.1
 	RUN opam pin add -k version ocaml-base-compiler 4.07.1
@@ -13016,6 +13763,7 @@ ocurrent/opam-staging:ubuntu-20.04-ocaml-4.06-s390x, ocurrent/opam-staging:ubunt
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-20.04-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.07 --packages=ocaml-base-compiler.4.07.1
 	RUN opam pin add -k version ocaml-base-compiler 4.07.1
@@ -13030,6 +13778,7 @@ ocurrent/opam-staging:ubuntu-20.04-ocaml-4.07-s390x, ocurrent/opam-staging:ubunt
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-20.04-opam-s390x
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.08 --packages=ocaml-base-compiler.4.08.1
 	RUN opam pin add -k version ocaml-base-compiler 4.08.1
@@ -13042,6 +13791,7 @@ ocurrent/opam-staging:ubuntu-20.04-ocaml-4.07-s390x, ocurrent/opam-staging:ubunt
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-20.04-opam-ppc64le
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.08 --packages=ocaml-base-compiler.4.08.1
 	RUN opam pin add -k version ocaml-base-compiler 4.08.1
@@ -13054,6 +13804,7 @@ ocurrent/opam-staging:ubuntu-20.04-ocaml-4.07-s390x, ocurrent/opam-staging:ubunt
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-20.04-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.08 --packages=ocaml-base-compiler.4.08.1
 	RUN opam pin add -k version ocaml-base-compiler 4.08.1
@@ -13066,6 +13817,7 @@ ocurrent/opam-staging:ubuntu-20.04-ocaml-4.07-s390x, ocurrent/opam-staging:ubunt
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-20.04-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.08 --packages=ocaml-base-compiler.4.08.1
 	RUN opam pin add -k version ocaml-base-compiler 4.08.1
@@ -13079,6 +13831,7 @@ ocurrent/opam-staging:ubuntu-20.04-ocaml-4.08-s390x, ocurrent/opam-staging:ubunt
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-20.04-opam-s390x
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.09 --packages=ocaml-base-compiler.4.09.1
 	RUN opam pin add -k version ocaml-base-compiler 4.09.1
@@ -13091,6 +13844,7 @@ ocurrent/opam-staging:ubuntu-20.04-ocaml-4.08-s390x, ocurrent/opam-staging:ubunt
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-20.04-opam-ppc64le
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.09 --packages=ocaml-base-compiler.4.09.1
 	RUN opam pin add -k version ocaml-base-compiler 4.09.1
@@ -13103,6 +13857,7 @@ ocurrent/opam-staging:ubuntu-20.04-ocaml-4.08-s390x, ocurrent/opam-staging:ubunt
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-20.04-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.09 --packages=ocaml-base-compiler.4.09.1
 	RUN opam pin add -k version ocaml-base-compiler 4.09.1
@@ -13115,6 +13870,7 @@ ocurrent/opam-staging:ubuntu-20.04-ocaml-4.08-s390x, ocurrent/opam-staging:ubunt
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-20.04-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.09 --packages=ocaml-base-compiler.4.09.1
 	RUN opam pin add -k version ocaml-base-compiler 4.09.1
@@ -13128,6 +13884,7 @@ ocurrent/opam-staging:ubuntu-20.04-ocaml-4.09-s390x, ocurrent/opam-staging:ubunt
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-20.04-opam-s390x
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.10 --packages=ocaml-base-compiler.4.10.2
 	RUN opam pin add -k version ocaml-base-compiler 4.10.2
@@ -13140,6 +13897,7 @@ ocurrent/opam-staging:ubuntu-20.04-ocaml-4.09-s390x, ocurrent/opam-staging:ubunt
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-20.04-opam-ppc64le
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.10 --packages=ocaml-base-compiler.4.10.2
 	RUN opam pin add -k version ocaml-base-compiler 4.10.2
@@ -13152,6 +13910,7 @@ ocurrent/opam-staging:ubuntu-20.04-ocaml-4.09-s390x, ocurrent/opam-staging:ubunt
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-20.04-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.10 --packages=ocaml-base-compiler.4.10.2
 	RUN opam pin add -k version ocaml-base-compiler 4.10.2
@@ -13164,6 +13923,7 @@ ocurrent/opam-staging:ubuntu-20.04-ocaml-4.09-s390x, ocurrent/opam-staging:ubunt
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-20.04-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.10 --packages=ocaml-base-compiler.4.10.2
 	RUN opam pin add -k version ocaml-base-compiler 4.10.2
@@ -13177,6 +13937,7 @@ ocurrent/opam-staging:ubuntu-20.04-ocaml-4.10-s390x, ocurrent/opam-staging:ubunt
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-20.04-opam-s390x
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.11 --packages=ocaml-base-compiler.4.11.2
 	RUN opam pin add -k version ocaml-base-compiler 4.11.2
@@ -13189,6 +13950,7 @@ ocurrent/opam-staging:ubuntu-20.04-ocaml-4.10-s390x, ocurrent/opam-staging:ubunt
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-20.04-opam-ppc64le
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.11 --packages=ocaml-base-compiler.4.11.2
 	RUN opam pin add -k version ocaml-base-compiler 4.11.2
@@ -13201,6 +13963,7 @@ ocurrent/opam-staging:ubuntu-20.04-ocaml-4.10-s390x, ocurrent/opam-staging:ubunt
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-20.04-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.11 --packages=ocaml-base-compiler.4.11.2
 	RUN opam pin add -k version ocaml-base-compiler 4.11.2
@@ -13213,6 +13976,7 @@ ocurrent/opam-staging:ubuntu-20.04-ocaml-4.10-s390x, ocurrent/opam-staging:ubunt
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-20.04-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.11 --packages=ocaml-base-compiler.4.11.2
 	RUN opam pin add -k version ocaml-base-compiler 4.11.2
@@ -13225,6 +13989,7 @@ ocurrent/opam-staging:ubuntu-20.04-ocaml-4.10-s390x, ocurrent/opam-staging:ubunt
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-20.04-opam-riscv64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.11 --packages=ocaml-base-compiler.4.11.2
 	RUN opam pin add -k version ocaml-base-compiler 4.11.2
@@ -13238,6 +14003,7 @@ ocurrent/opam-staging:ubuntu-20.04-ocaml-4.11-s390x, ocurrent/opam-staging:ubunt
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-20.04-opam-s390x
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.12 --packages=ocaml-base-compiler.4.12.1
 	RUN opam pin add -k version ocaml-base-compiler 4.12.1
@@ -13250,6 +14016,7 @@ ocurrent/opam-staging:ubuntu-20.04-ocaml-4.11-s390x, ocurrent/opam-staging:ubunt
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-20.04-opam-ppc64le
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.12 --packages=ocaml-base-compiler.4.12.1
 	RUN opam pin add -k version ocaml-base-compiler 4.12.1
@@ -13262,6 +14029,7 @@ ocurrent/opam-staging:ubuntu-20.04-ocaml-4.11-s390x, ocurrent/opam-staging:ubunt
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-20.04-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.12 --packages=ocaml-base-compiler.4.12.1
 	RUN opam pin add -k version ocaml-base-compiler 4.12.1
@@ -13274,6 +14042,7 @@ ocurrent/opam-staging:ubuntu-20.04-ocaml-4.11-s390x, ocurrent/opam-staging:ubunt
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-20.04-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.12 --packages=ocaml-base-compiler.4.12.1
 	RUN opam pin add -k version ocaml-base-compiler 4.12.1
@@ -13286,6 +14055,7 @@ ocurrent/opam-staging:ubuntu-20.04-ocaml-4.11-s390x, ocurrent/opam-staging:ubunt
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-20.04-opam-riscv64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.12 --packages=ocaml-base-compiler.4.12.1
 	RUN opam pin add -k version ocaml-base-compiler 4.12.1
@@ -13299,6 +14069,7 @@ ocurrent/opam-staging:ubuntu-20.04-ocaml-4.12-s390x, ocurrent/opam-staging:ubunt
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-20.04-opam-s390x
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.13 --packages=ocaml-base-compiler.4.13.1
 	RUN opam pin add -k version ocaml-base-compiler 4.13.1
@@ -13311,6 +14082,7 @@ ocurrent/opam-staging:ubuntu-20.04-ocaml-4.12-s390x, ocurrent/opam-staging:ubunt
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-20.04-opam-ppc64le
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.13 --packages=ocaml-base-compiler.4.13.1
 	RUN opam pin add -k version ocaml-base-compiler 4.13.1
@@ -13323,6 +14095,7 @@ ocurrent/opam-staging:ubuntu-20.04-ocaml-4.12-s390x, ocurrent/opam-staging:ubunt
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-20.04-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.13 --packages=ocaml-base-compiler.4.13.1
 	RUN opam pin add -k version ocaml-base-compiler 4.13.1
@@ -13335,6 +14108,7 @@ ocurrent/opam-staging:ubuntu-20.04-ocaml-4.12-s390x, ocurrent/opam-staging:ubunt
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-20.04-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.13 --packages=ocaml-base-compiler.4.13.1
 	RUN opam pin add -k version ocaml-base-compiler 4.13.1
@@ -13347,6 +14121,7 @@ ocurrent/opam-staging:ubuntu-20.04-ocaml-4.12-s390x, ocurrent/opam-staging:ubunt
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-20.04-opam-riscv64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.13 --packages=ocaml-base-compiler.4.13.1
 	RUN opam pin add -k version ocaml-base-compiler 4.13.1
@@ -13360,6 +14135,7 @@ ocurrent/opam-staging:ubuntu-20.04-ocaml-4.13-s390x, ocurrent/opam-staging:ubunt
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-20.04-opam-s390x
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.14 --packages=ocaml-base-compiler.4.14.2
 	RUN opam pin add -k version ocaml-base-compiler 4.14.2
@@ -13372,6 +14148,7 @@ ocurrent/opam-staging:ubuntu-20.04-ocaml-4.13-s390x, ocurrent/opam-staging:ubunt
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-20.04-opam-ppc64le
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.14 --packages=ocaml-base-compiler.4.14.2
 	RUN opam pin add -k version ocaml-base-compiler 4.14.2
@@ -13384,6 +14161,7 @@ ocurrent/opam-staging:ubuntu-20.04-ocaml-4.13-s390x, ocurrent/opam-staging:ubunt
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-20.04-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.14 --packages=ocaml-base-compiler.4.14.2
 	RUN opam pin add -k version ocaml-base-compiler 4.14.2
@@ -13396,6 +14174,7 @@ ocurrent/opam-staging:ubuntu-20.04-ocaml-4.13-s390x, ocurrent/opam-staging:ubunt
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-20.04-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.14 --packages=ocaml-base-compiler.4.14.2
 	RUN opam pin add -k version ocaml-base-compiler 4.14.2
@@ -13408,6 +14187,7 @@ ocurrent/opam-staging:ubuntu-20.04-ocaml-4.13-s390x, ocurrent/opam-staging:ubunt
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-20.04-opam-riscv64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.14 --packages=ocaml-base-compiler.4.14.2
 	RUN opam pin add -k version ocaml-base-compiler 4.14.2
@@ -13421,6 +14201,7 @@ ocurrent/opam-staging:ubuntu-20.04-ocaml-4.14-s390x, ocurrent/opam-staging:ubunt
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-20.04-opam-s390x
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 5.0 --packages=ocaml-base-compiler.5.0.0
 	RUN opam pin add -k version ocaml-base-compiler 5.0.0
@@ -13433,6 +14214,7 @@ ocurrent/opam-staging:ubuntu-20.04-ocaml-4.14-s390x, ocurrent/opam-staging:ubunt
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-20.04-opam-ppc64le
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 5.0 --packages=ocaml-base-compiler.5.0.0
 	RUN opam pin add -k version ocaml-base-compiler 5.0.0
@@ -13445,6 +14227,7 @@ ocurrent/opam-staging:ubuntu-20.04-ocaml-4.14-s390x, ocurrent/opam-staging:ubunt
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-20.04-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 5.0 --packages=ocaml-base-compiler.5.0.0
 	RUN opam pin add -k version ocaml-base-compiler 5.0.0
@@ -13457,6 +14240,7 @@ ocurrent/opam-staging:ubuntu-20.04-ocaml-4.14-s390x, ocurrent/opam-staging:ubunt
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-20.04-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 5.0 --packages=ocaml-base-compiler.5.0.0
 	RUN opam pin add -k version ocaml-base-compiler 5.0.0
@@ -13469,6 +14253,7 @@ ocurrent/opam-staging:ubuntu-20.04-ocaml-4.14-s390x, ocurrent/opam-staging:ubunt
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-20.04-opam-riscv64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 5.0 --packages=ocaml-base-compiler.5.0.0
 	RUN opam pin add -k version ocaml-base-compiler 5.0.0
@@ -13482,6 +14267,7 @@ ocurrent/opam-staging:ubuntu-20.04-ocaml-5.0-s390x, ocurrent/opam-staging:ubuntu
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-20.04-opam-s390x
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
 	RUN apt-get -y update
@@ -13499,6 +14285,7 @@ ocurrent/opam-staging:ubuntu-20.04-ocaml-5.0-s390x, ocurrent/opam-staging:ubuntu
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-20.04-opam-ppc64le
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
 	RUN apt-get -y update
@@ -13516,6 +14303,7 @@ ocurrent/opam-staging:ubuntu-20.04-ocaml-5.0-s390x, ocurrent/opam-staging:ubuntu
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-20.04-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
 	RUN apt-get -y update
@@ -13533,6 +14321,7 @@ ocurrent/opam-staging:ubuntu-20.04-ocaml-5.0-s390x, ocurrent/opam-staging:ubuntu
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-20.04-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
 	RUN apt-get -y update
@@ -13550,6 +14339,7 @@ ocurrent/opam-staging:ubuntu-20.04-ocaml-5.0-s390x, ocurrent/opam-staging:ubuntu
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-20.04-opam-riscv64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
 	RUN apt-get -y update
@@ -13568,6 +14358,7 @@ ocurrent/opam-staging:ubuntu-20.04-ocaml-5.1-s390x, ocurrent/opam-staging:ubuntu
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-20.04-opam-s390x
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
 	RUN apt-get -y update
@@ -13585,6 +14376,7 @@ ocurrent/opam-staging:ubuntu-20.04-ocaml-5.1-s390x, ocurrent/opam-staging:ubuntu
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-20.04-opam-ppc64le
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
 	RUN apt-get -y update
@@ -13602,6 +14394,7 @@ ocurrent/opam-staging:ubuntu-20.04-ocaml-5.1-s390x, ocurrent/opam-staging:ubuntu
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-20.04-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
 	RUN apt-get -y update
@@ -13619,6 +14412,7 @@ ocurrent/opam-staging:ubuntu-20.04-ocaml-5.1-s390x, ocurrent/opam-staging:ubuntu
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-20.04-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
 	RUN apt-get -y update
@@ -13636,6 +14430,7 @@ ocurrent/opam-staging:ubuntu-20.04-ocaml-5.1-s390x, ocurrent/opam-staging:ubuntu
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-20.04-opam-riscv64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
 	RUN apt-get -y update
@@ -13654,6 +14449,7 @@ ocurrent/opam-staging:ubuntu-20.04-ocaml-5.2-s390x, ocurrent/opam-staging:ubuntu
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-20.04-opam-s390x
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
 	RUN apt-get -y update
@@ -13671,6 +14467,7 @@ ocurrent/opam-staging:ubuntu-20.04-ocaml-5.2-s390x, ocurrent/opam-staging:ubuntu
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-20.04-opam-ppc64le
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
 	RUN apt-get -y update
@@ -13688,6 +14485,7 @@ ocurrent/opam-staging:ubuntu-20.04-ocaml-5.2-s390x, ocurrent/opam-staging:ubuntu
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-20.04-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
 	RUN apt-get -y update
@@ -13705,6 +14503,7 @@ ocurrent/opam-staging:ubuntu-20.04-ocaml-5.2-s390x, ocurrent/opam-staging:ubuntu
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-20.04-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
 	RUN apt-get -y update
@@ -13722,6 +14521,7 @@ ocurrent/opam-staging:ubuntu-20.04-ocaml-5.2-s390x, ocurrent/opam-staging:ubuntu
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-20.04-opam-riscv64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
 	RUN apt-get -y update
@@ -13741,6 +14541,7 @@ ocurrent/opam-staging:ubuntu-20.04-ocaml-5.3-s390x, ocurrent/opam-staging:ubuntu
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-20.04-opam-s390x
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	RUN opam repo add beta git+https://github.com/ocaml/ocaml-beta-repository --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
@@ -13759,6 +14560,7 @@ ocurrent/opam-staging:ubuntu-20.04-ocaml-5.3-s390x, ocurrent/opam-staging:ubuntu
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-20.04-opam-ppc64le
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	RUN opam repo add beta git+https://github.com/ocaml/ocaml-beta-repository --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
@@ -13777,6 +14579,7 @@ ocurrent/opam-staging:ubuntu-20.04-ocaml-5.3-s390x, ocurrent/opam-staging:ubuntu
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-20.04-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	RUN opam repo add beta git+https://github.com/ocaml/ocaml-beta-repository --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
@@ -13795,6 +14598,7 @@ ocurrent/opam-staging:ubuntu-20.04-ocaml-5.3-s390x, ocurrent/opam-staging:ubuntu
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-20.04-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	RUN opam repo add beta git+https://github.com/ocaml/ocaml-beta-repository --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
@@ -13813,6 +14617,7 @@ ocurrent/opam-staging:ubuntu-20.04-ocaml-5.3-s390x, ocurrent/opam-staging:ubuntu
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-20.04-opam-riscv64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	RUN opam repo add beta git+https://github.com/ocaml/ocaml-beta-repository --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
@@ -14234,6 +15039,7 @@ ocurrent/opam-staging:ubuntu-22.04-opam-s390x, ocurrent/opam-staging:ubuntu-22.0
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-22.04-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.02 --packages=ocaml-base-compiler.4.02.3
 	RUN opam pin add -k version ocaml-base-compiler 4.02.3
@@ -14248,6 +15054,7 @@ ocurrent/opam-staging:ubuntu-22.04-ocaml-4.02-amd64 -> ocaml/opam:ubuntu-22.04-o
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-22.04-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.03 --packages=ocaml-base-compiler.4.03.0
 	RUN opam pin add -k version ocaml-base-compiler 4.03.0
@@ -14262,6 +15069,7 @@ ocurrent/opam-staging:ubuntu-22.04-ocaml-4.03-amd64 -> ocaml/opam:ubuntu-22.04-o
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-22.04-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.04 --packages=ocaml-base-compiler.4.04.2
 	RUN opam pin add -k version ocaml-base-compiler 4.04.2
@@ -14276,6 +15084,7 @@ ocurrent/opam-staging:ubuntu-22.04-ocaml-4.04-amd64 -> ocaml/opam:ubuntu-22.04-o
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-22.04-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.05 --packages=ocaml-base-compiler.4.05.0
 	RUN opam pin add -k version ocaml-base-compiler 4.05.0
@@ -14290,6 +15099,7 @@ ocurrent/opam-staging:ubuntu-22.04-ocaml-4.05-amd64 -> ocaml/opam:ubuntu-22.04-o
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-22.04-opam-s390x
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.06 --packages=ocaml-base-compiler.4.06.1
 	RUN opam pin add -k version ocaml-base-compiler 4.06.1
@@ -14303,6 +15113,7 @@ ocurrent/opam-staging:ubuntu-22.04-ocaml-4.05-amd64 -> ocaml/opam:ubuntu-22.04-o
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-22.04-opam-ppc64le
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.06 --packages=ocaml-base-compiler.4.06.1
 	RUN opam pin add -k version ocaml-base-compiler 4.06.1
@@ -14316,6 +15127,7 @@ ocurrent/opam-staging:ubuntu-22.04-ocaml-4.05-amd64 -> ocaml/opam:ubuntu-22.04-o
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-22.04-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.06 --packages=ocaml-base-compiler.4.06.1
 	RUN opam pin add -k version ocaml-base-compiler 4.06.1
@@ -14329,6 +15141,7 @@ ocurrent/opam-staging:ubuntu-22.04-ocaml-4.05-amd64 -> ocaml/opam:ubuntu-22.04-o
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-22.04-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.06 --packages=ocaml-base-compiler.4.06.1
 	RUN opam pin add -k version ocaml-base-compiler 4.06.1
@@ -14343,6 +15156,7 @@ ocurrent/opam-staging:ubuntu-22.04-ocaml-4.06-s390x, ocurrent/opam-staging:ubunt
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-22.04-opam-s390x
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.07 --packages=ocaml-base-compiler.4.07.1
 	RUN opam pin add -k version ocaml-base-compiler 4.07.1
@@ -14356,6 +15170,7 @@ ocurrent/opam-staging:ubuntu-22.04-ocaml-4.06-s390x, ocurrent/opam-staging:ubunt
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-22.04-opam-ppc64le
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.07 --packages=ocaml-base-compiler.4.07.1
 	RUN opam pin add -k version ocaml-base-compiler 4.07.1
@@ -14369,6 +15184,7 @@ ocurrent/opam-staging:ubuntu-22.04-ocaml-4.06-s390x, ocurrent/opam-staging:ubunt
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-22.04-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.07 --packages=ocaml-base-compiler.4.07.1
 	RUN opam pin add -k version ocaml-base-compiler 4.07.1
@@ -14382,6 +15198,7 @@ ocurrent/opam-staging:ubuntu-22.04-ocaml-4.06-s390x, ocurrent/opam-staging:ubunt
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-22.04-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.07 --packages=ocaml-base-compiler.4.07.1
 	RUN opam pin add -k version ocaml-base-compiler 4.07.1
@@ -14396,6 +15213,7 @@ ocurrent/opam-staging:ubuntu-22.04-ocaml-4.07-s390x, ocurrent/opam-staging:ubunt
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-22.04-opam-s390x
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.08 --packages=ocaml-base-compiler.4.08.1
 	RUN opam pin add -k version ocaml-base-compiler 4.08.1
@@ -14408,6 +15226,7 @@ ocurrent/opam-staging:ubuntu-22.04-ocaml-4.07-s390x, ocurrent/opam-staging:ubunt
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-22.04-opam-ppc64le
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.08 --packages=ocaml-base-compiler.4.08.1
 	RUN opam pin add -k version ocaml-base-compiler 4.08.1
@@ -14420,6 +15239,7 @@ ocurrent/opam-staging:ubuntu-22.04-ocaml-4.07-s390x, ocurrent/opam-staging:ubunt
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-22.04-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.08 --packages=ocaml-base-compiler.4.08.1
 	RUN opam pin add -k version ocaml-base-compiler 4.08.1
@@ -14432,6 +15252,7 @@ ocurrent/opam-staging:ubuntu-22.04-ocaml-4.07-s390x, ocurrent/opam-staging:ubunt
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-22.04-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.08 --packages=ocaml-base-compiler.4.08.1
 	RUN opam pin add -k version ocaml-base-compiler 4.08.1
@@ -14445,6 +15266,7 @@ ocurrent/opam-staging:ubuntu-22.04-ocaml-4.08-s390x, ocurrent/opam-staging:ubunt
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-22.04-opam-s390x
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.09 --packages=ocaml-base-compiler.4.09.1
 	RUN opam pin add -k version ocaml-base-compiler 4.09.1
@@ -14457,6 +15279,7 @@ ocurrent/opam-staging:ubuntu-22.04-ocaml-4.08-s390x, ocurrent/opam-staging:ubunt
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-22.04-opam-ppc64le
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.09 --packages=ocaml-base-compiler.4.09.1
 	RUN opam pin add -k version ocaml-base-compiler 4.09.1
@@ -14469,6 +15292,7 @@ ocurrent/opam-staging:ubuntu-22.04-ocaml-4.08-s390x, ocurrent/opam-staging:ubunt
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-22.04-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.09 --packages=ocaml-base-compiler.4.09.1
 	RUN opam pin add -k version ocaml-base-compiler 4.09.1
@@ -14481,6 +15305,7 @@ ocurrent/opam-staging:ubuntu-22.04-ocaml-4.08-s390x, ocurrent/opam-staging:ubunt
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-22.04-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.09 --packages=ocaml-base-compiler.4.09.1
 	RUN opam pin add -k version ocaml-base-compiler 4.09.1
@@ -14494,6 +15319,7 @@ ocurrent/opam-staging:ubuntu-22.04-ocaml-4.09-s390x, ocurrent/opam-staging:ubunt
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-22.04-opam-s390x
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.10 --packages=ocaml-base-compiler.4.10.2
 	RUN opam pin add -k version ocaml-base-compiler 4.10.2
@@ -14506,6 +15332,7 @@ ocurrent/opam-staging:ubuntu-22.04-ocaml-4.09-s390x, ocurrent/opam-staging:ubunt
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-22.04-opam-ppc64le
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.10 --packages=ocaml-base-compiler.4.10.2
 	RUN opam pin add -k version ocaml-base-compiler 4.10.2
@@ -14518,6 +15345,7 @@ ocurrent/opam-staging:ubuntu-22.04-ocaml-4.09-s390x, ocurrent/opam-staging:ubunt
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-22.04-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.10 --packages=ocaml-base-compiler.4.10.2
 	RUN opam pin add -k version ocaml-base-compiler 4.10.2
@@ -14530,6 +15358,7 @@ ocurrent/opam-staging:ubuntu-22.04-ocaml-4.09-s390x, ocurrent/opam-staging:ubunt
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-22.04-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.10 --packages=ocaml-base-compiler.4.10.2
 	RUN opam pin add -k version ocaml-base-compiler 4.10.2
@@ -14543,6 +15372,7 @@ ocurrent/opam-staging:ubuntu-22.04-ocaml-4.10-s390x, ocurrent/opam-staging:ubunt
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-22.04-opam-s390x
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.11 --packages=ocaml-base-compiler.4.11.2
 	RUN opam pin add -k version ocaml-base-compiler 4.11.2
@@ -14555,6 +15385,7 @@ ocurrent/opam-staging:ubuntu-22.04-ocaml-4.10-s390x, ocurrent/opam-staging:ubunt
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-22.04-opam-ppc64le
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.11 --packages=ocaml-base-compiler.4.11.2
 	RUN opam pin add -k version ocaml-base-compiler 4.11.2
@@ -14567,6 +15398,7 @@ ocurrent/opam-staging:ubuntu-22.04-ocaml-4.10-s390x, ocurrent/opam-staging:ubunt
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-22.04-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.11 --packages=ocaml-base-compiler.4.11.2
 	RUN opam pin add -k version ocaml-base-compiler 4.11.2
@@ -14579,6 +15411,7 @@ ocurrent/opam-staging:ubuntu-22.04-ocaml-4.10-s390x, ocurrent/opam-staging:ubunt
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-22.04-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.11 --packages=ocaml-base-compiler.4.11.2
 	RUN opam pin add -k version ocaml-base-compiler 4.11.2
@@ -14591,6 +15424,7 @@ ocurrent/opam-staging:ubuntu-22.04-ocaml-4.10-s390x, ocurrent/opam-staging:ubunt
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-22.04-opam-riscv64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.11 --packages=ocaml-base-compiler.4.11.2
 	RUN opam pin add -k version ocaml-base-compiler 4.11.2
@@ -14604,6 +15438,7 @@ ocurrent/opam-staging:ubuntu-22.04-ocaml-4.11-s390x, ocurrent/opam-staging:ubunt
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-22.04-opam-s390x
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.12 --packages=ocaml-base-compiler.4.12.1
 	RUN opam pin add -k version ocaml-base-compiler 4.12.1
@@ -14616,6 +15451,7 @@ ocurrent/opam-staging:ubuntu-22.04-ocaml-4.11-s390x, ocurrent/opam-staging:ubunt
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-22.04-opam-ppc64le
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.12 --packages=ocaml-base-compiler.4.12.1
 	RUN opam pin add -k version ocaml-base-compiler 4.12.1
@@ -14628,6 +15464,7 @@ ocurrent/opam-staging:ubuntu-22.04-ocaml-4.11-s390x, ocurrent/opam-staging:ubunt
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-22.04-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.12 --packages=ocaml-base-compiler.4.12.1
 	RUN opam pin add -k version ocaml-base-compiler 4.12.1
@@ -14640,6 +15477,7 @@ ocurrent/opam-staging:ubuntu-22.04-ocaml-4.11-s390x, ocurrent/opam-staging:ubunt
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-22.04-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.12 --packages=ocaml-base-compiler.4.12.1
 	RUN opam pin add -k version ocaml-base-compiler 4.12.1
@@ -14652,6 +15490,7 @@ ocurrent/opam-staging:ubuntu-22.04-ocaml-4.11-s390x, ocurrent/opam-staging:ubunt
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-22.04-opam-riscv64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.12 --packages=ocaml-base-compiler.4.12.1
 	RUN opam pin add -k version ocaml-base-compiler 4.12.1
@@ -14665,6 +15504,7 @@ ocurrent/opam-staging:ubuntu-22.04-ocaml-4.12-s390x, ocurrent/opam-staging:ubunt
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-22.04-opam-s390x
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.13 --packages=ocaml-base-compiler.4.13.1
 	RUN opam pin add -k version ocaml-base-compiler 4.13.1
@@ -14677,6 +15517,7 @@ ocurrent/opam-staging:ubuntu-22.04-ocaml-4.12-s390x, ocurrent/opam-staging:ubunt
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-22.04-opam-ppc64le
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.13 --packages=ocaml-base-compiler.4.13.1
 	RUN opam pin add -k version ocaml-base-compiler 4.13.1
@@ -14689,6 +15530,7 @@ ocurrent/opam-staging:ubuntu-22.04-ocaml-4.12-s390x, ocurrent/opam-staging:ubunt
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-22.04-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.13 --packages=ocaml-base-compiler.4.13.1
 	RUN opam pin add -k version ocaml-base-compiler 4.13.1
@@ -14701,6 +15543,7 @@ ocurrent/opam-staging:ubuntu-22.04-ocaml-4.12-s390x, ocurrent/opam-staging:ubunt
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-22.04-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.13 --packages=ocaml-base-compiler.4.13.1
 	RUN opam pin add -k version ocaml-base-compiler 4.13.1
@@ -14713,6 +15556,7 @@ ocurrent/opam-staging:ubuntu-22.04-ocaml-4.12-s390x, ocurrent/opam-staging:ubunt
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-22.04-opam-riscv64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.13 --packages=ocaml-base-compiler.4.13.1
 	RUN opam pin add -k version ocaml-base-compiler 4.13.1
@@ -14726,6 +15570,7 @@ ocurrent/opam-staging:ubuntu-22.04-ocaml-4.13-s390x, ocurrent/opam-staging:ubunt
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-22.04-opam-s390x
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.14 --packages=ocaml-base-compiler.4.14.2
 	RUN opam pin add -k version ocaml-base-compiler 4.14.2
@@ -14738,6 +15583,7 @@ ocurrent/opam-staging:ubuntu-22.04-ocaml-4.13-s390x, ocurrent/opam-staging:ubunt
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-22.04-opam-ppc64le
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.14 --packages=ocaml-base-compiler.4.14.2
 	RUN opam pin add -k version ocaml-base-compiler 4.14.2
@@ -14750,6 +15596,7 @@ ocurrent/opam-staging:ubuntu-22.04-ocaml-4.13-s390x, ocurrent/opam-staging:ubunt
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-22.04-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.14 --packages=ocaml-base-compiler.4.14.2
 	RUN opam pin add -k version ocaml-base-compiler 4.14.2
@@ -14762,6 +15609,7 @@ ocurrent/opam-staging:ubuntu-22.04-ocaml-4.13-s390x, ocurrent/opam-staging:ubunt
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-22.04-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.14 --packages=ocaml-base-compiler.4.14.2
 	RUN opam pin add -k version ocaml-base-compiler 4.14.2
@@ -14774,6 +15622,7 @@ ocurrent/opam-staging:ubuntu-22.04-ocaml-4.13-s390x, ocurrent/opam-staging:ubunt
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-22.04-opam-riscv64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.14 --packages=ocaml-base-compiler.4.14.2
 	RUN opam pin add -k version ocaml-base-compiler 4.14.2
@@ -14787,6 +15636,7 @@ ocurrent/opam-staging:ubuntu-22.04-ocaml-4.14-s390x, ocurrent/opam-staging:ubunt
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-22.04-opam-s390x
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 5.0 --packages=ocaml-base-compiler.5.0.0
 	RUN opam pin add -k version ocaml-base-compiler 5.0.0
@@ -14799,6 +15649,7 @@ ocurrent/opam-staging:ubuntu-22.04-ocaml-4.14-s390x, ocurrent/opam-staging:ubunt
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-22.04-opam-ppc64le
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 5.0 --packages=ocaml-base-compiler.5.0.0
 	RUN opam pin add -k version ocaml-base-compiler 5.0.0
@@ -14811,6 +15662,7 @@ ocurrent/opam-staging:ubuntu-22.04-ocaml-4.14-s390x, ocurrent/opam-staging:ubunt
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-22.04-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 5.0 --packages=ocaml-base-compiler.5.0.0
 	RUN opam pin add -k version ocaml-base-compiler 5.0.0
@@ -14823,6 +15675,7 @@ ocurrent/opam-staging:ubuntu-22.04-ocaml-4.14-s390x, ocurrent/opam-staging:ubunt
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-22.04-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 5.0 --packages=ocaml-base-compiler.5.0.0
 	RUN opam pin add -k version ocaml-base-compiler 5.0.0
@@ -14835,6 +15688,7 @@ ocurrent/opam-staging:ubuntu-22.04-ocaml-4.14-s390x, ocurrent/opam-staging:ubunt
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-22.04-opam-riscv64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 5.0 --packages=ocaml-base-compiler.5.0.0
 	RUN opam pin add -k version ocaml-base-compiler 5.0.0
@@ -14848,6 +15702,7 @@ ocurrent/opam-staging:ubuntu-22.04-ocaml-5.0-s390x, ocurrent/opam-staging:ubuntu
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-22.04-opam-s390x
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
 	RUN apt-get -y update
@@ -14865,6 +15720,7 @@ ocurrent/opam-staging:ubuntu-22.04-ocaml-5.0-s390x, ocurrent/opam-staging:ubuntu
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-22.04-opam-ppc64le
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
 	RUN apt-get -y update
@@ -14882,6 +15738,7 @@ ocurrent/opam-staging:ubuntu-22.04-ocaml-5.0-s390x, ocurrent/opam-staging:ubuntu
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-22.04-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
 	RUN apt-get -y update
@@ -14899,6 +15756,7 @@ ocurrent/opam-staging:ubuntu-22.04-ocaml-5.0-s390x, ocurrent/opam-staging:ubuntu
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-22.04-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
 	RUN apt-get -y update
@@ -14916,6 +15774,7 @@ ocurrent/opam-staging:ubuntu-22.04-ocaml-5.0-s390x, ocurrent/opam-staging:ubuntu
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-22.04-opam-riscv64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
 	RUN apt-get -y update
@@ -14934,6 +15793,7 @@ ocurrent/opam-staging:ubuntu-22.04-ocaml-5.1-s390x, ocurrent/opam-staging:ubuntu
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-22.04-opam-s390x
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
 	RUN apt-get -y update
@@ -14951,6 +15811,7 @@ ocurrent/opam-staging:ubuntu-22.04-ocaml-5.1-s390x, ocurrent/opam-staging:ubuntu
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-22.04-opam-ppc64le
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
 	RUN apt-get -y update
@@ -14968,6 +15829,7 @@ ocurrent/opam-staging:ubuntu-22.04-ocaml-5.1-s390x, ocurrent/opam-staging:ubuntu
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-22.04-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
 	RUN apt-get -y update
@@ -14985,6 +15847,7 @@ ocurrent/opam-staging:ubuntu-22.04-ocaml-5.1-s390x, ocurrent/opam-staging:ubuntu
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-22.04-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
 	RUN apt-get -y update
@@ -15002,6 +15865,7 @@ ocurrent/opam-staging:ubuntu-22.04-ocaml-5.1-s390x, ocurrent/opam-staging:ubuntu
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-22.04-opam-riscv64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
 	RUN apt-get -y update
@@ -15020,6 +15884,7 @@ ocurrent/opam-staging:ubuntu-22.04-ocaml-5.2-s390x, ocurrent/opam-staging:ubuntu
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-22.04-opam-s390x
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
 	RUN apt-get -y update
@@ -15037,6 +15902,7 @@ ocurrent/opam-staging:ubuntu-22.04-ocaml-5.2-s390x, ocurrent/opam-staging:ubuntu
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-22.04-opam-ppc64le
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
 	RUN apt-get -y update
@@ -15054,6 +15920,7 @@ ocurrent/opam-staging:ubuntu-22.04-ocaml-5.2-s390x, ocurrent/opam-staging:ubuntu
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-22.04-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
 	RUN apt-get -y update
@@ -15071,6 +15938,7 @@ ocurrent/opam-staging:ubuntu-22.04-ocaml-5.2-s390x, ocurrent/opam-staging:ubuntu
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-22.04-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
 	RUN apt-get -y update
@@ -15088,6 +15956,7 @@ ocurrent/opam-staging:ubuntu-22.04-ocaml-5.2-s390x, ocurrent/opam-staging:ubuntu
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-22.04-opam-riscv64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
 	RUN apt-get -y update
@@ -15107,6 +15976,7 @@ ocurrent/opam-staging:ubuntu-22.04-ocaml-5.3-s390x, ocurrent/opam-staging:ubuntu
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-22.04-opam-s390x
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	RUN opam repo add beta git+https://github.com/ocaml/ocaml-beta-repository --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
@@ -15125,6 +15995,7 @@ ocurrent/opam-staging:ubuntu-22.04-ocaml-5.3-s390x, ocurrent/opam-staging:ubuntu
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-22.04-opam-ppc64le
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	RUN opam repo add beta git+https://github.com/ocaml/ocaml-beta-repository --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
@@ -15143,6 +16014,7 @@ ocurrent/opam-staging:ubuntu-22.04-ocaml-5.3-s390x, ocurrent/opam-staging:ubuntu
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-22.04-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	RUN opam repo add beta git+https://github.com/ocaml/ocaml-beta-repository --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
@@ -15161,6 +16033,7 @@ ocurrent/opam-staging:ubuntu-22.04-ocaml-5.3-s390x, ocurrent/opam-staging:ubuntu
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-22.04-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	RUN opam repo add beta git+https://github.com/ocaml/ocaml-beta-repository --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
@@ -15179,6 +16052,7 @@ ocurrent/opam-staging:ubuntu-22.04-ocaml-5.3-s390x, ocurrent/opam-staging:ubuntu
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-22.04-opam-riscv64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	RUN opam repo add beta git+https://github.com/ocaml/ocaml-beta-repository --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
@@ -15600,6 +16474,7 @@ ocurrent/opam-staging:ubuntu-24.04-opam-s390x, ocurrent/opam-staging:ubuntu-24.0
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-24.04-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.02 --packages=ocaml-base-compiler.4.02.3
 	RUN opam pin add -k version ocaml-base-compiler 4.02.3
@@ -15615,6 +16490,7 @@ ocurrent/opam-staging:ubuntu-24.04-ocaml-4.02-amd64 -> ocaml/opam:ubuntu-lts-oca
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-24.04-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.03 --packages=ocaml-base-compiler.4.03.0
 	RUN opam pin add -k version ocaml-base-compiler 4.03.0
@@ -15630,6 +16506,7 @@ ocurrent/opam-staging:ubuntu-24.04-ocaml-4.03-amd64 -> ocaml/opam:ubuntu-lts-oca
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-24.04-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.04 --packages=ocaml-base-compiler.4.04.2
 	RUN opam pin add -k version ocaml-base-compiler 4.04.2
@@ -15645,6 +16522,7 @@ ocurrent/opam-staging:ubuntu-24.04-ocaml-4.04-amd64 -> ocaml/opam:ubuntu-lts-oca
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-24.04-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.05 --packages=ocaml-base-compiler.4.05.0
 	RUN opam pin add -k version ocaml-base-compiler 4.05.0
@@ -15660,6 +16538,7 @@ ocurrent/opam-staging:ubuntu-24.04-ocaml-4.05-amd64 -> ocaml/opam:ubuntu-lts-oca
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-24.04-opam-s390x
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.06 --packages=ocaml-base-compiler.4.06.1
 	RUN opam pin add -k version ocaml-base-compiler 4.06.1
@@ -15673,6 +16552,7 @@ ocurrent/opam-staging:ubuntu-24.04-ocaml-4.05-amd64 -> ocaml/opam:ubuntu-lts-oca
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-24.04-opam-ppc64le
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.06 --packages=ocaml-base-compiler.4.06.1
 	RUN opam pin add -k version ocaml-base-compiler 4.06.1
@@ -15686,6 +16566,7 @@ ocurrent/opam-staging:ubuntu-24.04-ocaml-4.05-amd64 -> ocaml/opam:ubuntu-lts-oca
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-24.04-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.06 --packages=ocaml-base-compiler.4.06.1
 	RUN opam pin add -k version ocaml-base-compiler 4.06.1
@@ -15699,6 +16580,7 @@ ocurrent/opam-staging:ubuntu-24.04-ocaml-4.05-amd64 -> ocaml/opam:ubuntu-lts-oca
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-24.04-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.06 --packages=ocaml-base-compiler.4.06.1
 	RUN opam pin add -k version ocaml-base-compiler 4.06.1
@@ -15714,6 +16596,7 @@ ocurrent/opam-staging:ubuntu-24.04-ocaml-4.06-s390x, ocurrent/opam-staging:ubunt
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-24.04-opam-s390x
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.07 --packages=ocaml-base-compiler.4.07.1
 	RUN opam pin add -k version ocaml-base-compiler 4.07.1
@@ -15727,6 +16610,7 @@ ocurrent/opam-staging:ubuntu-24.04-ocaml-4.06-s390x, ocurrent/opam-staging:ubunt
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-24.04-opam-ppc64le
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.07 --packages=ocaml-base-compiler.4.07.1
 	RUN opam pin add -k version ocaml-base-compiler 4.07.1
@@ -15740,6 +16624,7 @@ ocurrent/opam-staging:ubuntu-24.04-ocaml-4.06-s390x, ocurrent/opam-staging:ubunt
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-24.04-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.07 --packages=ocaml-base-compiler.4.07.1
 	RUN opam pin add -k version ocaml-base-compiler 4.07.1
@@ -15753,6 +16638,7 @@ ocurrent/opam-staging:ubuntu-24.04-ocaml-4.06-s390x, ocurrent/opam-staging:ubunt
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-24.04-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.07 --packages=ocaml-base-compiler.4.07.1
 	RUN opam pin add -k version ocaml-base-compiler 4.07.1
@@ -15768,6 +16654,7 @@ ocurrent/opam-staging:ubuntu-24.04-ocaml-4.07-s390x, ocurrent/opam-staging:ubunt
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-24.04-opam-s390x
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.08 --packages=ocaml-base-compiler.4.08.1
 	RUN opam pin add -k version ocaml-base-compiler 4.08.1
@@ -15780,6 +16667,7 @@ ocurrent/opam-staging:ubuntu-24.04-ocaml-4.07-s390x, ocurrent/opam-staging:ubunt
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-24.04-opam-ppc64le
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.08 --packages=ocaml-base-compiler.4.08.1
 	RUN opam pin add -k version ocaml-base-compiler 4.08.1
@@ -15792,6 +16680,7 @@ ocurrent/opam-staging:ubuntu-24.04-ocaml-4.07-s390x, ocurrent/opam-staging:ubunt
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-24.04-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.08 --packages=ocaml-base-compiler.4.08.1
 	RUN opam pin add -k version ocaml-base-compiler 4.08.1
@@ -15804,6 +16693,7 @@ ocurrent/opam-staging:ubuntu-24.04-ocaml-4.07-s390x, ocurrent/opam-staging:ubunt
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-24.04-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.08 --packages=ocaml-base-compiler.4.08.1
 	RUN opam pin add -k version ocaml-base-compiler 4.08.1
@@ -15818,6 +16708,7 @@ ocurrent/opam-staging:ubuntu-24.04-ocaml-4.08-s390x, ocurrent/opam-staging:ubunt
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-24.04-opam-s390x
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.09 --packages=ocaml-base-compiler.4.09.1
 	RUN opam pin add -k version ocaml-base-compiler 4.09.1
@@ -15830,6 +16721,7 @@ ocurrent/opam-staging:ubuntu-24.04-ocaml-4.08-s390x, ocurrent/opam-staging:ubunt
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-24.04-opam-ppc64le
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.09 --packages=ocaml-base-compiler.4.09.1
 	RUN opam pin add -k version ocaml-base-compiler 4.09.1
@@ -15842,6 +16734,7 @@ ocurrent/opam-staging:ubuntu-24.04-ocaml-4.08-s390x, ocurrent/opam-staging:ubunt
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-24.04-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.09 --packages=ocaml-base-compiler.4.09.1
 	RUN opam pin add -k version ocaml-base-compiler 4.09.1
@@ -15854,6 +16747,7 @@ ocurrent/opam-staging:ubuntu-24.04-ocaml-4.08-s390x, ocurrent/opam-staging:ubunt
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-24.04-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.09 --packages=ocaml-base-compiler.4.09.1
 	RUN opam pin add -k version ocaml-base-compiler 4.09.1
@@ -15868,6 +16762,7 @@ ocurrent/opam-staging:ubuntu-24.04-ocaml-4.09-s390x, ocurrent/opam-staging:ubunt
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-24.04-opam-s390x
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.10 --packages=ocaml-base-compiler.4.10.2
 	RUN opam pin add -k version ocaml-base-compiler 4.10.2
@@ -15880,6 +16775,7 @@ ocurrent/opam-staging:ubuntu-24.04-ocaml-4.09-s390x, ocurrent/opam-staging:ubunt
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-24.04-opam-ppc64le
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.10 --packages=ocaml-base-compiler.4.10.2
 	RUN opam pin add -k version ocaml-base-compiler 4.10.2
@@ -15892,6 +16788,7 @@ ocurrent/opam-staging:ubuntu-24.04-ocaml-4.09-s390x, ocurrent/opam-staging:ubunt
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-24.04-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.10 --packages=ocaml-base-compiler.4.10.2
 	RUN opam pin add -k version ocaml-base-compiler 4.10.2
@@ -15904,6 +16801,7 @@ ocurrent/opam-staging:ubuntu-24.04-ocaml-4.09-s390x, ocurrent/opam-staging:ubunt
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-24.04-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.10 --packages=ocaml-base-compiler.4.10.2
 	RUN opam pin add -k version ocaml-base-compiler 4.10.2
@@ -15918,6 +16816,7 @@ ocurrent/opam-staging:ubuntu-24.04-ocaml-4.10-s390x, ocurrent/opam-staging:ubunt
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-24.04-opam-s390x
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.11 --packages=ocaml-base-compiler.4.11.2
 	RUN opam pin add -k version ocaml-base-compiler 4.11.2
@@ -15930,6 +16829,7 @@ ocurrent/opam-staging:ubuntu-24.04-ocaml-4.10-s390x, ocurrent/opam-staging:ubunt
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-24.04-opam-ppc64le
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.11 --packages=ocaml-base-compiler.4.11.2
 	RUN opam pin add -k version ocaml-base-compiler 4.11.2
@@ -15942,6 +16842,7 @@ ocurrent/opam-staging:ubuntu-24.04-ocaml-4.10-s390x, ocurrent/opam-staging:ubunt
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-24.04-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.11 --packages=ocaml-base-compiler.4.11.2
 	RUN opam pin add -k version ocaml-base-compiler 4.11.2
@@ -15954,6 +16855,7 @@ ocurrent/opam-staging:ubuntu-24.04-ocaml-4.10-s390x, ocurrent/opam-staging:ubunt
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-24.04-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.11 --packages=ocaml-base-compiler.4.11.2
 	RUN opam pin add -k version ocaml-base-compiler 4.11.2
@@ -15966,6 +16868,7 @@ ocurrent/opam-staging:ubuntu-24.04-ocaml-4.10-s390x, ocurrent/opam-staging:ubunt
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-24.04-opam-riscv64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.11 --packages=ocaml-base-compiler.4.11.2
 	RUN opam pin add -k version ocaml-base-compiler 4.11.2
@@ -15980,6 +16883,7 @@ ocurrent/opam-staging:ubuntu-24.04-ocaml-4.11-s390x, ocurrent/opam-staging:ubunt
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-24.04-opam-s390x
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.12 --packages=ocaml-base-compiler.4.12.1
 	RUN opam pin add -k version ocaml-base-compiler 4.12.1
@@ -15992,6 +16896,7 @@ ocurrent/opam-staging:ubuntu-24.04-ocaml-4.11-s390x, ocurrent/opam-staging:ubunt
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-24.04-opam-ppc64le
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.12 --packages=ocaml-base-compiler.4.12.1
 	RUN opam pin add -k version ocaml-base-compiler 4.12.1
@@ -16004,6 +16909,7 @@ ocurrent/opam-staging:ubuntu-24.04-ocaml-4.11-s390x, ocurrent/opam-staging:ubunt
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-24.04-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.12 --packages=ocaml-base-compiler.4.12.1
 	RUN opam pin add -k version ocaml-base-compiler 4.12.1
@@ -16016,6 +16922,7 @@ ocurrent/opam-staging:ubuntu-24.04-ocaml-4.11-s390x, ocurrent/opam-staging:ubunt
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-24.04-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.12 --packages=ocaml-base-compiler.4.12.1
 	RUN opam pin add -k version ocaml-base-compiler 4.12.1
@@ -16028,6 +16935,7 @@ ocurrent/opam-staging:ubuntu-24.04-ocaml-4.11-s390x, ocurrent/opam-staging:ubunt
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-24.04-opam-riscv64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.12 --packages=ocaml-base-compiler.4.12.1
 	RUN opam pin add -k version ocaml-base-compiler 4.12.1
@@ -16042,6 +16950,7 @@ ocurrent/opam-staging:ubuntu-24.04-ocaml-4.12-s390x, ocurrent/opam-staging:ubunt
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-24.04-opam-s390x
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.13 --packages=ocaml-base-compiler.4.13.1
 	RUN opam pin add -k version ocaml-base-compiler 4.13.1
@@ -16054,6 +16963,7 @@ ocurrent/opam-staging:ubuntu-24.04-ocaml-4.12-s390x, ocurrent/opam-staging:ubunt
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-24.04-opam-ppc64le
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.13 --packages=ocaml-base-compiler.4.13.1
 	RUN opam pin add -k version ocaml-base-compiler 4.13.1
@@ -16066,6 +16976,7 @@ ocurrent/opam-staging:ubuntu-24.04-ocaml-4.12-s390x, ocurrent/opam-staging:ubunt
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-24.04-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.13 --packages=ocaml-base-compiler.4.13.1
 	RUN opam pin add -k version ocaml-base-compiler 4.13.1
@@ -16078,6 +16989,7 @@ ocurrent/opam-staging:ubuntu-24.04-ocaml-4.12-s390x, ocurrent/opam-staging:ubunt
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-24.04-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.13 --packages=ocaml-base-compiler.4.13.1
 	RUN opam pin add -k version ocaml-base-compiler 4.13.1
@@ -16090,6 +17002,7 @@ ocurrent/opam-staging:ubuntu-24.04-ocaml-4.12-s390x, ocurrent/opam-staging:ubunt
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-24.04-opam-riscv64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.13 --packages=ocaml-base-compiler.4.13.1
 	RUN opam pin add -k version ocaml-base-compiler 4.13.1
@@ -16104,6 +17017,7 @@ ocurrent/opam-staging:ubuntu-24.04-ocaml-4.13-s390x, ocurrent/opam-staging:ubunt
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-24.04-opam-s390x
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.14 --packages=ocaml-base-compiler.4.14.2
 	RUN opam pin add -k version ocaml-base-compiler 4.14.2
@@ -16116,6 +17030,7 @@ ocurrent/opam-staging:ubuntu-24.04-ocaml-4.13-s390x, ocurrent/opam-staging:ubunt
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-24.04-opam-ppc64le
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.14 --packages=ocaml-base-compiler.4.14.2
 	RUN opam pin add -k version ocaml-base-compiler 4.14.2
@@ -16128,6 +17043,7 @@ ocurrent/opam-staging:ubuntu-24.04-ocaml-4.13-s390x, ocurrent/opam-staging:ubunt
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-24.04-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.14 --packages=ocaml-base-compiler.4.14.2
 	RUN opam pin add -k version ocaml-base-compiler 4.14.2
@@ -16140,6 +17056,7 @@ ocurrent/opam-staging:ubuntu-24.04-ocaml-4.13-s390x, ocurrent/opam-staging:ubunt
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-24.04-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.14 --packages=ocaml-base-compiler.4.14.2
 	RUN opam pin add -k version ocaml-base-compiler 4.14.2
@@ -16152,6 +17069,7 @@ ocurrent/opam-staging:ubuntu-24.04-ocaml-4.13-s390x, ocurrent/opam-staging:ubunt
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-24.04-opam-riscv64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.14 --packages=ocaml-base-compiler.4.14.2
 	RUN opam pin add -k version ocaml-base-compiler 4.14.2
@@ -16166,6 +17084,7 @@ ocurrent/opam-staging:ubuntu-24.04-ocaml-4.14-s390x, ocurrent/opam-staging:ubunt
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-24.04-opam-s390x
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 5.0 --packages=ocaml-base-compiler.5.0.0
 	RUN opam pin add -k version ocaml-base-compiler 5.0.0
@@ -16178,6 +17097,7 @@ ocurrent/opam-staging:ubuntu-24.04-ocaml-4.14-s390x, ocurrent/opam-staging:ubunt
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-24.04-opam-ppc64le
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 5.0 --packages=ocaml-base-compiler.5.0.0
 	RUN opam pin add -k version ocaml-base-compiler 5.0.0
@@ -16190,6 +17110,7 @@ ocurrent/opam-staging:ubuntu-24.04-ocaml-4.14-s390x, ocurrent/opam-staging:ubunt
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-24.04-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 5.0 --packages=ocaml-base-compiler.5.0.0
 	RUN opam pin add -k version ocaml-base-compiler 5.0.0
@@ -16202,6 +17123,7 @@ ocurrent/opam-staging:ubuntu-24.04-ocaml-4.14-s390x, ocurrent/opam-staging:ubunt
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-24.04-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 5.0 --packages=ocaml-base-compiler.5.0.0
 	RUN opam pin add -k version ocaml-base-compiler 5.0.0
@@ -16214,6 +17136,7 @@ ocurrent/opam-staging:ubuntu-24.04-ocaml-4.14-s390x, ocurrent/opam-staging:ubunt
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-24.04-opam-riscv64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 5.0 --packages=ocaml-base-compiler.5.0.0
 	RUN opam pin add -k version ocaml-base-compiler 5.0.0
@@ -16228,6 +17151,7 @@ ocurrent/opam-staging:ubuntu-24.04-ocaml-5.0-s390x, ocurrent/opam-staging:ubuntu
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-24.04-opam-s390x
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
 	RUN apt-get -y update
@@ -16245,6 +17169,7 @@ ocurrent/opam-staging:ubuntu-24.04-ocaml-5.0-s390x, ocurrent/opam-staging:ubuntu
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-24.04-opam-ppc64le
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
 	RUN apt-get -y update
@@ -16262,6 +17187,7 @@ ocurrent/opam-staging:ubuntu-24.04-ocaml-5.0-s390x, ocurrent/opam-staging:ubuntu
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-24.04-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
 	RUN apt-get -y update
@@ -16279,6 +17205,7 @@ ocurrent/opam-staging:ubuntu-24.04-ocaml-5.0-s390x, ocurrent/opam-staging:ubuntu
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-24.04-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
 	RUN apt-get -y update
@@ -16296,6 +17223,7 @@ ocurrent/opam-staging:ubuntu-24.04-ocaml-5.0-s390x, ocurrent/opam-staging:ubuntu
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-24.04-opam-riscv64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
 	RUN apt-get -y update
@@ -16315,6 +17243,7 @@ ocurrent/opam-staging:ubuntu-24.04-ocaml-5.1-s390x, ocurrent/opam-staging:ubuntu
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-24.04-opam-s390x
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
 	RUN apt-get -y update
@@ -16332,6 +17261,7 @@ ocurrent/opam-staging:ubuntu-24.04-ocaml-5.1-s390x, ocurrent/opam-staging:ubuntu
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-24.04-opam-ppc64le
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
 	RUN apt-get -y update
@@ -16349,6 +17279,7 @@ ocurrent/opam-staging:ubuntu-24.04-ocaml-5.1-s390x, ocurrent/opam-staging:ubuntu
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-24.04-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
 	RUN apt-get -y update
@@ -16366,6 +17297,7 @@ ocurrent/opam-staging:ubuntu-24.04-ocaml-5.1-s390x, ocurrent/opam-staging:ubuntu
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-24.04-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
 	RUN apt-get -y update
@@ -16383,6 +17315,7 @@ ocurrent/opam-staging:ubuntu-24.04-ocaml-5.1-s390x, ocurrent/opam-staging:ubuntu
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-24.04-opam-riscv64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
 	RUN apt-get -y update
@@ -16402,6 +17335,7 @@ ocurrent/opam-staging:ubuntu-24.04-ocaml-5.2-s390x, ocurrent/opam-staging:ubuntu
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-24.04-opam-s390x
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
 	RUN apt-get -y update
@@ -16419,6 +17353,7 @@ ocurrent/opam-staging:ubuntu-24.04-ocaml-5.2-s390x, ocurrent/opam-staging:ubuntu
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-24.04-opam-ppc64le
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
 	RUN apt-get -y update
@@ -16436,6 +17371,7 @@ ocurrent/opam-staging:ubuntu-24.04-ocaml-5.2-s390x, ocurrent/opam-staging:ubuntu
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-24.04-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
 	RUN apt-get -y update
@@ -16453,6 +17389,7 @@ ocurrent/opam-staging:ubuntu-24.04-ocaml-5.2-s390x, ocurrent/opam-staging:ubuntu
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-24.04-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
 	RUN apt-get -y update
@@ -16470,6 +17407,7 @@ ocurrent/opam-staging:ubuntu-24.04-ocaml-5.2-s390x, ocurrent/opam-staging:ubuntu
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-24.04-opam-riscv64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
 	RUN apt-get -y update
@@ -16491,6 +17429,7 @@ ocurrent/opam-staging:ubuntu-24.04-ocaml-5.3-s390x, ocurrent/opam-staging:ubuntu
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-24.04-opam-s390x
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	RUN opam repo add beta git+https://github.com/ocaml/ocaml-beta-repository --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
@@ -16509,6 +17448,7 @@ ocurrent/opam-staging:ubuntu-24.04-ocaml-5.3-s390x, ocurrent/opam-staging:ubuntu
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-24.04-opam-ppc64le
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	RUN opam repo add beta git+https://github.com/ocaml/ocaml-beta-repository --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
@@ -16527,6 +17467,7 @@ ocurrent/opam-staging:ubuntu-24.04-ocaml-5.3-s390x, ocurrent/opam-staging:ubuntu
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-24.04-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	RUN opam repo add beta git+https://github.com/ocaml/ocaml-beta-repository --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
@@ -16545,6 +17486,7 @@ ocurrent/opam-staging:ubuntu-24.04-ocaml-5.3-s390x, ocurrent/opam-staging:ubuntu
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-24.04-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	RUN opam repo add beta git+https://github.com/ocaml/ocaml-beta-repository --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
@@ -16563,6 +17505,7 @@ ocurrent/opam-staging:ubuntu-24.04-ocaml-5.3-s390x, ocurrent/opam-staging:ubuntu
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-24.04-opam-riscv64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	RUN opam repo add beta git+https://github.com/ocaml/ocaml-beta-repository --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
@@ -16985,6 +17928,7 @@ ocurrent/opam-staging:ubuntu-24.10-opam-s390x, ocurrent/opam-staging:ubuntu-24.1
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-24.10-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.02 --packages=ocaml-base-compiler.4.02.3
@@ -17001,6 +17945,7 @@ ocurrent/opam-staging:ubuntu-24.10-ocaml-4.02-amd64 -> ocaml/opam:ubuntu-ocaml-4
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-24.10-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.03 --packages=ocaml-base-compiler.4.03.0
@@ -17017,6 +17962,7 @@ ocurrent/opam-staging:ubuntu-24.10-ocaml-4.03-amd64 -> ocaml/opam:ubuntu-ocaml-4
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-24.10-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.04 --packages=ocaml-base-compiler.4.04.2
@@ -17033,6 +17979,7 @@ ocurrent/opam-staging:ubuntu-24.10-ocaml-4.04-amd64 -> ocaml/opam:ubuntu-ocaml-4
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-24.10-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.05 --packages=ocaml-base-compiler.4.05.0
@@ -17049,6 +17996,7 @@ ocurrent/opam-staging:ubuntu-24.10-ocaml-4.05-amd64 -> ocaml/opam:ubuntu-ocaml-4
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-24.10-opam-s390x
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.06 --packages=ocaml-base-compiler.4.06.1
@@ -17063,6 +18011,7 @@ ocurrent/opam-staging:ubuntu-24.10-ocaml-4.05-amd64 -> ocaml/opam:ubuntu-ocaml-4
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-24.10-opam-ppc64le
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.06 --packages=ocaml-base-compiler.4.06.1
@@ -17077,6 +18026,7 @@ ocurrent/opam-staging:ubuntu-24.10-ocaml-4.05-amd64 -> ocaml/opam:ubuntu-ocaml-4
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-24.10-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.06 --packages=ocaml-base-compiler.4.06.1
@@ -17091,6 +18041,7 @@ ocurrent/opam-staging:ubuntu-24.10-ocaml-4.05-amd64 -> ocaml/opam:ubuntu-ocaml-4
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-24.10-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.06 --packages=ocaml-base-compiler.4.06.1
@@ -17107,6 +18058,7 @@ ocurrent/opam-staging:ubuntu-24.10-ocaml-4.06-s390x, ocurrent/opam-staging:ubunt
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-24.10-opam-s390x
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.07 --packages=ocaml-base-compiler.4.07.1
@@ -17121,6 +18073,7 @@ ocurrent/opam-staging:ubuntu-24.10-ocaml-4.06-s390x, ocurrent/opam-staging:ubunt
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-24.10-opam-ppc64le
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.07 --packages=ocaml-base-compiler.4.07.1
@@ -17135,6 +18088,7 @@ ocurrent/opam-staging:ubuntu-24.10-ocaml-4.06-s390x, ocurrent/opam-staging:ubunt
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-24.10-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.07 --packages=ocaml-base-compiler.4.07.1
@@ -17149,6 +18103,7 @@ ocurrent/opam-staging:ubuntu-24.10-ocaml-4.06-s390x, ocurrent/opam-staging:ubunt
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-24.10-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.07 --packages=ocaml-base-compiler.4.07.1
@@ -17165,6 +18120,7 @@ ocurrent/opam-staging:ubuntu-24.10-ocaml-4.07-s390x, ocurrent/opam-staging:ubunt
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-24.10-opam-s390x
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.08 --packages=ocaml-base-compiler.4.08.1
 	RUN opam pin add -k version ocaml-base-compiler 4.08.1
@@ -17177,6 +18133,7 @@ ocurrent/opam-staging:ubuntu-24.10-ocaml-4.07-s390x, ocurrent/opam-staging:ubunt
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-24.10-opam-ppc64le
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.08 --packages=ocaml-base-compiler.4.08.1
 	RUN opam pin add -k version ocaml-base-compiler 4.08.1
@@ -17189,6 +18146,7 @@ ocurrent/opam-staging:ubuntu-24.10-ocaml-4.07-s390x, ocurrent/opam-staging:ubunt
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-24.10-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.08 --packages=ocaml-base-compiler.4.08.1
 	RUN opam pin add -k version ocaml-base-compiler 4.08.1
@@ -17201,6 +18159,7 @@ ocurrent/opam-staging:ubuntu-24.10-ocaml-4.07-s390x, ocurrent/opam-staging:ubunt
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-24.10-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.08 --packages=ocaml-base-compiler.4.08.1
 	RUN opam pin add -k version ocaml-base-compiler 4.08.1
@@ -17215,6 +18174,7 @@ ocurrent/opam-staging:ubuntu-24.10-ocaml-4.08-s390x, ocurrent/opam-staging:ubunt
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-24.10-opam-s390x
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.09 --packages=ocaml-base-compiler.4.09.1
 	RUN opam pin add -k version ocaml-base-compiler 4.09.1
@@ -17227,6 +18187,7 @@ ocurrent/opam-staging:ubuntu-24.10-ocaml-4.08-s390x, ocurrent/opam-staging:ubunt
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-24.10-opam-ppc64le
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.09 --packages=ocaml-base-compiler.4.09.1
 	RUN opam pin add -k version ocaml-base-compiler 4.09.1
@@ -17239,6 +18200,7 @@ ocurrent/opam-staging:ubuntu-24.10-ocaml-4.08-s390x, ocurrent/opam-staging:ubunt
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-24.10-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.09 --packages=ocaml-base-compiler.4.09.1
 	RUN opam pin add -k version ocaml-base-compiler 4.09.1
@@ -17251,6 +18213,7 @@ ocurrent/opam-staging:ubuntu-24.10-ocaml-4.08-s390x, ocurrent/opam-staging:ubunt
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-24.10-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.09 --packages=ocaml-base-compiler.4.09.1
 	RUN opam pin add -k version ocaml-base-compiler 4.09.1
@@ -17265,6 +18228,7 @@ ocurrent/opam-staging:ubuntu-24.10-ocaml-4.09-s390x, ocurrent/opam-staging:ubunt
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-24.10-opam-s390x
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.10 --packages=ocaml-base-compiler.4.10.2
 	RUN opam pin add -k version ocaml-base-compiler 4.10.2
@@ -17277,6 +18241,7 @@ ocurrent/opam-staging:ubuntu-24.10-ocaml-4.09-s390x, ocurrent/opam-staging:ubunt
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-24.10-opam-ppc64le
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.10 --packages=ocaml-base-compiler.4.10.2
 	RUN opam pin add -k version ocaml-base-compiler 4.10.2
@@ -17289,6 +18254,7 @@ ocurrent/opam-staging:ubuntu-24.10-ocaml-4.09-s390x, ocurrent/opam-staging:ubunt
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-24.10-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.10 --packages=ocaml-base-compiler.4.10.2
 	RUN opam pin add -k version ocaml-base-compiler 4.10.2
@@ -17301,6 +18267,7 @@ ocurrent/opam-staging:ubuntu-24.10-ocaml-4.09-s390x, ocurrent/opam-staging:ubunt
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-24.10-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.10 --packages=ocaml-base-compiler.4.10.2
 	RUN opam pin add -k version ocaml-base-compiler 4.10.2
@@ -17315,6 +18282,7 @@ ocurrent/opam-staging:ubuntu-24.10-ocaml-4.10-s390x, ocurrent/opam-staging:ubunt
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-24.10-opam-s390x
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.11 --packages=ocaml-base-compiler.4.11.2
 	RUN opam pin add -k version ocaml-base-compiler 4.11.2
@@ -17327,6 +18295,7 @@ ocurrent/opam-staging:ubuntu-24.10-ocaml-4.10-s390x, ocurrent/opam-staging:ubunt
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-24.10-opam-ppc64le
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.11 --packages=ocaml-base-compiler.4.11.2
 	RUN opam pin add -k version ocaml-base-compiler 4.11.2
@@ -17339,6 +18308,7 @@ ocurrent/opam-staging:ubuntu-24.10-ocaml-4.10-s390x, ocurrent/opam-staging:ubunt
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-24.10-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.11 --packages=ocaml-base-compiler.4.11.2
 	RUN opam pin add -k version ocaml-base-compiler 4.11.2
@@ -17351,6 +18321,7 @@ ocurrent/opam-staging:ubuntu-24.10-ocaml-4.10-s390x, ocurrent/opam-staging:ubunt
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-24.10-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.11 --packages=ocaml-base-compiler.4.11.2
 	RUN opam pin add -k version ocaml-base-compiler 4.11.2
@@ -17363,6 +18334,7 @@ ocurrent/opam-staging:ubuntu-24.10-ocaml-4.10-s390x, ocurrent/opam-staging:ubunt
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-24.10-opam-riscv64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.11 --packages=ocaml-base-compiler.4.11.2
 	RUN opam pin add -k version ocaml-base-compiler 4.11.2
@@ -17377,6 +18349,7 @@ ocurrent/opam-staging:ubuntu-24.10-ocaml-4.11-s390x, ocurrent/opam-staging:ubunt
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-24.10-opam-s390x
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.12 --packages=ocaml-base-compiler.4.12.1
 	RUN opam pin add -k version ocaml-base-compiler 4.12.1
@@ -17389,6 +18362,7 @@ ocurrent/opam-staging:ubuntu-24.10-ocaml-4.11-s390x, ocurrent/opam-staging:ubunt
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-24.10-opam-ppc64le
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.12 --packages=ocaml-base-compiler.4.12.1
 	RUN opam pin add -k version ocaml-base-compiler 4.12.1
@@ -17401,6 +18375,7 @@ ocurrent/opam-staging:ubuntu-24.10-ocaml-4.11-s390x, ocurrent/opam-staging:ubunt
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-24.10-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.12 --packages=ocaml-base-compiler.4.12.1
 	RUN opam pin add -k version ocaml-base-compiler 4.12.1
@@ -17413,6 +18388,7 @@ ocurrent/opam-staging:ubuntu-24.10-ocaml-4.11-s390x, ocurrent/opam-staging:ubunt
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-24.10-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.12 --packages=ocaml-base-compiler.4.12.1
 	RUN opam pin add -k version ocaml-base-compiler 4.12.1
@@ -17425,6 +18401,7 @@ ocurrent/opam-staging:ubuntu-24.10-ocaml-4.11-s390x, ocurrent/opam-staging:ubunt
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-24.10-opam-riscv64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.12 --packages=ocaml-base-compiler.4.12.1
 	RUN opam pin add -k version ocaml-base-compiler 4.12.1
@@ -17439,6 +18416,7 @@ ocurrent/opam-staging:ubuntu-24.10-ocaml-4.12-s390x, ocurrent/opam-staging:ubunt
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-24.10-opam-s390x
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.13 --packages=ocaml-base-compiler.4.13.1
 	RUN opam pin add -k version ocaml-base-compiler 4.13.1
@@ -17451,6 +18429,7 @@ ocurrent/opam-staging:ubuntu-24.10-ocaml-4.12-s390x, ocurrent/opam-staging:ubunt
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-24.10-opam-ppc64le
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.13 --packages=ocaml-base-compiler.4.13.1
 	RUN opam pin add -k version ocaml-base-compiler 4.13.1
@@ -17463,6 +18442,7 @@ ocurrent/opam-staging:ubuntu-24.10-ocaml-4.12-s390x, ocurrent/opam-staging:ubunt
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-24.10-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.13 --packages=ocaml-base-compiler.4.13.1
 	RUN opam pin add -k version ocaml-base-compiler 4.13.1
@@ -17475,6 +18455,7 @@ ocurrent/opam-staging:ubuntu-24.10-ocaml-4.12-s390x, ocurrent/opam-staging:ubunt
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-24.10-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.13 --packages=ocaml-base-compiler.4.13.1
 	RUN opam pin add -k version ocaml-base-compiler 4.13.1
@@ -17487,6 +18468,7 @@ ocurrent/opam-staging:ubuntu-24.10-ocaml-4.12-s390x, ocurrent/opam-staging:ubunt
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-24.10-opam-riscv64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.13 --packages=ocaml-base-compiler.4.13.1
 	RUN opam pin add -k version ocaml-base-compiler 4.13.1
@@ -17501,6 +18483,7 @@ ocurrent/opam-staging:ubuntu-24.10-ocaml-4.13-s390x, ocurrent/opam-staging:ubunt
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-24.10-opam-s390x
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.14 --packages=ocaml-base-compiler.4.14.2
 	RUN opam pin add -k version ocaml-base-compiler 4.14.2
@@ -17513,6 +18496,7 @@ ocurrent/opam-staging:ubuntu-24.10-ocaml-4.13-s390x, ocurrent/opam-staging:ubunt
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-24.10-opam-ppc64le
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.14 --packages=ocaml-base-compiler.4.14.2
 	RUN opam pin add -k version ocaml-base-compiler 4.14.2
@@ -17525,6 +18509,7 @@ ocurrent/opam-staging:ubuntu-24.10-ocaml-4.13-s390x, ocurrent/opam-staging:ubunt
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-24.10-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.14 --packages=ocaml-base-compiler.4.14.2
 	RUN opam pin add -k version ocaml-base-compiler 4.14.2
@@ -17537,6 +18522,7 @@ ocurrent/opam-staging:ubuntu-24.10-ocaml-4.13-s390x, ocurrent/opam-staging:ubunt
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-24.10-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.14 --packages=ocaml-base-compiler.4.14.2
 	RUN opam pin add -k version ocaml-base-compiler 4.14.2
@@ -17549,6 +18535,7 @@ ocurrent/opam-staging:ubuntu-24.10-ocaml-4.13-s390x, ocurrent/opam-staging:ubunt
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-24.10-opam-riscv64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.14 --packages=ocaml-base-compiler.4.14.2
 	RUN opam pin add -k version ocaml-base-compiler 4.14.2
@@ -17563,6 +18550,7 @@ ocurrent/opam-staging:ubuntu-24.10-ocaml-4.14-s390x, ocurrent/opam-staging:ubunt
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-24.10-opam-s390x
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 5.0 --packages=ocaml-base-compiler.5.0.0
 	RUN opam pin add -k version ocaml-base-compiler 5.0.0
@@ -17575,6 +18563,7 @@ ocurrent/opam-staging:ubuntu-24.10-ocaml-4.14-s390x, ocurrent/opam-staging:ubunt
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-24.10-opam-ppc64le
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 5.0 --packages=ocaml-base-compiler.5.0.0
 	RUN opam pin add -k version ocaml-base-compiler 5.0.0
@@ -17587,6 +18576,7 @@ ocurrent/opam-staging:ubuntu-24.10-ocaml-4.14-s390x, ocurrent/opam-staging:ubunt
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-24.10-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 5.0 --packages=ocaml-base-compiler.5.0.0
 	RUN opam pin add -k version ocaml-base-compiler 5.0.0
@@ -17599,6 +18589,7 @@ ocurrent/opam-staging:ubuntu-24.10-ocaml-4.14-s390x, ocurrent/opam-staging:ubunt
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-24.10-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 5.0 --packages=ocaml-base-compiler.5.0.0
 	RUN opam pin add -k version ocaml-base-compiler 5.0.0
@@ -17611,6 +18602,7 @@ ocurrent/opam-staging:ubuntu-24.10-ocaml-4.14-s390x, ocurrent/opam-staging:ubunt
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-24.10-opam-riscv64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 5.0 --packages=ocaml-base-compiler.5.0.0
 	RUN opam pin add -k version ocaml-base-compiler 5.0.0
@@ -17625,6 +18617,7 @@ ocurrent/opam-staging:ubuntu-24.10-ocaml-5.0-s390x, ocurrent/opam-staging:ubuntu
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-24.10-opam-s390x
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
 	RUN apt-get -y update
@@ -17642,6 +18635,7 @@ ocurrent/opam-staging:ubuntu-24.10-ocaml-5.0-s390x, ocurrent/opam-staging:ubuntu
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-24.10-opam-ppc64le
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
 	RUN apt-get -y update
@@ -17659,6 +18653,7 @@ ocurrent/opam-staging:ubuntu-24.10-ocaml-5.0-s390x, ocurrent/opam-staging:ubuntu
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-24.10-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
 	RUN apt-get -y update
@@ -17676,6 +18671,7 @@ ocurrent/opam-staging:ubuntu-24.10-ocaml-5.0-s390x, ocurrent/opam-staging:ubuntu
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-24.10-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
 	RUN apt-get -y update
@@ -17693,6 +18689,7 @@ ocurrent/opam-staging:ubuntu-24.10-ocaml-5.0-s390x, ocurrent/opam-staging:ubuntu
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-24.10-opam-riscv64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
 	RUN apt-get -y update
@@ -17712,6 +18709,7 @@ ocurrent/opam-staging:ubuntu-24.10-ocaml-5.1-s390x, ocurrent/opam-staging:ubuntu
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-24.10-opam-s390x
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
 	RUN apt-get -y update
@@ -17729,6 +18727,7 @@ ocurrent/opam-staging:ubuntu-24.10-ocaml-5.1-s390x, ocurrent/opam-staging:ubuntu
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-24.10-opam-ppc64le
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
 	RUN apt-get -y update
@@ -17746,6 +18745,7 @@ ocurrent/opam-staging:ubuntu-24.10-ocaml-5.1-s390x, ocurrent/opam-staging:ubuntu
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-24.10-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
 	RUN apt-get -y update
@@ -17763,6 +18763,7 @@ ocurrent/opam-staging:ubuntu-24.10-ocaml-5.1-s390x, ocurrent/opam-staging:ubuntu
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-24.10-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
 	RUN apt-get -y update
@@ -17780,6 +18781,7 @@ ocurrent/opam-staging:ubuntu-24.10-ocaml-5.1-s390x, ocurrent/opam-staging:ubuntu
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-24.10-opam-riscv64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
 	RUN apt-get -y update
@@ -17799,6 +18801,7 @@ ocurrent/opam-staging:ubuntu-24.10-ocaml-5.2-s390x, ocurrent/opam-staging:ubuntu
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-24.10-opam-s390x
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
 	RUN apt-get -y update
@@ -17816,6 +18819,7 @@ ocurrent/opam-staging:ubuntu-24.10-ocaml-5.2-s390x, ocurrent/opam-staging:ubuntu
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-24.10-opam-ppc64le
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
 	RUN apt-get -y update
@@ -17833,6 +18837,7 @@ ocurrent/opam-staging:ubuntu-24.10-ocaml-5.2-s390x, ocurrent/opam-staging:ubuntu
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-24.10-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
 	RUN apt-get -y update
@@ -17850,6 +18855,7 @@ ocurrent/opam-staging:ubuntu-24.10-ocaml-5.2-s390x, ocurrent/opam-staging:ubuntu
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-24.10-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
 	RUN apt-get -y update
@@ -17867,6 +18873,7 @@ ocurrent/opam-staging:ubuntu-24.10-ocaml-5.2-s390x, ocurrent/opam-staging:ubuntu
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-24.10-opam-riscv64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
 	RUN apt-get -y update
@@ -17888,6 +18895,7 @@ ocurrent/opam-staging:ubuntu-24.10-ocaml-5.3-s390x, ocurrent/opam-staging:ubuntu
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-24.10-opam-s390x
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	RUN opam repo add beta git+https://github.com/ocaml/ocaml-beta-repository --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
@@ -17906,6 +18914,7 @@ ocurrent/opam-staging:ubuntu-24.10-ocaml-5.3-s390x, ocurrent/opam-staging:ubuntu
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-24.10-opam-ppc64le
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	RUN opam repo add beta git+https://github.com/ocaml/ocaml-beta-repository --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
@@ -17924,6 +18933,7 @@ ocurrent/opam-staging:ubuntu-24.10-ocaml-5.3-s390x, ocurrent/opam-staging:ubuntu
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-24.10-opam-arm64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	RUN opam repo add beta git+https://github.com/ocaml/ocaml-beta-repository --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
@@ -17942,6 +18952,7 @@ ocurrent/opam-staging:ubuntu-24.10-ocaml-5.3-s390x, ocurrent/opam-staging:ubuntu
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-24.10-opam-amd64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	RUN opam repo add beta git+https://github.com/ocaml/ocaml-beta-repository --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
@@ -17960,6 +18971,7 @@ ocurrent/opam-staging:ubuntu-24.10-ocaml-5.3-s390x, ocurrent/opam-staging:ubuntu
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-24.10-opam-riscv64
+	RUN opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	RUN opam repo add beta git+https://github.com/ocaml/ocaml-beta-repository --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	USER root
@@ -18065,6 +19077,7 @@ windows-server-mingw-ltsc2022/amd64
 	# escape=`
 
 	FROM ocurrent/opam-staging:windows-server-mingw-ltsc2022-opam-amd64
+	RUN ocaml-env exec --64 -- opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN ocaml-env exec --64 --no-opam -- opam switch create 4.14 --packages=ocaml-variants.4.14.2+mingw64
 	RUN ocaml-env exec --64 -- opam pin add -k version ocaml-variants 4.14.2+mingw64
@@ -18162,6 +19175,7 @@ windows-mingw-ltsc2019/amd64
 	# escape=`
 
 	FROM ocurrent/opam-staging:windows-mingw-ltsc2019-opam-amd64
+	RUN ocaml-env exec --64 -- opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN ocaml-env exec --64 --no-opam -- opam switch create 4.14 --packages=ocaml-variants.4.14.2+mingw64
 	RUN ocaml-env exec --64 -- opam pin add -k version ocaml-variants 4.14.2+mingw64
@@ -18175,6 +19189,7 @@ ocurrent/opam-staging:windows-server-mingw-ltsc2022-ocaml-4.14-amd64, ocurrent/o
 	# escape=`
 
 	FROM ocurrent/opam-staging:windows-server-mingw-ltsc2022-opam-amd64
+	RUN ocaml-env exec --64 -- opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN ocaml-env exec --64 --no-opam -- opam switch create 4.13 --packages=ocaml-variants.4.13.1+mingw64
 	RUN ocaml-env exec --64 -- opam pin add -k version ocaml-variants 4.13.1+mingw64
@@ -18187,6 +19202,7 @@ ocurrent/opam-staging:windows-server-mingw-ltsc2022-ocaml-4.14-amd64, ocurrent/o
 	# escape=`
 
 	FROM ocurrent/opam-staging:windows-mingw-ltsc2019-opam-amd64
+	RUN ocaml-env exec --64 -- opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN ocaml-env exec --64 --no-opam -- opam switch create 4.13 --packages=ocaml-variants.4.13.1+mingw64
 	RUN ocaml-env exec --64 -- opam pin add -k version ocaml-variants 4.13.1+mingw64
@@ -18200,6 +19216,7 @@ ocurrent/opam-staging:windows-server-mingw-ltsc2022-ocaml-4.13-amd64, ocurrent/o
 	# escape=`
 
 	FROM ocurrent/opam-staging:windows-server-mingw-ltsc2022-opam-amd64
+	RUN ocaml-env exec --64 -- opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN ocaml-env exec --64 --no-opam -- opam switch create 4.12 --packages=ocaml-variants.4.12.1+mingw64
 	RUN ocaml-env exec --64 -- opam pin add -k version ocaml-variants 4.12.1+mingw64
@@ -18212,6 +19229,7 @@ ocurrent/opam-staging:windows-server-mingw-ltsc2022-ocaml-4.13-amd64, ocurrent/o
 	# escape=`
 
 	FROM ocurrent/opam-staging:windows-mingw-ltsc2019-opam-amd64
+	RUN ocaml-env exec --64 -- opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN ocaml-env exec --64 --no-opam -- opam switch create 4.12 --packages=ocaml-variants.4.12.1+mingw64
 	RUN ocaml-env exec --64 -- opam pin add -k version ocaml-variants 4.12.1+mingw64
@@ -18225,6 +19243,7 @@ ocurrent/opam-staging:windows-server-mingw-ltsc2022-ocaml-4.12-amd64, ocurrent/o
 	# escape=`
 
 	FROM ocurrent/opam-staging:windows-server-mingw-ltsc2022-opam-amd64
+	RUN ocaml-env exec --64 -- opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN ocaml-env exec --64 --no-opam -- opam switch create 4.11 --packages=ocaml-variants.4.11.2+mingw64
 	RUN ocaml-env exec --64 -- opam pin add -k version ocaml-variants 4.11.2+mingw64
@@ -18237,6 +19256,7 @@ ocurrent/opam-staging:windows-server-mingw-ltsc2022-ocaml-4.12-amd64, ocurrent/o
 	# escape=`
 
 	FROM ocurrent/opam-staging:windows-mingw-ltsc2019-opam-amd64
+	RUN ocaml-env exec --64 -- opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN ocaml-env exec --64 --no-opam -- opam switch create 4.11 --packages=ocaml-variants.4.11.2+mingw64
 	RUN ocaml-env exec --64 -- opam pin add -k version ocaml-variants 4.11.2+mingw64
@@ -18250,6 +19270,7 @@ ocurrent/opam-staging:windows-server-mingw-ltsc2022-ocaml-4.11-amd64, ocurrent/o
 	# escape=`
 
 	FROM ocurrent/opam-staging:windows-server-mingw-ltsc2022-opam-amd64
+	RUN ocaml-env exec --64 -- opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN ocaml-env exec --64 --no-opam -- opam switch create 4.10 --packages=ocaml-variants.4.10.2+mingw64
 	RUN ocaml-env exec --64 -- opam pin add -k version ocaml-variants 4.10.2+mingw64
@@ -18262,6 +19283,7 @@ ocurrent/opam-staging:windows-server-mingw-ltsc2022-ocaml-4.11-amd64, ocurrent/o
 	# escape=`
 
 	FROM ocurrent/opam-staging:windows-mingw-ltsc2019-opam-amd64
+	RUN ocaml-env exec --64 -- opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN ocaml-env exec --64 --no-opam -- opam switch create 4.10 --packages=ocaml-variants.4.10.2+mingw64
 	RUN ocaml-env exec --64 -- opam pin add -k version ocaml-variants 4.10.2+mingw64
@@ -18275,6 +19297,7 @@ ocurrent/opam-staging:windows-server-mingw-ltsc2022-ocaml-4.10-amd64, ocurrent/o
 	# escape=`
 
 	FROM ocurrent/opam-staging:windows-server-mingw-ltsc2022-opam-amd64
+	RUN ocaml-env exec --64 -- opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN ocaml-env exec --64 --no-opam -- opam switch create 4.09 --packages=ocaml-variants.4.09.1+mingw64
 	RUN ocaml-env exec --64 -- opam pin add -k version ocaml-variants 4.09.1+mingw64
@@ -18287,6 +19310,7 @@ ocurrent/opam-staging:windows-server-mingw-ltsc2022-ocaml-4.10-amd64, ocurrent/o
 	# escape=`
 
 	FROM ocurrent/opam-staging:windows-mingw-ltsc2019-opam-amd64
+	RUN ocaml-env exec --64 -- opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN ocaml-env exec --64 --no-opam -- opam switch create 4.09 --packages=ocaml-variants.4.09.1+mingw64
 	RUN ocaml-env exec --64 -- opam pin add -k version ocaml-variants 4.09.1+mingw64
@@ -18300,6 +19324,7 @@ ocurrent/opam-staging:windows-server-mingw-ltsc2022-ocaml-4.09-amd64, ocurrent/o
 	# escape=`
 
 	FROM ocurrent/opam-staging:windows-server-mingw-ltsc2022-opam-amd64
+	RUN ocaml-env exec --64 -- opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN ocaml-env exec --64 --no-opam -- opam switch create 4.08 --packages=ocaml-variants.4.08.1+mingw64
 	RUN ocaml-env exec --64 -- opam pin add -k version ocaml-variants 4.08.1+mingw64
@@ -18312,6 +19337,7 @@ ocurrent/opam-staging:windows-server-mingw-ltsc2022-ocaml-4.09-amd64, ocurrent/o
 	# escape=`
 
 	FROM ocurrent/opam-staging:windows-mingw-ltsc2019-opam-amd64
+	RUN ocaml-env exec --64 -- opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN ocaml-env exec --64 --no-opam -- opam switch create 4.08 --packages=ocaml-variants.4.08.1+mingw64
 	RUN ocaml-env exec --64 -- opam pin add -k version ocaml-variants 4.08.1+mingw64
@@ -18325,6 +19351,7 @@ ocurrent/opam-staging:windows-server-mingw-ltsc2022-ocaml-4.08-amd64, ocurrent/o
 	# escape=`
 
 	FROM ocurrent/opam-staging:windows-server-mingw-ltsc2022-opam-amd64
+	RUN ocaml-env exec --64 -- opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN ocaml-env exec --64 --no-opam -- opam switch create 4.07 --packages=ocaml-variants.4.07.1+mingw64
 	RUN ocaml-env exec --64 -- opam pin add -k version ocaml-variants 4.07.1+mingw64
@@ -18337,6 +19364,7 @@ ocurrent/opam-staging:windows-server-mingw-ltsc2022-ocaml-4.08-amd64, ocurrent/o
 	# escape=`
 
 	FROM ocurrent/opam-staging:windows-mingw-ltsc2019-opam-amd64
+	RUN ocaml-env exec --64 -- opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN ocaml-env exec --64 --no-opam -- opam switch create 4.07 --packages=ocaml-variants.4.07.1+mingw64
 	RUN ocaml-env exec --64 -- opam pin add -k version ocaml-variants 4.07.1+mingw64
@@ -18350,6 +19378,7 @@ ocurrent/opam-staging:windows-server-mingw-ltsc2022-ocaml-4.07-amd64, ocurrent/o
 	# escape=`
 
 	FROM ocurrent/opam-staging:windows-server-mingw-ltsc2022-opam-amd64
+	RUN ocaml-env exec --64 -- opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN ocaml-env exec --64 --no-opam -- opam switch create 4.06 --packages=ocaml-variants.4.06.1+mingw64
 	RUN ocaml-env exec --64 -- opam pin add -k version ocaml-variants 4.06.1+mingw64
@@ -18362,6 +19391,7 @@ ocurrent/opam-staging:windows-server-mingw-ltsc2022-ocaml-4.07-amd64, ocurrent/o
 	# escape=`
 
 	FROM ocurrent/opam-staging:windows-mingw-ltsc2019-opam-amd64
+	RUN ocaml-env exec --64 -- opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN ocaml-env exec --64 --no-opam -- opam switch create 4.06 --packages=ocaml-variants.4.06.1+mingw64
 	RUN ocaml-env exec --64 -- opam pin add -k version ocaml-variants 4.06.1+mingw64
@@ -18375,6 +19405,7 @@ ocurrent/opam-staging:windows-server-mingw-ltsc2022-ocaml-4.06-amd64, ocurrent/o
 	# escape=`
 
 	FROM ocurrent/opam-staging:windows-server-mingw-ltsc2022-opam-amd64
+	RUN ocaml-env exec --64 -- opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN ocaml-env exec --64 --no-opam -- opam switch create 4.05 --packages=ocaml-variants.4.05.0+mingw64
 	RUN ocaml-env exec --64 -- opam pin add -k version ocaml-variants 4.05.0+mingw64
@@ -18387,6 +19418,7 @@ ocurrent/opam-staging:windows-server-mingw-ltsc2022-ocaml-4.06-amd64, ocurrent/o
 	# escape=`
 
 	FROM ocurrent/opam-staging:windows-mingw-ltsc2019-opam-amd64
+	RUN ocaml-env exec --64 -- opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN ocaml-env exec --64 --no-opam -- opam switch create 4.05 --packages=ocaml-variants.4.05.0+mingw64
 	RUN ocaml-env exec --64 -- opam pin add -k version ocaml-variants 4.05.0+mingw64
@@ -18400,6 +19432,7 @@ ocurrent/opam-staging:windows-server-mingw-ltsc2022-ocaml-4.05-amd64, ocurrent/o
 	# escape=`
 
 	FROM ocurrent/opam-staging:windows-server-mingw-ltsc2022-opam-amd64
+	RUN ocaml-env exec --64 -- opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN ocaml-env exec --64 --no-opam -- opam switch create 4.04 --packages=ocaml-variants.4.04.2+mingw64
 	RUN ocaml-env exec --64 -- opam pin add -k version ocaml-variants 4.04.2+mingw64
@@ -18412,6 +19445,7 @@ ocurrent/opam-staging:windows-server-mingw-ltsc2022-ocaml-4.05-amd64, ocurrent/o
 	# escape=`
 
 	FROM ocurrent/opam-staging:windows-mingw-ltsc2019-opam-amd64
+	RUN ocaml-env exec --64 -- opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN ocaml-env exec --64 --no-opam -- opam switch create 4.04 --packages=ocaml-variants.4.04.2+mingw64
 	RUN ocaml-env exec --64 -- opam pin add -k version ocaml-variants 4.04.2+mingw64
@@ -18425,6 +19459,7 @@ ocurrent/opam-staging:windows-server-mingw-ltsc2022-ocaml-4.04-amd64, ocurrent/o
 	# escape=`
 
 	FROM ocurrent/opam-staging:windows-server-mingw-ltsc2022-opam-amd64
+	RUN ocaml-env exec --64 -- opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN ocaml-env exec --64 --no-opam -- opam switch create 4.03 --packages=ocaml-variants.4.03.0+mingw64
 	RUN ocaml-env exec --64 -- opam pin add -k version ocaml-variants 4.03.0+mingw64
@@ -18437,6 +19472,7 @@ ocurrent/opam-staging:windows-server-mingw-ltsc2022-ocaml-4.04-amd64, ocurrent/o
 	# escape=`
 
 	FROM ocurrent/opam-staging:windows-mingw-ltsc2019-opam-amd64
+	RUN ocaml-env exec --64 -- opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN ocaml-env exec --64 --no-opam -- opam switch create 4.03 --packages=ocaml-variants.4.03.0+mingw64
 	RUN ocaml-env exec --64 -- opam pin add -k version ocaml-variants 4.03.0+mingw64
@@ -18450,6 +19486,7 @@ ocurrent/opam-staging:windows-server-mingw-ltsc2022-ocaml-4.03-amd64, ocurrent/o
 	# escape=`
 
 	FROM ocurrent/opam-staging:windows-server-mingw-ltsc2022-opam-amd64
+	RUN ocaml-env exec --64 -- opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN ocaml-env exec --64 --no-opam -- opam switch create 4.02 --packages=ocaml-variants.4.02.3+mingw64
 	RUN ocaml-env exec --64 -- opam pin add -k version ocaml-variants 4.02.3+mingw64
@@ -18462,6 +19499,7 @@ ocurrent/opam-staging:windows-server-mingw-ltsc2022-ocaml-4.03-amd64, ocurrent/o
 	# escape=`
 
 	FROM ocurrent/opam-staging:windows-mingw-ltsc2019-opam-amd64
+	RUN ocaml-env exec --64 -- opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN ocaml-env exec --64 --no-opam -- opam switch create 4.02 --packages=ocaml-variants.4.02.3+mingw64
 	RUN ocaml-env exec --64 -- opam pin add -k version ocaml-variants 4.02.3+mingw64
@@ -18621,6 +19659,7 @@ windows-server-msvc-ltsc2022/amd64
 	# escape=`
 
 	FROM ocurrent/opam-staging:windows-server-msvc-ltsc2022-opam-amd64
+	RUN ocaml-env exec --64 --ms -- opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN ocaml-env exec --64 --ms --no-opam -- opam switch create 4.14 --packages=ocaml-variants.4.14.2+msvc64
 	RUN ocaml-env exec --64 --ms -- opam pin add -k version ocaml-variants 4.14.2+msvc64
@@ -18724,6 +19763,7 @@ windows-msvc-ltsc2019/amd64
 	# escape=`
 
 	FROM ocurrent/opam-staging:windows-msvc-ltsc2019-opam-amd64
+	RUN ocaml-env exec --64 --ms -- opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN ocaml-env exec --64 --ms --no-opam -- opam switch create 4.14 --packages=ocaml-variants.4.14.2+msvc64
 	RUN ocaml-env exec --64 --ms -- opam pin add -k version ocaml-variants 4.14.2+msvc64
@@ -18737,6 +19777,7 @@ ocurrent/opam-staging:windows-server-msvc-ltsc2022-ocaml-4.14-amd64, ocurrent/op
 	# escape=`
 
 	FROM ocurrent/opam-staging:windows-server-msvc-ltsc2022-opam-amd64
+	RUN ocaml-env exec --64 --ms -- opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN ocaml-env exec --64 --ms --no-opam -- opam switch create 4.13 --packages=ocaml-variants.4.13.1+msvc64
 	RUN ocaml-env exec --64 --ms -- opam pin add -k version ocaml-variants 4.13.1+msvc64
@@ -18749,6 +19790,7 @@ ocurrent/opam-staging:windows-server-msvc-ltsc2022-ocaml-4.14-amd64, ocurrent/op
 	# escape=`
 
 	FROM ocurrent/opam-staging:windows-msvc-ltsc2019-opam-amd64
+	RUN ocaml-env exec --64 --ms -- opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN ocaml-env exec --64 --ms --no-opam -- opam switch create 4.13 --packages=ocaml-variants.4.13.1+msvc64
 	RUN ocaml-env exec --64 --ms -- opam pin add -k version ocaml-variants 4.13.1+msvc64
@@ -18762,6 +19804,7 @@ ocurrent/opam-staging:windows-server-msvc-ltsc2022-ocaml-4.13-amd64, ocurrent/op
 	# escape=`
 
 	FROM ocurrent/opam-staging:windows-server-msvc-ltsc2022-opam-amd64
+	RUN ocaml-env exec --64 --ms -- opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN ocaml-env exec --64 --ms --no-opam -- opam switch create 4.12 --packages=ocaml-variants.4.12.1+msvc64
 	RUN ocaml-env exec --64 --ms -- opam pin add -k version ocaml-variants 4.12.1+msvc64
@@ -18774,6 +19817,7 @@ ocurrent/opam-staging:windows-server-msvc-ltsc2022-ocaml-4.13-amd64, ocurrent/op
 	# escape=`
 
 	FROM ocurrent/opam-staging:windows-msvc-ltsc2019-opam-amd64
+	RUN ocaml-env exec --64 --ms -- opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN ocaml-env exec --64 --ms --no-opam -- opam switch create 4.12 --packages=ocaml-variants.4.12.1+msvc64
 	RUN ocaml-env exec --64 --ms -- opam pin add -k version ocaml-variants 4.12.1+msvc64
@@ -18787,6 +19831,7 @@ ocurrent/opam-staging:windows-server-msvc-ltsc2022-ocaml-4.12-amd64, ocurrent/op
 	# escape=`
 
 	FROM ocurrent/opam-staging:windows-server-msvc-ltsc2022-opam-amd64
+	RUN ocaml-env exec --64 --ms -- opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN ocaml-env exec --64 --ms --no-opam -- opam switch create 4.11 --packages=ocaml-variants.4.11.2+msvc64
 	RUN ocaml-env exec --64 --ms -- opam pin add -k version ocaml-variants 4.11.2+msvc64
@@ -18799,6 +19844,7 @@ ocurrent/opam-staging:windows-server-msvc-ltsc2022-ocaml-4.12-amd64, ocurrent/op
 	# escape=`
 
 	FROM ocurrent/opam-staging:windows-msvc-ltsc2019-opam-amd64
+	RUN ocaml-env exec --64 --ms -- opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN ocaml-env exec --64 --ms --no-opam -- opam switch create 4.11 --packages=ocaml-variants.4.11.2+msvc64
 	RUN ocaml-env exec --64 --ms -- opam pin add -k version ocaml-variants 4.11.2+msvc64
@@ -18812,6 +19858,7 @@ ocurrent/opam-staging:windows-server-msvc-ltsc2022-ocaml-4.11-amd64, ocurrent/op
 	# escape=`
 
 	FROM ocurrent/opam-staging:windows-server-msvc-ltsc2022-opam-amd64
+	RUN ocaml-env exec --64 --ms -- opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN ocaml-env exec --64 --ms --no-opam -- opam switch create 4.10 --packages=ocaml-variants.4.10.2+msvc64
 	RUN ocaml-env exec --64 --ms -- opam pin add -k version ocaml-variants 4.10.2+msvc64
@@ -18824,6 +19871,7 @@ ocurrent/opam-staging:windows-server-msvc-ltsc2022-ocaml-4.11-amd64, ocurrent/op
 	# escape=`
 
 	FROM ocurrent/opam-staging:windows-msvc-ltsc2019-opam-amd64
+	RUN ocaml-env exec --64 --ms -- opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN ocaml-env exec --64 --ms --no-opam -- opam switch create 4.10 --packages=ocaml-variants.4.10.2+msvc64
 	RUN ocaml-env exec --64 --ms -- opam pin add -k version ocaml-variants 4.10.2+msvc64
@@ -18837,6 +19885,7 @@ ocurrent/opam-staging:windows-server-msvc-ltsc2022-ocaml-4.10-amd64, ocurrent/op
 	# escape=`
 
 	FROM ocurrent/opam-staging:windows-server-msvc-ltsc2022-opam-amd64
+	RUN ocaml-env exec --64 --ms -- opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN ocaml-env exec --64 --ms --no-opam -- opam switch create 4.09 --packages=ocaml-variants.4.09.1+msvc64
 	RUN ocaml-env exec --64 --ms -- opam pin add -k version ocaml-variants 4.09.1+msvc64
@@ -18849,6 +19898,7 @@ ocurrent/opam-staging:windows-server-msvc-ltsc2022-ocaml-4.10-amd64, ocurrent/op
 	# escape=`
 
 	FROM ocurrent/opam-staging:windows-msvc-ltsc2019-opam-amd64
+	RUN ocaml-env exec --64 --ms -- opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN ocaml-env exec --64 --ms --no-opam -- opam switch create 4.09 --packages=ocaml-variants.4.09.1+msvc64
 	RUN ocaml-env exec --64 --ms -- opam pin add -k version ocaml-variants 4.09.1+msvc64
@@ -18862,6 +19912,7 @@ ocurrent/opam-staging:windows-server-msvc-ltsc2022-ocaml-4.09-amd64, ocurrent/op
 	# escape=`
 
 	FROM ocurrent/opam-staging:windows-server-msvc-ltsc2022-opam-amd64
+	RUN ocaml-env exec --64 --ms -- opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN ocaml-env exec --64 --ms --no-opam -- opam switch create 4.08 --packages=ocaml-variants.4.08.1+msvc64
 	RUN ocaml-env exec --64 --ms -- opam pin add -k version ocaml-variants 4.08.1+msvc64
@@ -18874,6 +19925,7 @@ ocurrent/opam-staging:windows-server-msvc-ltsc2022-ocaml-4.09-amd64, ocurrent/op
 	# escape=`
 
 	FROM ocurrent/opam-staging:windows-msvc-ltsc2019-opam-amd64
+	RUN ocaml-env exec --64 --ms -- opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN ocaml-env exec --64 --ms --no-opam -- opam switch create 4.08 --packages=ocaml-variants.4.08.1+msvc64
 	RUN ocaml-env exec --64 --ms -- opam pin add -k version ocaml-variants 4.08.1+msvc64
@@ -18887,6 +19939,7 @@ ocurrent/opam-staging:windows-server-msvc-ltsc2022-ocaml-4.08-amd64, ocurrent/op
 	# escape=`
 
 	FROM ocurrent/opam-staging:windows-server-msvc-ltsc2022-opam-amd64
+	RUN ocaml-env exec --64 --ms -- opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN ocaml-env exec --64 --ms --no-opam -- opam switch create 4.07 --packages=ocaml-variants.4.07.1+msvc64
 	RUN ocaml-env exec --64 --ms -- opam pin add -k version ocaml-variants 4.07.1+msvc64
@@ -18899,6 +19952,7 @@ ocurrent/opam-staging:windows-server-msvc-ltsc2022-ocaml-4.08-amd64, ocurrent/op
 	# escape=`
 
 	FROM ocurrent/opam-staging:windows-msvc-ltsc2019-opam-amd64
+	RUN ocaml-env exec --64 --ms -- opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN ocaml-env exec --64 --ms --no-opam -- opam switch create 4.07 --packages=ocaml-variants.4.07.1+msvc64
 	RUN ocaml-env exec --64 --ms -- opam pin add -k version ocaml-variants 4.07.1+msvc64
@@ -18912,6 +19966,7 @@ ocurrent/opam-staging:windows-server-msvc-ltsc2022-ocaml-4.07-amd64, ocurrent/op
 	# escape=`
 
 	FROM ocurrent/opam-staging:windows-server-msvc-ltsc2022-opam-amd64
+	RUN ocaml-env exec --64 --ms -- opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN ocaml-env exec --64 --ms --no-opam -- opam switch create 4.06 --packages=ocaml-variants.4.06.1+msvc64
 	RUN ocaml-env exec --64 --ms -- opam pin add -k version ocaml-variants 4.06.1+msvc64
@@ -18924,6 +19979,7 @@ ocurrent/opam-staging:windows-server-msvc-ltsc2022-ocaml-4.07-amd64, ocurrent/op
 	# escape=`
 
 	FROM ocurrent/opam-staging:windows-msvc-ltsc2019-opam-amd64
+	RUN ocaml-env exec --64 --ms -- opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN ocaml-env exec --64 --ms --no-opam -- opam switch create 4.06 --packages=ocaml-variants.4.06.1+msvc64
 	RUN ocaml-env exec --64 --ms -- opam pin add -k version ocaml-variants 4.06.1+msvc64

--- a/src/pipeline.ml
+++ b/src/pipeline.ml
@@ -109,6 +109,7 @@ let install_compiler_df ~distro ~arch ~switch ?windows_port opam_image =
    | `Windows | `Cygwin -> parser_directive (`Escape '`')) @@
   from opam_image @@
   shell @@
+  run "opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default" @@
   maybe_add_overlay run distro switch @@
   maybe_add_beta run switch @@
   maybe_add_multicore run switch @@


### PR DESCRIPTION
Builds of 4.02.3 are failing.  `base-ocamlbuild` has been removed from opam reposistory.

```
#9 [2/6] RUN opam switch create 4.02 --packages=ocaml-base-compiler.4.02.3
#9 sha256:63800acae249cb5f12e27cfe84c02b9a074f2324aa96a2a88bd5a86101f246bf
#9 16.56 Switch initialisation failed: clean up? ('n' will leave the switch partially installed) [Y/n] y
#9 16.56 [ERROR] Could not resolve set of base packages:
#9 16.56         The following dependencies couldn't be met:
#9 16.56           - ocaml-base-compiler -> base-ocamlbuild
#9 16.56               unknown package
#9 16.56 
#9 16.56 
#9 ERROR: executor failed running [/bin/sh -c opam switch create 4.02 --packages=ocaml-base-compiler.4.02.3]: exit code: 20
```

Following [archive phase 2](https://github.com/ocaml/opam-repository/pull/27273), we need to include `opam repository add archive git+https://github.com/ocaml/opam-repository-archive`.

The CI failures will clear once #314 is merged.