### PR TITLE
Use `--no-opam` with `ocaml-env` on Windows.

### DIFF
--- a/builds.expected
+++ b/builds.expected
@@ -19077,7 +19077,7 @@ windows-server-mingw-ltsc2022/amd64
 	# escape=`
 
 	FROM ocurrent/opam-staging:windows-server-mingw-ltsc2022-opam-amd64
-	RUN ocaml-env exec --64 -- opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
+	RUN ocaml-env exec --64 --no-opam -- opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN ocaml-env exec --64 --no-opam -- opam switch create 4.14 --packages=ocaml-variants.4.14.2+mingw64
 	RUN ocaml-env exec --64 -- opam pin add -k version ocaml-variants 4.14.2+mingw64
@@ -19175,7 +19175,7 @@ windows-mingw-ltsc2019/amd64
 	# escape=`
 
 	FROM ocurrent/opam-staging:windows-mingw-ltsc2019-opam-amd64
-	RUN ocaml-env exec --64 -- opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
+	RUN ocaml-env exec --64 --no-opam -- opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN ocaml-env exec --64 --no-opam -- opam switch create 4.14 --packages=ocaml-variants.4.14.2+mingw64
 	RUN ocaml-env exec --64 -- opam pin add -k version ocaml-variants 4.14.2+mingw64
@@ -19189,7 +19189,7 @@ ocurrent/opam-staging:windows-server-mingw-ltsc2022-ocaml-4.14-amd64, ocurrent/o
 	# escape=`
 
 	FROM ocurrent/opam-staging:windows-server-mingw-ltsc2022-opam-amd64
-	RUN ocaml-env exec --64 -- opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
+	RUN ocaml-env exec --64 --no-opam -- opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN ocaml-env exec --64 --no-opam -- opam switch create 4.13 --packages=ocaml-variants.4.13.1+mingw64
 	RUN ocaml-env exec --64 -- opam pin add -k version ocaml-variants 4.13.1+mingw64
@@ -19202,7 +19202,7 @@ ocurrent/opam-staging:windows-server-mingw-ltsc2022-ocaml-4.14-amd64, ocurrent/o
 	# escape=`
 
 	FROM ocurrent/opam-staging:windows-mingw-ltsc2019-opam-amd64
-	RUN ocaml-env exec --64 -- opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
+	RUN ocaml-env exec --64 --no-opam -- opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN ocaml-env exec --64 --no-opam -- opam switch create 4.13 --packages=ocaml-variants.4.13.1+mingw64
 	RUN ocaml-env exec --64 -- opam pin add -k version ocaml-variants 4.13.1+mingw64
@@ -19216,7 +19216,7 @@ ocurrent/opam-staging:windows-server-mingw-ltsc2022-ocaml-4.13-amd64, ocurrent/o
 	# escape=`
 
 	FROM ocurrent/opam-staging:windows-server-mingw-ltsc2022-opam-amd64
-	RUN ocaml-env exec --64 -- opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
+	RUN ocaml-env exec --64 --no-opam -- opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN ocaml-env exec --64 --no-opam -- opam switch create 4.12 --packages=ocaml-variants.4.12.1+mingw64
 	RUN ocaml-env exec --64 -- opam pin add -k version ocaml-variants 4.12.1+mingw64
@@ -19229,7 +19229,7 @@ ocurrent/opam-staging:windows-server-mingw-ltsc2022-ocaml-4.13-amd64, ocurrent/o
 	# escape=`
 
 	FROM ocurrent/opam-staging:windows-mingw-ltsc2019-opam-amd64
-	RUN ocaml-env exec --64 -- opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
+	RUN ocaml-env exec --64 --no-opam -- opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN ocaml-env exec --64 --no-opam -- opam switch create 4.12 --packages=ocaml-variants.4.12.1+mingw64
 	RUN ocaml-env exec --64 -- opam pin add -k version ocaml-variants 4.12.1+mingw64
@@ -19243,7 +19243,7 @@ ocurrent/opam-staging:windows-server-mingw-ltsc2022-ocaml-4.12-amd64, ocurrent/o
 	# escape=`
 
 	FROM ocurrent/opam-staging:windows-server-mingw-ltsc2022-opam-amd64
-	RUN ocaml-env exec --64 -- opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
+	RUN ocaml-env exec --64 --no-opam -- opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN ocaml-env exec --64 --no-opam -- opam switch create 4.11 --packages=ocaml-variants.4.11.2+mingw64
 	RUN ocaml-env exec --64 -- opam pin add -k version ocaml-variants 4.11.2+mingw64
@@ -19256,7 +19256,7 @@ ocurrent/opam-staging:windows-server-mingw-ltsc2022-ocaml-4.12-amd64, ocurrent/o
 	# escape=`
 
 	FROM ocurrent/opam-staging:windows-mingw-ltsc2019-opam-amd64
-	RUN ocaml-env exec --64 -- opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
+	RUN ocaml-env exec --64 --no-opam -- opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN ocaml-env exec --64 --no-opam -- opam switch create 4.11 --packages=ocaml-variants.4.11.2+mingw64
 	RUN ocaml-env exec --64 -- opam pin add -k version ocaml-variants 4.11.2+mingw64
@@ -19270,7 +19270,7 @@ ocurrent/opam-staging:windows-server-mingw-ltsc2022-ocaml-4.11-amd64, ocurrent/o
 	# escape=`
 
 	FROM ocurrent/opam-staging:windows-server-mingw-ltsc2022-opam-amd64
-	RUN ocaml-env exec --64 -- opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
+	RUN ocaml-env exec --64 --no-opam -- opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN ocaml-env exec --64 --no-opam -- opam switch create 4.10 --packages=ocaml-variants.4.10.2+mingw64
 	RUN ocaml-env exec --64 -- opam pin add -k version ocaml-variants 4.10.2+mingw64
@@ -19283,7 +19283,7 @@ ocurrent/opam-staging:windows-server-mingw-ltsc2022-ocaml-4.11-amd64, ocurrent/o
 	# escape=`
 
 	FROM ocurrent/opam-staging:windows-mingw-ltsc2019-opam-amd64
-	RUN ocaml-env exec --64 -- opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
+	RUN ocaml-env exec --64 --no-opam -- opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN ocaml-env exec --64 --no-opam -- opam switch create 4.10 --packages=ocaml-variants.4.10.2+mingw64
 	RUN ocaml-env exec --64 -- opam pin add -k version ocaml-variants 4.10.2+mingw64
@@ -19297,7 +19297,7 @@ ocurrent/opam-staging:windows-server-mingw-ltsc2022-ocaml-4.10-amd64, ocurrent/o
 	# escape=`
 
 	FROM ocurrent/opam-staging:windows-server-mingw-ltsc2022-opam-amd64
-	RUN ocaml-env exec --64 -- opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
+	RUN ocaml-env exec --64 --no-opam -- opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN ocaml-env exec --64 --no-opam -- opam switch create 4.09 --packages=ocaml-variants.4.09.1+mingw64
 	RUN ocaml-env exec --64 -- opam pin add -k version ocaml-variants 4.09.1+mingw64
@@ -19310,7 +19310,7 @@ ocurrent/opam-staging:windows-server-mingw-ltsc2022-ocaml-4.10-amd64, ocurrent/o
 	# escape=`
 
 	FROM ocurrent/opam-staging:windows-mingw-ltsc2019-opam-amd64
-	RUN ocaml-env exec --64 -- opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
+	RUN ocaml-env exec --64 --no-opam -- opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN ocaml-env exec --64 --no-opam -- opam switch create 4.09 --packages=ocaml-variants.4.09.1+mingw64
 	RUN ocaml-env exec --64 -- opam pin add -k version ocaml-variants 4.09.1+mingw64
@@ -19324,7 +19324,7 @@ ocurrent/opam-staging:windows-server-mingw-ltsc2022-ocaml-4.09-amd64, ocurrent/o
 	# escape=`
 
 	FROM ocurrent/opam-staging:windows-server-mingw-ltsc2022-opam-amd64
-	RUN ocaml-env exec --64 -- opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
+	RUN ocaml-env exec --64 --no-opam -- opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN ocaml-env exec --64 --no-opam -- opam switch create 4.08 --packages=ocaml-variants.4.08.1+mingw64
 	RUN ocaml-env exec --64 -- opam pin add -k version ocaml-variants 4.08.1+mingw64
@@ -19337,7 +19337,7 @@ ocurrent/opam-staging:windows-server-mingw-ltsc2022-ocaml-4.09-amd64, ocurrent/o
 	# escape=`
 
 	FROM ocurrent/opam-staging:windows-mingw-ltsc2019-opam-amd64
-	RUN ocaml-env exec --64 -- opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
+	RUN ocaml-env exec --64 --no-opam -- opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN ocaml-env exec --64 --no-opam -- opam switch create 4.08 --packages=ocaml-variants.4.08.1+mingw64
 	RUN ocaml-env exec --64 -- opam pin add -k version ocaml-variants 4.08.1+mingw64
@@ -19351,7 +19351,7 @@ ocurrent/opam-staging:windows-server-mingw-ltsc2022-ocaml-4.08-amd64, ocurrent/o
 	# escape=`
 
 	FROM ocurrent/opam-staging:windows-server-mingw-ltsc2022-opam-amd64
-	RUN ocaml-env exec --64 -- opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
+	RUN ocaml-env exec --64 --no-opam -- opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN ocaml-env exec --64 --no-opam -- opam switch create 4.07 --packages=ocaml-variants.4.07.1+mingw64
 	RUN ocaml-env exec --64 -- opam pin add -k version ocaml-variants 4.07.1+mingw64
@@ -19364,7 +19364,7 @@ ocurrent/opam-staging:windows-server-mingw-ltsc2022-ocaml-4.08-amd64, ocurrent/o
 	# escape=`
 
 	FROM ocurrent/opam-staging:windows-mingw-ltsc2019-opam-amd64
-	RUN ocaml-env exec --64 -- opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
+	RUN ocaml-env exec --64 --no-opam -- opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN ocaml-env exec --64 --no-opam -- opam switch create 4.07 --packages=ocaml-variants.4.07.1+mingw64
 	RUN ocaml-env exec --64 -- opam pin add -k version ocaml-variants 4.07.1+mingw64
@@ -19378,7 +19378,7 @@ ocurrent/opam-staging:windows-server-mingw-ltsc2022-ocaml-4.07-amd64, ocurrent/o
 	# escape=`
 
 	FROM ocurrent/opam-staging:windows-server-mingw-ltsc2022-opam-amd64
-	RUN ocaml-env exec --64 -- opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
+	RUN ocaml-env exec --64 --no-opam -- opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN ocaml-env exec --64 --no-opam -- opam switch create 4.06 --packages=ocaml-variants.4.06.1+mingw64
 	RUN ocaml-env exec --64 -- opam pin add -k version ocaml-variants 4.06.1+mingw64
@@ -19391,7 +19391,7 @@ ocurrent/opam-staging:windows-server-mingw-ltsc2022-ocaml-4.07-amd64, ocurrent/o
 	# escape=`
 
 	FROM ocurrent/opam-staging:windows-mingw-ltsc2019-opam-amd64
-	RUN ocaml-env exec --64 -- opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
+	RUN ocaml-env exec --64 --no-opam -- opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN ocaml-env exec --64 --no-opam -- opam switch create 4.06 --packages=ocaml-variants.4.06.1+mingw64
 	RUN ocaml-env exec --64 -- opam pin add -k version ocaml-variants 4.06.1+mingw64
@@ -19405,7 +19405,7 @@ ocurrent/opam-staging:windows-server-mingw-ltsc2022-ocaml-4.06-amd64, ocurrent/o
 	# escape=`
 
 	FROM ocurrent/opam-staging:windows-server-mingw-ltsc2022-opam-amd64
-	RUN ocaml-env exec --64 -- opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
+	RUN ocaml-env exec --64 --no-opam -- opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN ocaml-env exec --64 --no-opam -- opam switch create 4.05 --packages=ocaml-variants.4.05.0+mingw64
 	RUN ocaml-env exec --64 -- opam pin add -k version ocaml-variants 4.05.0+mingw64
@@ -19418,7 +19418,7 @@ ocurrent/opam-staging:windows-server-mingw-ltsc2022-ocaml-4.06-amd64, ocurrent/o
 	# escape=`
 
 	FROM ocurrent/opam-staging:windows-mingw-ltsc2019-opam-amd64
-	RUN ocaml-env exec --64 -- opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
+	RUN ocaml-env exec --64 --no-opam -- opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN ocaml-env exec --64 --no-opam -- opam switch create 4.05 --packages=ocaml-variants.4.05.0+mingw64
 	RUN ocaml-env exec --64 -- opam pin add -k version ocaml-variants 4.05.0+mingw64
@@ -19432,7 +19432,7 @@ ocurrent/opam-staging:windows-server-mingw-ltsc2022-ocaml-4.05-amd64, ocurrent/o
 	# escape=`
 
 	FROM ocurrent/opam-staging:windows-server-mingw-ltsc2022-opam-amd64
-	RUN ocaml-env exec --64 -- opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
+	RUN ocaml-env exec --64 --no-opam -- opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN ocaml-env exec --64 --no-opam -- opam switch create 4.04 --packages=ocaml-variants.4.04.2+mingw64
 	RUN ocaml-env exec --64 -- opam pin add -k version ocaml-variants 4.04.2+mingw64
@@ -19445,7 +19445,7 @@ ocurrent/opam-staging:windows-server-mingw-ltsc2022-ocaml-4.05-amd64, ocurrent/o
 	# escape=`
 
 	FROM ocurrent/opam-staging:windows-mingw-ltsc2019-opam-amd64
-	RUN ocaml-env exec --64 -- opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
+	RUN ocaml-env exec --64 --no-opam -- opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN ocaml-env exec --64 --no-opam -- opam switch create 4.04 --packages=ocaml-variants.4.04.2+mingw64
 	RUN ocaml-env exec --64 -- opam pin add -k version ocaml-variants 4.04.2+mingw64
@@ -19459,7 +19459,7 @@ ocurrent/opam-staging:windows-server-mingw-ltsc2022-ocaml-4.04-amd64, ocurrent/o
 	# escape=`
 
 	FROM ocurrent/opam-staging:windows-server-mingw-ltsc2022-opam-amd64
-	RUN ocaml-env exec --64 -- opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
+	RUN ocaml-env exec --64 --no-opam -- opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN ocaml-env exec --64 --no-opam -- opam switch create 4.03 --packages=ocaml-variants.4.03.0+mingw64
 	RUN ocaml-env exec --64 -- opam pin add -k version ocaml-variants 4.03.0+mingw64
@@ -19472,7 +19472,7 @@ ocurrent/opam-staging:windows-server-mingw-ltsc2022-ocaml-4.04-amd64, ocurrent/o
 	# escape=`
 
 	FROM ocurrent/opam-staging:windows-mingw-ltsc2019-opam-amd64
-	RUN ocaml-env exec --64 -- opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
+	RUN ocaml-env exec --64 --no-opam -- opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN ocaml-env exec --64 --no-opam -- opam switch create 4.03 --packages=ocaml-variants.4.03.0+mingw64
 	RUN ocaml-env exec --64 -- opam pin add -k version ocaml-variants 4.03.0+mingw64
@@ -19486,7 +19486,7 @@ ocurrent/opam-staging:windows-server-mingw-ltsc2022-ocaml-4.03-amd64, ocurrent/o
 	# escape=`
 
 	FROM ocurrent/opam-staging:windows-server-mingw-ltsc2022-opam-amd64
-	RUN ocaml-env exec --64 -- opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
+	RUN ocaml-env exec --64 --no-opam -- opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN ocaml-env exec --64 --no-opam -- opam switch create 4.02 --packages=ocaml-variants.4.02.3+mingw64
 	RUN ocaml-env exec --64 -- opam pin add -k version ocaml-variants 4.02.3+mingw64
@@ -19499,7 +19499,7 @@ ocurrent/opam-staging:windows-server-mingw-ltsc2022-ocaml-4.03-amd64, ocurrent/o
 	# escape=`
 
 	FROM ocurrent/opam-staging:windows-mingw-ltsc2019-opam-amd64
-	RUN ocaml-env exec --64 -- opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
+	RUN ocaml-env exec --64 --no-opam -- opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN ocaml-env exec --64 --no-opam -- opam switch create 4.02 --packages=ocaml-variants.4.02.3+mingw64
 	RUN ocaml-env exec --64 -- opam pin add -k version ocaml-variants 4.02.3+mingw64
@@ -19659,7 +19659,7 @@ windows-server-msvc-ltsc2022/amd64
 	# escape=`
 
 	FROM ocurrent/opam-staging:windows-server-msvc-ltsc2022-opam-amd64
-	RUN ocaml-env exec --64 --ms -- opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
+	RUN ocaml-env exec --64 --ms --no-opam -- opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN ocaml-env exec --64 --ms --no-opam -- opam switch create 4.14 --packages=ocaml-variants.4.14.2+msvc64
 	RUN ocaml-env exec --64 --ms -- opam pin add -k version ocaml-variants 4.14.2+msvc64
@@ -19763,7 +19763,7 @@ windows-msvc-ltsc2019/amd64
 	# escape=`
 
 	FROM ocurrent/opam-staging:windows-msvc-ltsc2019-opam-amd64
-	RUN ocaml-env exec --64 --ms -- opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
+	RUN ocaml-env exec --64 --ms --no-opam -- opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN ocaml-env exec --64 --ms --no-opam -- opam switch create 4.14 --packages=ocaml-variants.4.14.2+msvc64
 	RUN ocaml-env exec --64 --ms -- opam pin add -k version ocaml-variants 4.14.2+msvc64
@@ -19777,7 +19777,7 @@ ocurrent/opam-staging:windows-server-msvc-ltsc2022-ocaml-4.14-amd64, ocurrent/op
 	# escape=`
 
 	FROM ocurrent/opam-staging:windows-server-msvc-ltsc2022-opam-amd64
-	RUN ocaml-env exec --64 --ms -- opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
+	RUN ocaml-env exec --64 --ms --no-opam -- opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN ocaml-env exec --64 --ms --no-opam -- opam switch create 4.13 --packages=ocaml-variants.4.13.1+msvc64
 	RUN ocaml-env exec --64 --ms -- opam pin add -k version ocaml-variants 4.13.1+msvc64
@@ -19790,7 +19790,7 @@ ocurrent/opam-staging:windows-server-msvc-ltsc2022-ocaml-4.14-amd64, ocurrent/op
 	# escape=`
 
 	FROM ocurrent/opam-staging:windows-msvc-ltsc2019-opam-amd64
-	RUN ocaml-env exec --64 --ms -- opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
+	RUN ocaml-env exec --64 --ms --no-opam -- opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN ocaml-env exec --64 --ms --no-opam -- opam switch create 4.13 --packages=ocaml-variants.4.13.1+msvc64
 	RUN ocaml-env exec --64 --ms -- opam pin add -k version ocaml-variants 4.13.1+msvc64
@@ -19804,7 +19804,7 @@ ocurrent/opam-staging:windows-server-msvc-ltsc2022-ocaml-4.13-amd64, ocurrent/op
 	# escape=`
 
 	FROM ocurrent/opam-staging:windows-server-msvc-ltsc2022-opam-amd64
-	RUN ocaml-env exec --64 --ms -- opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
+	RUN ocaml-env exec --64 --ms --no-opam -- opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN ocaml-env exec --64 --ms --no-opam -- opam switch create 4.12 --packages=ocaml-variants.4.12.1+msvc64
 	RUN ocaml-env exec --64 --ms -- opam pin add -k version ocaml-variants 4.12.1+msvc64
@@ -19817,7 +19817,7 @@ ocurrent/opam-staging:windows-server-msvc-ltsc2022-ocaml-4.13-amd64, ocurrent/op
 	# escape=`
 
 	FROM ocurrent/opam-staging:windows-msvc-ltsc2019-opam-amd64
-	RUN ocaml-env exec --64 --ms -- opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
+	RUN ocaml-env exec --64 --ms --no-opam -- opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN ocaml-env exec --64 --ms --no-opam -- opam switch create 4.12 --packages=ocaml-variants.4.12.1+msvc64
 	RUN ocaml-env exec --64 --ms -- opam pin add -k version ocaml-variants 4.12.1+msvc64
@@ -19831,7 +19831,7 @@ ocurrent/opam-staging:windows-server-msvc-ltsc2022-ocaml-4.12-amd64, ocurrent/op
 	# escape=`
 
 	FROM ocurrent/opam-staging:windows-server-msvc-ltsc2022-opam-amd64
-	RUN ocaml-env exec --64 --ms -- opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
+	RUN ocaml-env exec --64 --ms --no-opam -- opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN ocaml-env exec --64 --ms --no-opam -- opam switch create 4.11 --packages=ocaml-variants.4.11.2+msvc64
 	RUN ocaml-env exec --64 --ms -- opam pin add -k version ocaml-variants 4.11.2+msvc64
@@ -19844,7 +19844,7 @@ ocurrent/opam-staging:windows-server-msvc-ltsc2022-ocaml-4.12-amd64, ocurrent/op
 	# escape=`
 
 	FROM ocurrent/opam-staging:windows-msvc-ltsc2019-opam-amd64
-	RUN ocaml-env exec --64 --ms -- opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
+	RUN ocaml-env exec --64 --ms --no-opam -- opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN ocaml-env exec --64 --ms --no-opam -- opam switch create 4.11 --packages=ocaml-variants.4.11.2+msvc64
 	RUN ocaml-env exec --64 --ms -- opam pin add -k version ocaml-variants 4.11.2+msvc64
@@ -19858,7 +19858,7 @@ ocurrent/opam-staging:windows-server-msvc-ltsc2022-ocaml-4.11-amd64, ocurrent/op
 	# escape=`
 
 	FROM ocurrent/opam-staging:windows-server-msvc-ltsc2022-opam-amd64
-	RUN ocaml-env exec --64 --ms -- opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
+	RUN ocaml-env exec --64 --ms --no-opam -- opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN ocaml-env exec --64 --ms --no-opam -- opam switch create 4.10 --packages=ocaml-variants.4.10.2+msvc64
 	RUN ocaml-env exec --64 --ms -- opam pin add -k version ocaml-variants 4.10.2+msvc64
@@ -19871,7 +19871,7 @@ ocurrent/opam-staging:windows-server-msvc-ltsc2022-ocaml-4.11-amd64, ocurrent/op
 	# escape=`
 
 	FROM ocurrent/opam-staging:windows-msvc-ltsc2019-opam-amd64
-	RUN ocaml-env exec --64 --ms -- opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
+	RUN ocaml-env exec --64 --ms --no-opam -- opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN ocaml-env exec --64 --ms --no-opam -- opam switch create 4.10 --packages=ocaml-variants.4.10.2+msvc64
 	RUN ocaml-env exec --64 --ms -- opam pin add -k version ocaml-variants 4.10.2+msvc64
@@ -19885,7 +19885,7 @@ ocurrent/opam-staging:windows-server-msvc-ltsc2022-ocaml-4.10-amd64, ocurrent/op
 	# escape=`
 
 	FROM ocurrent/opam-staging:windows-server-msvc-ltsc2022-opam-amd64
-	RUN ocaml-env exec --64 --ms -- opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
+	RUN ocaml-env exec --64 --ms --no-opam -- opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN ocaml-env exec --64 --ms --no-opam -- opam switch create 4.09 --packages=ocaml-variants.4.09.1+msvc64
 	RUN ocaml-env exec --64 --ms -- opam pin add -k version ocaml-variants 4.09.1+msvc64
@@ -19898,7 +19898,7 @@ ocurrent/opam-staging:windows-server-msvc-ltsc2022-ocaml-4.10-amd64, ocurrent/op
 	# escape=`
 
 	FROM ocurrent/opam-staging:windows-msvc-ltsc2019-opam-amd64
-	RUN ocaml-env exec --64 --ms -- opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
+	RUN ocaml-env exec --64 --ms --no-opam -- opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN ocaml-env exec --64 --ms --no-opam -- opam switch create 4.09 --packages=ocaml-variants.4.09.1+msvc64
 	RUN ocaml-env exec --64 --ms -- opam pin add -k version ocaml-variants 4.09.1+msvc64
@@ -19912,7 +19912,7 @@ ocurrent/opam-staging:windows-server-msvc-ltsc2022-ocaml-4.09-amd64, ocurrent/op
 	# escape=`
 
 	FROM ocurrent/opam-staging:windows-server-msvc-ltsc2022-opam-amd64
-	RUN ocaml-env exec --64 --ms -- opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
+	RUN ocaml-env exec --64 --ms --no-opam -- opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN ocaml-env exec --64 --ms --no-opam -- opam switch create 4.08 --packages=ocaml-variants.4.08.1+msvc64
 	RUN ocaml-env exec --64 --ms -- opam pin add -k version ocaml-variants 4.08.1+msvc64
@@ -19925,7 +19925,7 @@ ocurrent/opam-staging:windows-server-msvc-ltsc2022-ocaml-4.09-amd64, ocurrent/op
 	# escape=`
 
 	FROM ocurrent/opam-staging:windows-msvc-ltsc2019-opam-amd64
-	RUN ocaml-env exec --64 --ms -- opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
+	RUN ocaml-env exec --64 --ms --no-opam -- opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN ocaml-env exec --64 --ms --no-opam -- opam switch create 4.08 --packages=ocaml-variants.4.08.1+msvc64
 	RUN ocaml-env exec --64 --ms -- opam pin add -k version ocaml-variants 4.08.1+msvc64
@@ -19939,7 +19939,7 @@ ocurrent/opam-staging:windows-server-msvc-ltsc2022-ocaml-4.08-amd64, ocurrent/op
 	# escape=`
 
 	FROM ocurrent/opam-staging:windows-server-msvc-ltsc2022-opam-amd64
-	RUN ocaml-env exec --64 --ms -- opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
+	RUN ocaml-env exec --64 --ms --no-opam -- opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN ocaml-env exec --64 --ms --no-opam -- opam switch create 4.07 --packages=ocaml-variants.4.07.1+msvc64
 	RUN ocaml-env exec --64 --ms -- opam pin add -k version ocaml-variants 4.07.1+msvc64
@@ -19952,7 +19952,7 @@ ocurrent/opam-staging:windows-server-msvc-ltsc2022-ocaml-4.08-amd64, ocurrent/op
 	# escape=`
 
 	FROM ocurrent/opam-staging:windows-msvc-ltsc2019-opam-amd64
-	RUN ocaml-env exec --64 --ms -- opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
+	RUN ocaml-env exec --64 --ms --no-opam -- opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN ocaml-env exec --64 --ms --no-opam -- opam switch create 4.07 --packages=ocaml-variants.4.07.1+msvc64
 	RUN ocaml-env exec --64 --ms -- opam pin add -k version ocaml-variants 4.07.1+msvc64
@@ -19966,7 +19966,7 @@ ocurrent/opam-staging:windows-server-msvc-ltsc2022-ocaml-4.07-amd64, ocurrent/op
 	# escape=`
 
 	FROM ocurrent/opam-staging:windows-server-msvc-ltsc2022-opam-amd64
-	RUN ocaml-env exec --64 --ms -- opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
+	RUN ocaml-env exec --64 --ms --no-opam -- opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN ocaml-env exec --64 --ms --no-opam -- opam switch create 4.06 --packages=ocaml-variants.4.06.1+msvc64
 	RUN ocaml-env exec --64 --ms -- opam pin add -k version ocaml-variants 4.06.1+msvc64
@@ -19979,7 +19979,7 @@ ocurrent/opam-staging:windows-server-msvc-ltsc2022-ocaml-4.07-amd64, ocurrent/op
 	# escape=`
 
 	FROM ocurrent/opam-staging:windows-msvc-ltsc2019-opam-amd64
-	RUN ocaml-env exec --64 --ms -- opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
+	RUN ocaml-env exec --64 --ms --no-opam -- opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN ocaml-env exec --64 --ms --no-opam -- opam switch create 4.06 --packages=ocaml-variants.4.06.1+msvc64
 	RUN ocaml-env exec --64 --ms -- opam pin add -k version ocaml-variants 4.06.1+msvc64

--- a/src/pipeline.ml
+++ b/src/pipeline.ml
@@ -109,7 +109,7 @@ let install_compiler_df ~distro ~arch ~switch ?windows_port opam_image =
    | `Windows | `Cygwin -> parser_directive (`Escape '`')) @@
   from opam_image @@
   shell @@
-  run "opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default" @@
+  run_no_opam "opam repo add opam-repository-archive git+https://github.com/ocaml/opam-repository-archive --set-default" @@
   maybe_add_overlay run distro switch @@
   maybe_add_beta run switch @@
   maybe_add_multicore run switch @@


### PR DESCRIPTION
The opam repository archive added in #313 is failing on Windows builds.  At the point of invocation of `opam repo add` no opam switch exists therefore `ocaml-env` needs the `--no-opam` flag.  This mirrors subsequent command line options.