### PR TITLE
Update to OCaml 4.14.3 and 5.4.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     libssl-dev \
     m4 \
     pkg-config
-RUN cd ~/opam-repository && git fetch -q origin master && git reset --hard 10a02a697b08f6d78a6c4c2cb9a76136afc7776d && opam update
+RUN cd ~/opam-repository && git fetch -q origin master && git reset --hard 78794d942e7b27f3c8283c4fd2b05a9f20adf597 && opam update
 RUN opam pin add dockerfile.dev git+https://github.com/ocurrent/ocaml-dockerfile.git -y --no-action && \
     opam pin add dockerfile-cmd.dev git+https://github.com/ocurrent/ocaml-dockerfile.git -y --no-action && \
     opam pin add dockerfile-opam.dev git+https://github.com/ocurrent/ocaml-dockerfile.git -y --no-action && \

--- a/builds.expected
+++ b/builds.expected
@@ -930,25 +930,27 @@ ocurrent/opam-staging:alpine-3.23-ocaml-4.13-nnpchecker-amd64 -> ocaml/opam:alpi
 
 ocurrent/opam-staging:alpine-3.23-ocaml-4.13-no-flat-float-array-arm64, ocurrent/opam-staging:alpine-3.23-ocaml-4.13-no-flat-float-array-amd64 -> ocaml/opam:alpine-3.23-ocaml-4.13-no-flat-float-array
 ocurrent/opam-staging:alpine-3.23-ocaml-4.13-no-flat-float-array-arm64, ocurrent/opam-staging:alpine-3.23-ocaml-4.13-no-flat-float-array-amd64 -> ocaml/opam:alpine-ocaml-4.13-no-flat-float-array
-4.14.2/arm64
+4.14.3/arm64
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:alpine-3.23-opam-arm64
+	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.14 --packages=ocaml-base-compiler.4.14.2
-	RUN opam pin add -k version ocaml-base-compiler 4.14.2
+	RUN opam switch create 4.14 --packages=ocaml-base-compiler.4.14.3
+	RUN opam pin add -k version ocaml-base-compiler 4.14.3
 	RUN opam install -y opam-depext
 	ENTRYPOINT [ "opam", "exec", "--" ]
 	CMD bash
 	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
 
-4.14.2/amd64
+4.14.3/amd64
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:alpine-3.23-opam-amd64
+	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.14 --packages=ocaml-base-compiler.4.14.2
-	RUN opam pin add -k version ocaml-base-compiler 4.14.2
+	RUN opam switch create 4.14 --packages=ocaml-base-compiler.4.14.3
+	RUN opam pin add -k version ocaml-base-compiler 4.14.3
 	RUN opam install -y opam-depext
 	ENTRYPOINT [ "opam", "exec", "--" ]
 	CMD bash
@@ -956,25 +958,27 @@ ocurrent/opam-staging:alpine-3.23-ocaml-4.13-no-flat-float-array-arm64, ocurrent
 
 ocurrent/opam-staging:alpine-3.23-ocaml-4.14-arm64, ocurrent/opam-staging:alpine-3.23-ocaml-4.14-amd64 -> ocaml/opam:alpine-3.23-ocaml-4.14
 ocurrent/opam-staging:alpine-3.23-ocaml-4.14-arm64, ocurrent/opam-staging:alpine-3.23-ocaml-4.14-amd64 -> ocaml/opam:alpine-ocaml-4.14
-4.14.2+afl/arm64
+4.14.3+afl/arm64
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:alpine-3.23-opam-arm64
+	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.14 --packages=ocaml-variants.4.14.2+options,ocaml-options-only-afl
-	RUN opam pin add -k version ocaml-variants 4.14.2+options
+	RUN opam switch create 4.14 --packages=ocaml-variants.4.14.3+options,ocaml-options-only-afl
+	RUN opam pin add -k version ocaml-variants 4.14.3+options
 	RUN opam install -y opam-depext
 	ENTRYPOINT [ "opam", "exec", "--" ]
 	CMD bash
 	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
 
-4.14.2+afl/amd64
+4.14.3+afl/amd64
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:alpine-3.23-opam-amd64
+	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.14 --packages=ocaml-variants.4.14.2+options,ocaml-options-only-afl
-	RUN opam pin add -k version ocaml-variants 4.14.2+options
+	RUN opam switch create 4.14 --packages=ocaml-variants.4.14.3+options,ocaml-options-only-afl
+	RUN opam pin add -k version ocaml-variants 4.14.3+options
 	RUN opam install -y opam-depext
 	ENTRYPOINT [ "opam", "exec", "--" ]
 	CMD bash
@@ -982,25 +986,27 @@ ocurrent/opam-staging:alpine-3.23-ocaml-4.14-arm64, ocurrent/opam-staging:alpine
 
 ocurrent/opam-staging:alpine-3.23-ocaml-4.14-afl-arm64, ocurrent/opam-staging:alpine-3.23-ocaml-4.14-afl-amd64 -> ocaml/opam:alpine-3.23-ocaml-4.14-afl
 ocurrent/opam-staging:alpine-3.23-ocaml-4.14-afl-arm64, ocurrent/opam-staging:alpine-3.23-ocaml-4.14-afl-amd64 -> ocaml/opam:alpine-ocaml-4.14-afl
-4.14.2+flambda/arm64
+4.14.3+flambda/arm64
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:alpine-3.23-opam-arm64
+	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.14 --packages=ocaml-variants.4.14.2+options,ocaml-options-only-flambda
-	RUN opam pin add -k version ocaml-variants 4.14.2+options
+	RUN opam switch create 4.14 --packages=ocaml-variants.4.14.3+options,ocaml-options-only-flambda
+	RUN opam pin add -k version ocaml-variants 4.14.3+options
 	RUN opam install -y opam-depext
 	ENTRYPOINT [ "opam", "exec", "--" ]
 	CMD bash
 	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
 
-4.14.2+flambda/amd64
+4.14.3+flambda/amd64
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:alpine-3.23-opam-amd64
+	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.14 --packages=ocaml-variants.4.14.2+options,ocaml-options-only-flambda
-	RUN opam pin add -k version ocaml-variants 4.14.2+options
+	RUN opam switch create 4.14 --packages=ocaml-variants.4.14.3+options,ocaml-options-only-flambda
+	RUN opam pin add -k version ocaml-variants 4.14.3+options
 	RUN opam install -y opam-depext
 	ENTRYPOINT [ "opam", "exec", "--" ]
 	CMD bash
@@ -1008,13 +1014,14 @@ ocurrent/opam-staging:alpine-3.23-ocaml-4.14-afl-arm64, ocurrent/opam-staging:al
 
 ocurrent/opam-staging:alpine-3.23-ocaml-4.14-flambda-arm64, ocurrent/opam-staging:alpine-3.23-ocaml-4.14-flambda-amd64 -> ocaml/opam:alpine-3.23-ocaml-4.14-flambda
 ocurrent/opam-staging:alpine-3.23-ocaml-4.14-flambda-arm64, ocurrent/opam-staging:alpine-3.23-ocaml-4.14-flambda-amd64 -> ocaml/opam:alpine-ocaml-4.14-flambda
-4.14.2+flambda+fp/amd64
+4.14.3+flambda+fp/amd64
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:alpine-3.23-opam-amd64
+	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.14 --packages=ocaml-variants.4.14.2+options,ocaml-options-only-flambda-fp
-	RUN opam pin add -k version ocaml-variants 4.14.2+options
+	RUN opam switch create 4.14 --packages=ocaml-variants.4.14.3+options,ocaml-options-only-flambda-fp
+	RUN opam pin add -k version ocaml-variants 4.14.3+options
 	RUN opam install -y opam-depext
 	ENTRYPOINT [ "opam", "exec", "--" ]
 	CMD bash
@@ -1022,13 +1029,14 @@ ocurrent/opam-staging:alpine-3.23-ocaml-4.14-flambda-arm64, ocurrent/opam-stagin
 
 ocurrent/opam-staging:alpine-3.23-ocaml-4.14-flambda-fp-amd64 -> ocaml/opam:alpine-3.23-ocaml-4.14-flambda-fp
 ocurrent/opam-staging:alpine-3.23-ocaml-4.14-flambda-fp-amd64 -> ocaml/opam:alpine-ocaml-4.14-flambda-fp
-4.14.2+fp/amd64
+4.14.3+fp/amd64
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:alpine-3.23-opam-amd64
+	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.14 --packages=ocaml-variants.4.14.2+options,ocaml-options-only-fp
-	RUN opam pin add -k version ocaml-variants 4.14.2+options
+	RUN opam switch create 4.14 --packages=ocaml-variants.4.14.3+options,ocaml-options-only-fp
+	RUN opam pin add -k version ocaml-variants 4.14.3+options
 	RUN opam install -y opam-depext
 	ENTRYPOINT [ "opam", "exec", "--" ]
 	CMD bash
@@ -1036,25 +1044,27 @@ ocurrent/opam-staging:alpine-3.23-ocaml-4.14-flambda-fp-amd64 -> ocaml/opam:alpi
 
 ocurrent/opam-staging:alpine-3.23-ocaml-4.14-fp-amd64 -> ocaml/opam:alpine-3.23-ocaml-4.14-fp
 ocurrent/opam-staging:alpine-3.23-ocaml-4.14-fp-amd64 -> ocaml/opam:alpine-ocaml-4.14-fp
-4.14.2+nnp/arm64
+4.14.3+nnp/arm64
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:alpine-3.23-opam-arm64
+	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.14 --packages=ocaml-variants.4.14.2+options,ocaml-options-only-nnp
-	RUN opam pin add -k version ocaml-variants 4.14.2+options
+	RUN opam switch create 4.14 --packages=ocaml-variants.4.14.3+options,ocaml-options-only-nnp
+	RUN opam pin add -k version ocaml-variants 4.14.3+options
 	RUN opam install -y opam-depext
 	ENTRYPOINT [ "opam", "exec", "--" ]
 	CMD bash
 	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
 
-4.14.2+nnp/amd64
+4.14.3+nnp/amd64
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:alpine-3.23-opam-amd64
+	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.14 --packages=ocaml-variants.4.14.2+options,ocaml-options-only-nnp
-	RUN opam pin add -k version ocaml-variants 4.14.2+options
+	RUN opam switch create 4.14 --packages=ocaml-variants.4.14.3+options,ocaml-options-only-nnp
+	RUN opam pin add -k version ocaml-variants 4.14.3+options
 	RUN opam install -y opam-depext
 	ENTRYPOINT [ "opam", "exec", "--" ]
 	CMD bash
@@ -1062,13 +1072,14 @@ ocurrent/opam-staging:alpine-3.23-ocaml-4.14-fp-amd64 -> ocaml/opam:alpine-ocaml
 
 ocurrent/opam-staging:alpine-3.23-ocaml-4.14-nnp-arm64, ocurrent/opam-staging:alpine-3.23-ocaml-4.14-nnp-amd64 -> ocaml/opam:alpine-3.23-ocaml-4.14-nnp
 ocurrent/opam-staging:alpine-3.23-ocaml-4.14-nnp-arm64, ocurrent/opam-staging:alpine-3.23-ocaml-4.14-nnp-amd64 -> ocaml/opam:alpine-ocaml-4.14-nnp
-4.14.2+nnpchecker/amd64
+4.14.3+nnpchecker/amd64
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:alpine-3.23-opam-amd64
+	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.14 --packages=ocaml-variants.4.14.2+options,ocaml-options-only-nnpchecker
-	RUN opam pin add -k version ocaml-variants 4.14.2+options
+	RUN opam switch create 4.14 --packages=ocaml-variants.4.14.3+options,ocaml-options-only-nnpchecker
+	RUN opam pin add -k version ocaml-variants 4.14.3+options
 	RUN opam install -y opam-depext
 	ENTRYPOINT [ "opam", "exec", "--" ]
 	CMD bash
@@ -1076,25 +1087,27 @@ ocurrent/opam-staging:alpine-3.23-ocaml-4.14-nnp-arm64, ocurrent/opam-staging:al
 
 ocurrent/opam-staging:alpine-3.23-ocaml-4.14-nnpchecker-amd64 -> ocaml/opam:alpine-3.23-ocaml-4.14-nnpchecker
 ocurrent/opam-staging:alpine-3.23-ocaml-4.14-nnpchecker-amd64 -> ocaml/opam:alpine-ocaml-4.14-nnpchecker
-4.14.2+no-flat-float-array/arm64
+4.14.3+no-flat-float-array/arm64
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:alpine-3.23-opam-arm64
+	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.14 --packages=ocaml-variants.4.14.2+options,ocaml-options-only-no-flat-float-array
-	RUN opam pin add -k version ocaml-variants 4.14.2+options
+	RUN opam switch create 4.14 --packages=ocaml-variants.4.14.3+options,ocaml-options-only-no-flat-float-array
+	RUN opam pin add -k version ocaml-variants 4.14.3+options
 	RUN opam install -y opam-depext
 	ENTRYPOINT [ "opam", "exec", "--" ]
 	CMD bash
 	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
 
-4.14.2+no-flat-float-array/amd64
+4.14.3+no-flat-float-array/amd64
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:alpine-3.23-opam-amd64
+	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.14 --packages=ocaml-variants.4.14.2+options,ocaml-options-only-no-flat-float-array
-	RUN opam pin add -k version ocaml-variants 4.14.2+options
+	RUN opam switch create 4.14 --packages=ocaml-variants.4.14.3+options,ocaml-options-only-no-flat-float-array
+	RUN opam pin add -k version ocaml-variants 4.14.3+options
 	RUN opam install -y opam-depext
 	ENTRYPOINT [ "opam", "exec", "--" ]
 	CMD bash
@@ -1622,7 +1635,7 @@ ocurrent/opam-staging:alpine-3.23-ocaml-5.3-flambda-arm64, ocurrent/opam-staging
 
 ocurrent/opam-staging:alpine-3.23-ocaml-5.3-no-flat-float-array-arm64, ocurrent/opam-staging:alpine-3.23-ocaml-5.3-no-flat-float-array-amd64 -> ocaml/opam:alpine-3.23-ocaml-5.3-no-flat-float-array
 ocurrent/opam-staging:alpine-3.23-ocaml-5.3-no-flat-float-array-arm64, ocurrent/opam-staging:alpine-3.23-ocaml-5.3-no-flat-float-array-amd64 -> ocaml/opam:alpine-ocaml-5.3-no-flat-float-array
-5.4.0/arm64
+5.4.1/arm64
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:alpine-3.23-opam-arm64
@@ -1631,14 +1644,14 @@ ocurrent/opam-staging:alpine-3.23-ocaml-5.3-no-flat-float-array-arm64, ocurrent/
 	RUN apk update && apk upgrade
 	RUN apk add zstd
 	USER opam
-	RUN opam switch create 5.4 --packages=ocaml-base-compiler.5.4.0
-	RUN opam pin add -k version ocaml-base-compiler 5.4.0
+	RUN opam switch create 5.4 --packages=ocaml-base-compiler.5.4.1
+	RUN opam pin add -k version ocaml-base-compiler 5.4.1
 	RUN opam install -y opam-depext
 	ENTRYPOINT [ "opam", "exec", "--" ]
 	CMD bash
 	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
 
-5.4.0/amd64
+5.4.1/amd64
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:alpine-3.23-opam-amd64
@@ -1647,8 +1660,8 @@ ocurrent/opam-staging:alpine-3.23-ocaml-5.3-no-flat-float-array-arm64, ocurrent/
 	RUN apk update && apk upgrade
 	RUN apk add zstd
 	USER opam
-	RUN opam switch create 5.4 --packages=ocaml-base-compiler.5.4.0
-	RUN opam pin add -k version ocaml-base-compiler 5.4.0
+	RUN opam switch create 5.4 --packages=ocaml-base-compiler.5.4.1
+	RUN opam pin add -k version ocaml-base-compiler 5.4.1
 	RUN opam install -y opam-depext
 	ENTRYPOINT [ "opam", "exec", "--" ]
 	CMD bash
@@ -1658,7 +1671,7 @@ ocurrent/opam-staging:alpine-3.23-ocaml-5.4-arm64, ocurrent/opam-staging:alpine-
 ocurrent/opam-staging:alpine-3.23-ocaml-5.4-arm64, ocurrent/opam-staging:alpine-3.23-ocaml-5.4-amd64 -> ocaml/opam:alpine-3.23
 ocurrent/opam-staging:alpine-3.23-ocaml-5.4-arm64, ocurrent/opam-staging:alpine-3.23-ocaml-5.4-amd64 -> ocaml/opam:alpine-3.23-ocaml-5.4
 ocurrent/opam-staging:alpine-3.23-ocaml-5.4-arm64, ocurrent/opam-staging:alpine-3.23-ocaml-5.4-amd64 -> ocaml/opam:alpine-ocaml-5.4
-5.4.0+afl/arm64
+5.4.1+afl/arm64
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:alpine-3.23-opam-arm64
@@ -1667,14 +1680,14 @@ ocurrent/opam-staging:alpine-3.23-ocaml-5.4-arm64, ocurrent/opam-staging:alpine-
 	RUN apk update && apk upgrade
 	RUN apk add zstd
 	USER opam
-	RUN opam switch create 5.4 --packages=ocaml-variants.5.4.0+options,ocaml-options-only-afl
-	RUN opam pin add -k version ocaml-variants 5.4.0+options
+	RUN opam switch create 5.4 --packages=ocaml-variants.5.4.1+options,ocaml-options-only-afl
+	RUN opam pin add -k version ocaml-variants 5.4.1+options
 	RUN opam install -y opam-depext
 	ENTRYPOINT [ "opam", "exec", "--" ]
 	CMD bash
 	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
 
-5.4.0+afl/amd64
+5.4.1+afl/amd64
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:alpine-3.23-opam-amd64
@@ -1683,8 +1696,8 @@ ocurrent/opam-staging:alpine-3.23-ocaml-5.4-arm64, ocurrent/opam-staging:alpine-
 	RUN apk update && apk upgrade
 	RUN apk add zstd
 	USER opam
-	RUN opam switch create 5.4 --packages=ocaml-variants.5.4.0+options,ocaml-options-only-afl
-	RUN opam pin add -k version ocaml-variants 5.4.0+options
+	RUN opam switch create 5.4 --packages=ocaml-variants.5.4.1+options,ocaml-options-only-afl
+	RUN opam pin add -k version ocaml-variants 5.4.1+options
 	RUN opam install -y opam-depext
 	ENTRYPOINT [ "opam", "exec", "--" ]
 	CMD bash
@@ -1692,7 +1705,7 @@ ocurrent/opam-staging:alpine-3.23-ocaml-5.4-arm64, ocurrent/opam-staging:alpine-
 
 ocurrent/opam-staging:alpine-3.23-ocaml-5.4-afl-arm64, ocurrent/opam-staging:alpine-3.23-ocaml-5.4-afl-amd64 -> ocaml/opam:alpine-3.23-ocaml-5.4-afl
 ocurrent/opam-staging:alpine-3.23-ocaml-5.4-afl-arm64, ocurrent/opam-staging:alpine-3.23-ocaml-5.4-afl-amd64 -> ocaml/opam:alpine-ocaml-5.4-afl
-5.4.0+flambda/arm64
+5.4.1+flambda/arm64
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:alpine-3.23-opam-arm64
@@ -1701,14 +1714,14 @@ ocurrent/opam-staging:alpine-3.23-ocaml-5.4-afl-arm64, ocurrent/opam-staging:alp
 	RUN apk update && apk upgrade
 	RUN apk add zstd
 	USER opam
-	RUN opam switch create 5.4 --packages=ocaml-variants.5.4.0+options,ocaml-options-only-flambda
-	RUN opam pin add -k version ocaml-variants 5.4.0+options
+	RUN opam switch create 5.4 --packages=ocaml-variants.5.4.1+options,ocaml-options-only-flambda
+	RUN opam pin add -k version ocaml-variants 5.4.1+options
 	RUN opam install -y opam-depext
 	ENTRYPOINT [ "opam", "exec", "--" ]
 	CMD bash
 	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
 
-5.4.0+flambda/amd64
+5.4.1+flambda/amd64
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:alpine-3.23-opam-amd64
@@ -1717,8 +1730,8 @@ ocurrent/opam-staging:alpine-3.23-ocaml-5.4-afl-arm64, ocurrent/opam-staging:alp
 	RUN apk update && apk upgrade
 	RUN apk add zstd
 	USER opam
-	RUN opam switch create 5.4 --packages=ocaml-variants.5.4.0+options,ocaml-options-only-flambda
-	RUN opam pin add -k version ocaml-variants 5.4.0+options
+	RUN opam switch create 5.4 --packages=ocaml-variants.5.4.1+options,ocaml-options-only-flambda
+	RUN opam pin add -k version ocaml-variants 5.4.1+options
 	RUN opam install -y opam-depext
 	ENTRYPOINT [ "opam", "exec", "--" ]
 	CMD bash
@@ -1726,7 +1739,7 @@ ocurrent/opam-staging:alpine-3.23-ocaml-5.4-afl-arm64, ocurrent/opam-staging:alp
 
 ocurrent/opam-staging:alpine-3.23-ocaml-5.4-flambda-arm64, ocurrent/opam-staging:alpine-3.23-ocaml-5.4-flambda-amd64 -> ocaml/opam:alpine-3.23-ocaml-5.4-flambda
 ocurrent/opam-staging:alpine-3.23-ocaml-5.4-flambda-arm64, ocurrent/opam-staging:alpine-3.23-ocaml-5.4-flambda-amd64 -> ocaml/opam:alpine-ocaml-5.4-flambda
-5.4.0+no-flat-float-array/arm64
+5.4.1+no-flat-float-array/arm64
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:alpine-3.23-opam-arm64
@@ -1735,14 +1748,14 @@ ocurrent/opam-staging:alpine-3.23-ocaml-5.4-flambda-arm64, ocurrent/opam-staging
 	RUN apk update && apk upgrade
 	RUN apk add zstd
 	USER opam
-	RUN opam switch create 5.4 --packages=ocaml-variants.5.4.0+options,ocaml-options-only-no-flat-float-array
-	RUN opam pin add -k version ocaml-variants 5.4.0+options
+	RUN opam switch create 5.4 --packages=ocaml-variants.5.4.1+options,ocaml-options-only-no-flat-float-array
+	RUN opam pin add -k version ocaml-variants 5.4.1+options
 	RUN opam install -y opam-depext
 	ENTRYPOINT [ "opam", "exec", "--" ]
 	CMD bash
 	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
 
-5.4.0+no-flat-float-array/amd64
+5.4.1+no-flat-float-array/amd64
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:alpine-3.23-opam-amd64
@@ -1751,8 +1764,8 @@ ocurrent/opam-staging:alpine-3.23-ocaml-5.4-flambda-arm64, ocurrent/opam-staging
 	RUN apk update && apk upgrade
 	RUN apk add zstd
 	USER opam
-	RUN opam switch create 5.4 --packages=ocaml-variants.5.4.0+options,ocaml-options-only-no-flat-float-array
-	RUN opam pin add -k version ocaml-variants 5.4.0+options
+	RUN opam switch create 5.4 --packages=ocaml-variants.5.4.1+options,ocaml-options-only-no-flat-float-array
+	RUN opam pin add -k version ocaml-variants 5.4.1+options
 	RUN opam install -y opam-depext
 	ENTRYPOINT [ "opam", "exec", "--" ]
 	CMD bash
@@ -2063,13 +2076,14 @@ ocurrent/opam-staging:archlinux-ocaml-4.12-amd64 -> ocaml/opam:archlinux-ocaml-4
 	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
 
 ocurrent/opam-staging:archlinux-ocaml-4.13-amd64 -> ocaml/opam:archlinux-ocaml-4.13
-4.14.2/amd64
+4.14.3/amd64
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:archlinux-opam-amd64
+	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.14 --packages=ocaml-base-compiler.4.14.2
-	RUN opam pin add -k version ocaml-base-compiler 4.14.2
+	RUN opam switch create 4.14 --packages=ocaml-base-compiler.4.14.3
+	RUN opam pin add -k version ocaml-base-compiler 4.14.3
 	RUN opam install -y opam-depext
 	ENTRYPOINT [ "opam", "exec", "--" ]
 	CMD bash
@@ -2138,7 +2152,7 @@ ocurrent/opam-staging:archlinux-ocaml-5.2-amd64 -> ocaml/opam:archlinux-ocaml-5.
 	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
 
 ocurrent/opam-staging:archlinux-ocaml-5.3-amd64 -> ocaml/opam:archlinux-ocaml-5.3
-5.4.0/amd64
+5.4.1/amd64
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:archlinux-opam-amd64
@@ -2146,8 +2160,8 @@ ocurrent/opam-staging:archlinux-ocaml-5.3-amd64 -> ocaml/opam:archlinux-ocaml-5.
 	USER root
 	RUN pacman -Syu --noconfirm zstd && yes | pacman -Scc
 	USER opam
-	RUN opam switch create 5.4 --packages=ocaml-base-compiler.5.4.0
-	RUN opam pin add -k version ocaml-base-compiler 5.4.0
+	RUN opam switch create 5.4 --packages=ocaml-base-compiler.5.4.1
+	RUN opam pin add -k version ocaml-base-compiler 5.4.1
 	RUN opam install -y opam-depext
 	ENTRYPOINT [ "opam", "exec", "--" ]
 	CMD bash
@@ -2337,13 +2351,13 @@ ocurrent/opam-staging:centos-9-ocaml-4.12-amd64 -> ocaml/opam:centos-9-ocaml-4.1
 	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
 
 ocurrent/opam-staging:centos-9-ocaml-4.13-amd64 -> ocaml/opam:centos-9-ocaml-4.13
-4.14.2/amd64
+4.14.3/amd64
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:centos-9-opam-amd64
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.14 --packages=ocaml-base-compiler.4.14.2
-	RUN opam pin add -k version ocaml-base-compiler 4.14.2
+	RUN opam switch create 4.14 --packages=ocaml-base-compiler.4.14.3
+	RUN opam pin add -k version ocaml-base-compiler 4.14.3
 	RUN opam install -y opam-depext
 	ENTRYPOINT [ "opam", "exec", "--" ]
 	CMD bash
@@ -2411,7 +2425,7 @@ ocurrent/opam-staging:centos-9-ocaml-5.2-amd64 -> ocaml/opam:centos-9-ocaml-5.2
 	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
 
 ocurrent/opam-staging:centos-9-ocaml-5.3-amd64 -> ocaml/opam:centos-9-ocaml-5.3
-5.4.0/amd64
+5.4.1/amd64
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:centos-9-opam-amd64
@@ -2419,8 +2433,8 @@ ocurrent/opam-staging:centos-9-ocaml-5.3-amd64 -> ocaml/opam:centos-9-ocaml-5.3
 	USER root
 	RUN yum install -y zstd && yum clean packages
 	USER opam
-	RUN opam switch create 5.4 --packages=ocaml-base-compiler.5.4.0
-	RUN opam pin add -k version ocaml-base-compiler 5.4.0
+	RUN opam switch create 5.4 --packages=ocaml-base-compiler.5.4.1
+	RUN opam pin add -k version ocaml-base-compiler 5.4.1
 	RUN opam install -y opam-depext
 	ENTRYPOINT [ "opam", "exec", "--" ]
 	CMD bash
@@ -2616,13 +2630,13 @@ ocurrent/opam-staging:centos-10-ocaml-4.12-amd64 -> ocaml/opam:centos-ocaml-4.12
 
 ocurrent/opam-staging:centos-10-ocaml-4.13-amd64 -> ocaml/opam:centos-10-ocaml-4.13
 ocurrent/opam-staging:centos-10-ocaml-4.13-amd64 -> ocaml/opam:centos-ocaml-4.13
-4.14.2/amd64
+4.14.3/amd64
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:centos-10-opam-amd64
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.14 --packages=ocaml-base-compiler.4.14.2
-	RUN opam pin add -k version ocaml-base-compiler 4.14.2
+	RUN opam switch create 4.14 --packages=ocaml-base-compiler.4.14.3
+	RUN opam pin add -k version ocaml-base-compiler 4.14.3
 	RUN opam install -y opam-depext
 	ENTRYPOINT [ "opam", "exec", "--" ]
 	CMD bash
@@ -2695,7 +2709,7 @@ ocurrent/opam-staging:centos-10-ocaml-5.2-amd64 -> ocaml/opam:centos-ocaml-5.2
 
 ocurrent/opam-staging:centos-10-ocaml-5.3-amd64 -> ocaml/opam:centos-10-ocaml-5.3
 ocurrent/opam-staging:centos-10-ocaml-5.3-amd64 -> ocaml/opam:centos-ocaml-5.3
-5.4.0/amd64
+5.4.1/amd64
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:centos-10-opam-amd64
@@ -2703,8 +2717,8 @@ ocurrent/opam-staging:centos-10-ocaml-5.3-amd64 -> ocaml/opam:centos-ocaml-5.3
 	USER root
 	RUN yum install -y zstd && yum clean packages
 	USER opam
-	RUN opam switch create 5.4 --packages=ocaml-base-compiler.5.4.0
-	RUN opam pin add -k version ocaml-base-compiler 5.4.0
+	RUN opam switch create 5.4 --packages=ocaml-base-compiler.5.4.1
+	RUN opam pin add -k version ocaml-base-compiler 5.4.1
 	RUN opam install -y opam-depext
 	ENTRYPOINT [ "opam", "exec", "--" ]
 	CMD bash
@@ -2776,7 +2790,7 @@ debian-12/s390x
 	RUN chmod 440 /etc/sudoers.d/opam
 	RUN chown root:root /etc/sudoers.d/opam
 	RUN if getent passwd 1000; then userdel -r $(id -nu 1000); fi
-	RUN adduser --uid 1000 --disabled-password --gecos '' opam
+	RUN useradd --uid 1000 --create-home --shell /bin/bash opam
 	RUN passwd -l opam
 	RUN chown -R opam:opam /home/opam
 	USER opam
@@ -2861,7 +2875,7 @@ debian-12/ppc64le
 	RUN chmod 440 /etc/sudoers.d/opam
 	RUN chown root:root /etc/sudoers.d/opam
 	RUN if getent passwd 1000; then userdel -r $(id -nu 1000); fi
-	RUN adduser --uid 1000 --disabled-password --gecos '' opam
+	RUN useradd --uid 1000 --create-home --shell /bin/bash opam
 	RUN passwd -l opam
 	RUN chown -R opam:opam /home/opam
 	USER opam
@@ -2948,7 +2962,7 @@ debian-12/arm32v7
 	RUN chmod 440 /etc/sudoers.d/opam
 	RUN chown root:root /etc/sudoers.d/opam
 	RUN if getent passwd 1000; then userdel -r $(id -nu 1000); fi
-	RUN adduser --uid 1000 --disabled-password --gecos '' opam
+	RUN useradd --uid 1000 --create-home --shell /bin/bash opam
 	RUN passwd -l opam
 	RUN chown -R opam:opam /home/opam
 	USER opam
@@ -3034,7 +3048,7 @@ debian-12/arm64
 	RUN chmod 440 /etc/sudoers.d/opam
 	RUN chown root:root /etc/sudoers.d/opam
 	RUN if getent passwd 1000; then userdel -r $(id -nu 1000); fi
-	RUN adduser --uid 1000 --disabled-password --gecos '' opam
+	RUN useradd --uid 1000 --create-home --shell /bin/bash opam
 	RUN passwd -l opam
 	RUN chown -R opam:opam /home/opam
 	USER opam
@@ -3119,7 +3133,7 @@ debian-12/amd64
 	RUN chmod 440 /etc/sudoers.d/opam
 	RUN chown root:root /etc/sudoers.d/opam
 	RUN if getent passwd 1000; then userdel -r $(id -nu 1000); fi
-	RUN adduser --uid 1000 --disabled-password --gecos '' opam
+	RUN useradd --uid 1000 --create-home --shell /bin/bash opam
 	RUN passwd -l opam
 	RUN chown -R opam:opam /home/opam
 	USER opam
@@ -3206,7 +3220,7 @@ debian-12/i386
 	RUN chmod 440 /etc/sudoers.d/opam
 	RUN chown root:root /etc/sudoers.d/opam
 	RUN if getent passwd 1000; then userdel -r $(id -nu 1000); fi
-	RUN adduser --uid 1000 --disabled-password --gecos '' opam
+	RUN useradd --uid 1000 --create-home --shell /bin/bash opam
 	RUN passwd -l opam
 	RUN chown -R opam:opam /home/opam
 	USER opam
@@ -3700,75 +3714,75 @@ ocurrent/opam-staging:debian-12-ocaml-4.12-s390x, ocurrent/opam-staging:debian-1
 	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
 
 ocurrent/opam-staging:debian-12-ocaml-4.13-s390x, ocurrent/opam-staging:debian-12-ocaml-4.13-ppc64le, ocurrent/opam-staging:debian-12-ocaml-4.13-arm32v7, ocurrent/opam-staging:debian-12-ocaml-4.13-arm64, ocurrent/opam-staging:debian-12-ocaml-4.13-amd64, ocurrent/opam-staging:debian-12-ocaml-4.13-i386 -> ocaml/opam:debian-12-ocaml-4.13
-4.14.2/s390x
+4.14.3/s390x
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-s390x
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.14 --packages=ocaml-base-compiler.4.14.2
-	RUN opam pin add -k version ocaml-base-compiler 4.14.2
+	RUN opam switch create 4.14 --packages=ocaml-base-compiler.4.14.3
+	RUN opam pin add -k version ocaml-base-compiler 4.14.3
 	RUN opam install -y opam-depext
 	ENTRYPOINT [ "opam", "exec", "--" ]
 	CMD bash
 	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
 
-4.14.2/ppc64le
+4.14.3/ppc64le
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-ppc64le
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.14 --packages=ocaml-base-compiler.4.14.2
-	RUN opam pin add -k version ocaml-base-compiler 4.14.2
+	RUN opam switch create 4.14 --packages=ocaml-base-compiler.4.14.3
+	RUN opam pin add -k version ocaml-base-compiler 4.14.3
 	RUN opam install -y opam-depext
 	ENTRYPOINT [ "opam", "exec", "--" ]
 	CMD bash
 	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
 
-4.14.2/arm32v7
+4.14.3/arm32v7
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-arm32v7
 	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.14 --packages=ocaml-base-compiler.4.14.2
-	RUN opam pin add -k version ocaml-base-compiler 4.14.2
+	RUN opam switch create 4.14 --packages=ocaml-base-compiler.4.14.3
+	RUN opam pin add -k version ocaml-base-compiler 4.14.3
 	RUN opam install -y opam-depext
 	ENTRYPOINT [ "/usr/bin/linux32", "opam", "exec", "--" ]
 	CMD bash
 	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
 
-4.14.2/arm64
+4.14.3/arm64
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-arm64
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.14 --packages=ocaml-base-compiler.4.14.2
-	RUN opam pin add -k version ocaml-base-compiler 4.14.2
+	RUN opam switch create 4.14 --packages=ocaml-base-compiler.4.14.3
+	RUN opam pin add -k version ocaml-base-compiler 4.14.3
 	RUN opam install -y opam-depext
 	ENTRYPOINT [ "opam", "exec", "--" ]
 	CMD bash
 	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
 
-4.14.2/amd64
+4.14.3/amd64
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-amd64
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.14 --packages=ocaml-base-compiler.4.14.2
-	RUN opam pin add -k version ocaml-base-compiler 4.14.2
+	RUN opam switch create 4.14 --packages=ocaml-base-compiler.4.14.3
+	RUN opam pin add -k version ocaml-base-compiler 4.14.3
 	RUN opam install -y opam-depext
 	ENTRYPOINT [ "opam", "exec", "--" ]
 	CMD bash
 	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
 
-4.14.2/i386
+4.14.3/i386
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-i386
 	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.14 --packages=ocaml-base-compiler.4.14.2
-	RUN opam pin add -k version ocaml-base-compiler 4.14.2
+	RUN opam switch create 4.14 --packages=ocaml-base-compiler.4.14.3
+	RUN opam pin add -k version ocaml-base-compiler 4.14.3
 	RUN opam install -y opam-depext
 	ENTRYPOINT [ "/usr/bin/linux32", "opam", "exec", "--" ]
 	CMD bash
@@ -4165,7 +4179,7 @@ ocurrent/opam-staging:debian-12-ocaml-5.2-s390x, ocurrent/opam-staging:debian-12
 	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
 
 ocurrent/opam-staging:debian-12-ocaml-5.3-s390x, ocurrent/opam-staging:debian-12-ocaml-5.3-ppc64le, ocurrent/opam-staging:debian-12-ocaml-5.3-arm32v7, ocurrent/opam-staging:debian-12-ocaml-5.3-arm64, ocurrent/opam-staging:debian-12-ocaml-5.3-amd64, ocurrent/opam-staging:debian-12-ocaml-5.3-i386 -> ocaml/opam:debian-12-ocaml-5.3
-5.4.0/s390x
+5.4.1/s390x
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-s390x
@@ -4175,14 +4189,14 @@ ocurrent/opam-staging:debian-12-ocaml-5.3-s390x, ocurrent/opam-staging:debian-12
 	RUN DEBIAN_FRONTEND=noninteractive apt-get -y upgrade
 	RUN DEBIAN_FRONTEND=noninteractive apt-get -y install libzstd-dev
 	USER opam
-	RUN opam switch create 5.4 --packages=ocaml-base-compiler.5.4.0
-	RUN opam pin add -k version ocaml-base-compiler 5.4.0
+	RUN opam switch create 5.4 --packages=ocaml-base-compiler.5.4.1
+	RUN opam pin add -k version ocaml-base-compiler 5.4.1
 	RUN opam install -y opam-depext
 	ENTRYPOINT [ "opam", "exec", "--" ]
 	CMD bash
 	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
 
-5.4.0/ppc64le
+5.4.1/ppc64le
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-ppc64le
@@ -4192,14 +4206,14 @@ ocurrent/opam-staging:debian-12-ocaml-5.3-s390x, ocurrent/opam-staging:debian-12
 	RUN DEBIAN_FRONTEND=noninteractive apt-get -y upgrade
 	RUN DEBIAN_FRONTEND=noninteractive apt-get -y install libzstd-dev
 	USER opam
-	RUN opam switch create 5.4 --packages=ocaml-base-compiler.5.4.0
-	RUN opam pin add -k version ocaml-base-compiler 5.4.0
+	RUN opam switch create 5.4 --packages=ocaml-base-compiler.5.4.1
+	RUN opam pin add -k version ocaml-base-compiler 5.4.1
 	RUN opam install -y opam-depext
 	ENTRYPOINT [ "opam", "exec", "--" ]
 	CMD bash
 	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
 
-5.4.0/arm32v7
+5.4.1/arm32v7
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-arm32v7
@@ -4210,14 +4224,14 @@ ocurrent/opam-staging:debian-12-ocaml-5.3-s390x, ocurrent/opam-staging:debian-12
 	RUN DEBIAN_FRONTEND=noninteractive apt-get -y upgrade
 	RUN DEBIAN_FRONTEND=noninteractive apt-get -y install libzstd-dev
 	USER opam
-	RUN opam switch create 5.4 --packages=ocaml-base-compiler.5.4.0
-	RUN opam pin add -k version ocaml-base-compiler 5.4.0
+	RUN opam switch create 5.4 --packages=ocaml-base-compiler.5.4.1
+	RUN opam pin add -k version ocaml-base-compiler 5.4.1
 	RUN opam install -y opam-depext
 	ENTRYPOINT [ "/usr/bin/linux32", "opam", "exec", "--" ]
 	CMD bash
 	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
 
-5.4.0/arm64
+5.4.1/arm64
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-arm64
@@ -4227,14 +4241,14 @@ ocurrent/opam-staging:debian-12-ocaml-5.3-s390x, ocurrent/opam-staging:debian-12
 	RUN DEBIAN_FRONTEND=noninteractive apt-get -y upgrade
 	RUN DEBIAN_FRONTEND=noninteractive apt-get -y install libzstd-dev
 	USER opam
-	RUN opam switch create 5.4 --packages=ocaml-base-compiler.5.4.0
-	RUN opam pin add -k version ocaml-base-compiler 5.4.0
+	RUN opam switch create 5.4 --packages=ocaml-base-compiler.5.4.1
+	RUN opam pin add -k version ocaml-base-compiler 5.4.1
 	RUN opam install -y opam-depext
 	ENTRYPOINT [ "opam", "exec", "--" ]
 	CMD bash
 	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
 
-5.4.0/amd64
+5.4.1/amd64
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-amd64
@@ -4244,14 +4258,14 @@ ocurrent/opam-staging:debian-12-ocaml-5.3-s390x, ocurrent/opam-staging:debian-12
 	RUN DEBIAN_FRONTEND=noninteractive apt-get -y upgrade
 	RUN DEBIAN_FRONTEND=noninteractive apt-get -y install libzstd-dev
 	USER opam
-	RUN opam switch create 5.4 --packages=ocaml-base-compiler.5.4.0
-	RUN opam pin add -k version ocaml-base-compiler 5.4.0
+	RUN opam switch create 5.4 --packages=ocaml-base-compiler.5.4.1
+	RUN opam pin add -k version ocaml-base-compiler 5.4.1
 	RUN opam install -y opam-depext
 	ENTRYPOINT [ "opam", "exec", "--" ]
 	CMD bash
 	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
 
-5.4.0/i386
+5.4.1/i386
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-12-opam-i386
@@ -4262,8 +4276,8 @@ ocurrent/opam-staging:debian-12-ocaml-5.3-s390x, ocurrent/opam-staging:debian-12
 	RUN DEBIAN_FRONTEND=noninteractive apt-get -y upgrade
 	RUN DEBIAN_FRONTEND=noninteractive apt-get -y install libzstd-dev
 	USER opam
-	RUN opam switch create 5.4 --packages=ocaml-base-compiler.5.4.0
-	RUN opam pin add -k version ocaml-base-compiler 5.4.0
+	RUN opam switch create 5.4 --packages=ocaml-base-compiler.5.4.1
+	RUN opam pin add -k version ocaml-base-compiler 5.4.1
 	RUN opam install -y opam-depext
 	ENTRYPOINT [ "/usr/bin/linux32", "opam", "exec", "--" ]
 	CMD bash
@@ -4426,7 +4440,7 @@ debian-13/riscv64
 	RUN chmod 440 /etc/sudoers.d/opam
 	RUN chown root:root /etc/sudoers.d/opam
 	RUN if getent passwd 1000; then userdel -r $(id -nu 1000); fi
-	RUN adduser --uid 1000 --disabled-password --gecos '' opam
+	RUN useradd --uid 1000 --create-home --shell /bin/bash opam
 	RUN passwd -l opam
 	RUN chown -R opam:opam /home/opam
 	USER opam
@@ -4511,7 +4525,7 @@ debian-13/s390x
 	RUN chmod 440 /etc/sudoers.d/opam
 	RUN chown root:root /etc/sudoers.d/opam
 	RUN if getent passwd 1000; then userdel -r $(id -nu 1000); fi
-	RUN adduser --uid 1000 --disabled-password --gecos '' opam
+	RUN useradd --uid 1000 --create-home --shell /bin/bash opam
 	RUN passwd -l opam
 	RUN chown -R opam:opam /home/opam
 	USER opam
@@ -4596,7 +4610,7 @@ debian-13/ppc64le
 	RUN chmod 440 /etc/sudoers.d/opam
 	RUN chown root:root /etc/sudoers.d/opam
 	RUN if getent passwd 1000; then userdel -r $(id -nu 1000); fi
-	RUN adduser --uid 1000 --disabled-password --gecos '' opam
+	RUN useradd --uid 1000 --create-home --shell /bin/bash opam
 	RUN passwd -l opam
 	RUN chown -R opam:opam /home/opam
 	USER opam
@@ -4683,7 +4697,7 @@ debian-13/arm32v7
 	RUN chmod 440 /etc/sudoers.d/opam
 	RUN chown root:root /etc/sudoers.d/opam
 	RUN if getent passwd 1000; then userdel -r $(id -nu 1000); fi
-	RUN adduser --uid 1000 --disabled-password --gecos '' opam
+	RUN useradd --uid 1000 --create-home --shell /bin/bash opam
 	RUN passwd -l opam
 	RUN chown -R opam:opam /home/opam
 	USER opam
@@ -4769,7 +4783,7 @@ debian-13/arm64
 	RUN chmod 440 /etc/sudoers.d/opam
 	RUN chown root:root /etc/sudoers.d/opam
 	RUN if getent passwd 1000; then userdel -r $(id -nu 1000); fi
-	RUN adduser --uid 1000 --disabled-password --gecos '' opam
+	RUN useradd --uid 1000 --create-home --shell /bin/bash opam
 	RUN passwd -l opam
 	RUN chown -R opam:opam /home/opam
 	USER opam
@@ -4854,7 +4868,7 @@ debian-13/amd64
 	RUN chmod 440 /etc/sudoers.d/opam
 	RUN chown root:root /etc/sudoers.d/opam
 	RUN if getent passwd 1000; then userdel -r $(id -nu 1000); fi
-	RUN adduser --uid 1000 --disabled-password --gecos '' opam
+	RUN useradd --uid 1000 --create-home --shell /bin/bash opam
 	RUN passwd -l opam
 	RUN chown -R opam:opam /home/opam
 	USER opam
@@ -4941,7 +4955,7 @@ debian-13/i386
 	RUN chmod 440 /etc/sudoers.d/opam
 	RUN chown root:root /etc/sudoers.d/opam
 	RUN if getent passwd 1000; then userdel -r $(id -nu 1000); fi
-	RUN adduser --uid 1000 --disabled-password --gecos '' opam
+	RUN useradd --uid 1000 --create-home --shell /bin/bash opam
 	RUN passwd -l opam
 	RUN chown -R opam:opam /home/opam
 	USER opam
@@ -6953,87 +6967,87 @@ ocurrent/opam-staging:debian-13-ocaml-4.13-nnpchecker-amd64 -> ocaml/opam:debian
 
 ocurrent/opam-staging:debian-13-ocaml-4.13-no-flat-float-array-riscv64, ocurrent/opam-staging:debian-13-ocaml-4.13-no-flat-float-array-s390x, ocurrent/opam-staging:debian-13-ocaml-4.13-no-flat-float-array-ppc64le, ocurrent/opam-staging:debian-13-ocaml-4.13-no-flat-float-array-arm32v7, ocurrent/opam-staging:debian-13-ocaml-4.13-no-flat-float-array-arm64, ocurrent/opam-staging:debian-13-ocaml-4.13-no-flat-float-array-amd64, ocurrent/opam-staging:debian-13-ocaml-4.13-no-flat-float-array-i386 -> ocaml/opam:debian-13-ocaml-4.13-no-flat-float-array
 ocurrent/opam-staging:debian-13-ocaml-4.13-no-flat-float-array-riscv64, ocurrent/opam-staging:debian-13-ocaml-4.13-no-flat-float-array-s390x, ocurrent/opam-staging:debian-13-ocaml-4.13-no-flat-float-array-ppc64le, ocurrent/opam-staging:debian-13-ocaml-4.13-no-flat-float-array-arm32v7, ocurrent/opam-staging:debian-13-ocaml-4.13-no-flat-float-array-arm64, ocurrent/opam-staging:debian-13-ocaml-4.13-no-flat-float-array-amd64, ocurrent/opam-staging:debian-13-ocaml-4.13-no-flat-float-array-i386 -> ocaml/opam:debian-ocaml-4.13-no-flat-float-array
-4.14.2/riscv64
+4.14.3/riscv64
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-13-opam-riscv64
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.14 --packages=ocaml-base-compiler.4.14.2
-	RUN opam pin add -k version ocaml-base-compiler 4.14.2
+	RUN opam switch create 4.14 --packages=ocaml-base-compiler.4.14.3
+	RUN opam pin add -k version ocaml-base-compiler 4.14.3
 	RUN opam install -y opam-depext
 	ENTRYPOINT [ "opam", "exec", "--" ]
 	CMD bash
 	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
 
-4.14.2/s390x
+4.14.3/s390x
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-13-opam-s390x
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.14 --packages=ocaml-base-compiler.4.14.2
-	RUN opam pin add -k version ocaml-base-compiler 4.14.2
+	RUN opam switch create 4.14 --packages=ocaml-base-compiler.4.14.3
+	RUN opam pin add -k version ocaml-base-compiler 4.14.3
 	RUN opam install -y opam-depext
 	ENTRYPOINT [ "opam", "exec", "--" ]
 	CMD bash
 	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
 
-4.14.2/ppc64le
+4.14.3/ppc64le
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-13-opam-ppc64le
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.14 --packages=ocaml-base-compiler.4.14.2
-	RUN opam pin add -k version ocaml-base-compiler 4.14.2
+	RUN opam switch create 4.14 --packages=ocaml-base-compiler.4.14.3
+	RUN opam pin add -k version ocaml-base-compiler 4.14.3
 	RUN opam install -y opam-depext
 	ENTRYPOINT [ "opam", "exec", "--" ]
 	CMD bash
 	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
 
-4.14.2/arm32v7
+4.14.3/arm32v7
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-13-opam-arm32v7
 	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.14 --packages=ocaml-base-compiler.4.14.2
-	RUN opam pin add -k version ocaml-base-compiler 4.14.2
+	RUN opam switch create 4.14 --packages=ocaml-base-compiler.4.14.3
+	RUN opam pin add -k version ocaml-base-compiler 4.14.3
 	RUN opam install -y opam-depext
 	ENTRYPOINT [ "/usr/bin/linux32", "opam", "exec", "--" ]
 	CMD bash
 	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
 
-4.14.2/arm64
+4.14.3/arm64
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-13-opam-arm64
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.14 --packages=ocaml-base-compiler.4.14.2
-	RUN opam pin add -k version ocaml-base-compiler 4.14.2
+	RUN opam switch create 4.14 --packages=ocaml-base-compiler.4.14.3
+	RUN opam pin add -k version ocaml-base-compiler 4.14.3
 	RUN opam install -y opam-depext
 	ENTRYPOINT [ "opam", "exec", "--" ]
 	CMD bash
 	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
 
-4.14.2/amd64
+4.14.3/amd64
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-13-opam-amd64
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.14 --packages=ocaml-base-compiler.4.14.2
-	RUN opam pin add -k version ocaml-base-compiler 4.14.2
+	RUN opam switch create 4.14 --packages=ocaml-base-compiler.4.14.3
+	RUN opam pin add -k version ocaml-base-compiler 4.14.3
 	RUN opam install -y opam-depext
 	ENTRYPOINT [ "opam", "exec", "--" ]
 	CMD bash
 	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
 
-4.14.2/i386
+4.14.3/i386
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-13-opam-i386
 	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.14 --packages=ocaml-base-compiler.4.14.2
-	RUN opam pin add -k version ocaml-base-compiler 4.14.2
+	RUN opam switch create 4.14 --packages=ocaml-base-compiler.4.14.3
+	RUN opam pin add -k version ocaml-base-compiler 4.14.3
 	RUN opam install -y opam-depext
 	ENTRYPOINT [ "/usr/bin/linux32", "opam", "exec", "--" ]
 	CMD bash
@@ -7041,87 +7055,87 @@ ocurrent/opam-staging:debian-13-ocaml-4.13-no-flat-float-array-riscv64, ocurrent
 
 ocurrent/opam-staging:debian-13-ocaml-4.14-riscv64, ocurrent/opam-staging:debian-13-ocaml-4.14-s390x, ocurrent/opam-staging:debian-13-ocaml-4.14-ppc64le, ocurrent/opam-staging:debian-13-ocaml-4.14-arm32v7, ocurrent/opam-staging:debian-13-ocaml-4.14-arm64, ocurrent/opam-staging:debian-13-ocaml-4.14-amd64, ocurrent/opam-staging:debian-13-ocaml-4.14-i386 -> ocaml/opam:debian-13-ocaml-4.14
 ocurrent/opam-staging:debian-13-ocaml-4.14-riscv64, ocurrent/opam-staging:debian-13-ocaml-4.14-s390x, ocurrent/opam-staging:debian-13-ocaml-4.14-ppc64le, ocurrent/opam-staging:debian-13-ocaml-4.14-arm32v7, ocurrent/opam-staging:debian-13-ocaml-4.14-arm64, ocurrent/opam-staging:debian-13-ocaml-4.14-amd64, ocurrent/opam-staging:debian-13-ocaml-4.14-i386 -> ocaml/opam:debian-ocaml-4.14
-4.14.2+afl/riscv64
+4.14.3+afl/riscv64
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-13-opam-riscv64
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.14 --packages=ocaml-variants.4.14.2+options,ocaml-options-only-afl
-	RUN opam pin add -k version ocaml-variants 4.14.2+options
+	RUN opam switch create 4.14 --packages=ocaml-variants.4.14.3+options,ocaml-options-only-afl
+	RUN opam pin add -k version ocaml-variants 4.14.3+options
 	RUN opam install -y opam-depext
 	ENTRYPOINT [ "opam", "exec", "--" ]
 	CMD bash
 	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
 
-4.14.2+afl/s390x
+4.14.3+afl/s390x
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-13-opam-s390x
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.14 --packages=ocaml-variants.4.14.2+options,ocaml-options-only-afl
-	RUN opam pin add -k version ocaml-variants 4.14.2+options
+	RUN opam switch create 4.14 --packages=ocaml-variants.4.14.3+options,ocaml-options-only-afl
+	RUN opam pin add -k version ocaml-variants 4.14.3+options
 	RUN opam install -y opam-depext
 	ENTRYPOINT [ "opam", "exec", "--" ]
 	CMD bash
 	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
 
-4.14.2+afl/ppc64le
+4.14.3+afl/ppc64le
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-13-opam-ppc64le
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.14 --packages=ocaml-variants.4.14.2+options,ocaml-options-only-afl
-	RUN opam pin add -k version ocaml-variants 4.14.2+options
+	RUN opam switch create 4.14 --packages=ocaml-variants.4.14.3+options,ocaml-options-only-afl
+	RUN opam pin add -k version ocaml-variants 4.14.3+options
 	RUN opam install -y opam-depext
 	ENTRYPOINT [ "opam", "exec", "--" ]
 	CMD bash
 	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
 
-4.14.2+afl/arm32v7
+4.14.3+afl/arm32v7
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-13-opam-arm32v7
 	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.14 --packages=ocaml-variants.4.14.2+options,ocaml-options-only-afl
-	RUN opam pin add -k version ocaml-variants 4.14.2+options
+	RUN opam switch create 4.14 --packages=ocaml-variants.4.14.3+options,ocaml-options-only-afl
+	RUN opam pin add -k version ocaml-variants 4.14.3+options
 	RUN opam install -y opam-depext
 	ENTRYPOINT [ "/usr/bin/linux32", "opam", "exec", "--" ]
 	CMD bash
 	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
 
-4.14.2+afl/arm64
+4.14.3+afl/arm64
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-13-opam-arm64
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.14 --packages=ocaml-variants.4.14.2+options,ocaml-options-only-afl
-	RUN opam pin add -k version ocaml-variants 4.14.2+options
+	RUN opam switch create 4.14 --packages=ocaml-variants.4.14.3+options,ocaml-options-only-afl
+	RUN opam pin add -k version ocaml-variants 4.14.3+options
 	RUN opam install -y opam-depext
 	ENTRYPOINT [ "opam", "exec", "--" ]
 	CMD bash
 	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
 
-4.14.2+afl/amd64
+4.14.3+afl/amd64
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-13-opam-amd64
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.14 --packages=ocaml-variants.4.14.2+options,ocaml-options-only-afl
-	RUN opam pin add -k version ocaml-variants 4.14.2+options
+	RUN opam switch create 4.14 --packages=ocaml-variants.4.14.3+options,ocaml-options-only-afl
+	RUN opam pin add -k version ocaml-variants 4.14.3+options
 	RUN opam install -y opam-depext
 	ENTRYPOINT [ "opam", "exec", "--" ]
 	CMD bash
 	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
 
-4.14.2+afl/i386
+4.14.3+afl/i386
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-13-opam-i386
 	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.14 --packages=ocaml-variants.4.14.2+options,ocaml-options-only-afl
-	RUN opam pin add -k version ocaml-variants 4.14.2+options
+	RUN opam switch create 4.14 --packages=ocaml-variants.4.14.3+options,ocaml-options-only-afl
+	RUN opam pin add -k version ocaml-variants 4.14.3+options
 	RUN opam install -y opam-depext
 	ENTRYPOINT [ "/usr/bin/linux32", "opam", "exec", "--" ]
 	CMD bash
@@ -7129,87 +7143,87 @@ ocurrent/opam-staging:debian-13-ocaml-4.14-riscv64, ocurrent/opam-staging:debian
 
 ocurrent/opam-staging:debian-13-ocaml-4.14-afl-riscv64, ocurrent/opam-staging:debian-13-ocaml-4.14-afl-s390x, ocurrent/opam-staging:debian-13-ocaml-4.14-afl-ppc64le, ocurrent/opam-staging:debian-13-ocaml-4.14-afl-arm32v7, ocurrent/opam-staging:debian-13-ocaml-4.14-afl-arm64, ocurrent/opam-staging:debian-13-ocaml-4.14-afl-amd64, ocurrent/opam-staging:debian-13-ocaml-4.14-afl-i386 -> ocaml/opam:debian-13-ocaml-4.14-afl
 ocurrent/opam-staging:debian-13-ocaml-4.14-afl-riscv64, ocurrent/opam-staging:debian-13-ocaml-4.14-afl-s390x, ocurrent/opam-staging:debian-13-ocaml-4.14-afl-ppc64le, ocurrent/opam-staging:debian-13-ocaml-4.14-afl-arm32v7, ocurrent/opam-staging:debian-13-ocaml-4.14-afl-arm64, ocurrent/opam-staging:debian-13-ocaml-4.14-afl-amd64, ocurrent/opam-staging:debian-13-ocaml-4.14-afl-i386 -> ocaml/opam:debian-ocaml-4.14-afl
-4.14.2+flambda/riscv64
+4.14.3+flambda/riscv64
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-13-opam-riscv64
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.14 --packages=ocaml-variants.4.14.2+options,ocaml-options-only-flambda
-	RUN opam pin add -k version ocaml-variants 4.14.2+options
+	RUN opam switch create 4.14 --packages=ocaml-variants.4.14.3+options,ocaml-options-only-flambda
+	RUN opam pin add -k version ocaml-variants 4.14.3+options
 	RUN opam install -y opam-depext
 	ENTRYPOINT [ "opam", "exec", "--" ]
 	CMD bash
 	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
 
-4.14.2+flambda/s390x
+4.14.3+flambda/s390x
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-13-opam-s390x
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.14 --packages=ocaml-variants.4.14.2+options,ocaml-options-only-flambda
-	RUN opam pin add -k version ocaml-variants 4.14.2+options
+	RUN opam switch create 4.14 --packages=ocaml-variants.4.14.3+options,ocaml-options-only-flambda
+	RUN opam pin add -k version ocaml-variants 4.14.3+options
 	RUN opam install -y opam-depext
 	ENTRYPOINT [ "opam", "exec", "--" ]
 	CMD bash
 	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
 
-4.14.2+flambda/ppc64le
+4.14.3+flambda/ppc64le
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-13-opam-ppc64le
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.14 --packages=ocaml-variants.4.14.2+options,ocaml-options-only-flambda
-	RUN opam pin add -k version ocaml-variants 4.14.2+options
+	RUN opam switch create 4.14 --packages=ocaml-variants.4.14.3+options,ocaml-options-only-flambda
+	RUN opam pin add -k version ocaml-variants 4.14.3+options
 	RUN opam install -y opam-depext
 	ENTRYPOINT [ "opam", "exec", "--" ]
 	CMD bash
 	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
 
-4.14.2+flambda/arm32v7
+4.14.3+flambda/arm32v7
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-13-opam-arm32v7
 	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.14 --packages=ocaml-variants.4.14.2+options,ocaml-options-only-flambda
-	RUN opam pin add -k version ocaml-variants 4.14.2+options
+	RUN opam switch create 4.14 --packages=ocaml-variants.4.14.3+options,ocaml-options-only-flambda
+	RUN opam pin add -k version ocaml-variants 4.14.3+options
 	RUN opam install -y opam-depext
 	ENTRYPOINT [ "/usr/bin/linux32", "opam", "exec", "--" ]
 	CMD bash
 	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
 
-4.14.2+flambda/arm64
+4.14.3+flambda/arm64
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-13-opam-arm64
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.14 --packages=ocaml-variants.4.14.2+options,ocaml-options-only-flambda
-	RUN opam pin add -k version ocaml-variants 4.14.2+options
+	RUN opam switch create 4.14 --packages=ocaml-variants.4.14.3+options,ocaml-options-only-flambda
+	RUN opam pin add -k version ocaml-variants 4.14.3+options
 	RUN opam install -y opam-depext
 	ENTRYPOINT [ "opam", "exec", "--" ]
 	CMD bash
 	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
 
-4.14.2+flambda/amd64
+4.14.3+flambda/amd64
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-13-opam-amd64
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.14 --packages=ocaml-variants.4.14.2+options,ocaml-options-only-flambda
-	RUN opam pin add -k version ocaml-variants 4.14.2+options
+	RUN opam switch create 4.14 --packages=ocaml-variants.4.14.3+options,ocaml-options-only-flambda
+	RUN opam pin add -k version ocaml-variants 4.14.3+options
 	RUN opam install -y opam-depext
 	ENTRYPOINT [ "opam", "exec", "--" ]
 	CMD bash
 	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
 
-4.14.2+flambda/i386
+4.14.3+flambda/i386
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-13-opam-i386
 	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.14 --packages=ocaml-variants.4.14.2+options,ocaml-options-only-flambda
-	RUN opam pin add -k version ocaml-variants 4.14.2+options
+	RUN opam switch create 4.14 --packages=ocaml-variants.4.14.3+options,ocaml-options-only-flambda
+	RUN opam pin add -k version ocaml-variants 4.14.3+options
 	RUN opam install -y opam-depext
 	ENTRYPOINT [ "/usr/bin/linux32", "opam", "exec", "--" ]
 	CMD bash
@@ -7217,13 +7231,13 @@ ocurrent/opam-staging:debian-13-ocaml-4.14-afl-riscv64, ocurrent/opam-staging:de
 
 ocurrent/opam-staging:debian-13-ocaml-4.14-flambda-riscv64, ocurrent/opam-staging:debian-13-ocaml-4.14-flambda-s390x, ocurrent/opam-staging:debian-13-ocaml-4.14-flambda-ppc64le, ocurrent/opam-staging:debian-13-ocaml-4.14-flambda-arm32v7, ocurrent/opam-staging:debian-13-ocaml-4.14-flambda-arm64, ocurrent/opam-staging:debian-13-ocaml-4.14-flambda-amd64, ocurrent/opam-staging:debian-13-ocaml-4.14-flambda-i386 -> ocaml/opam:debian-13-ocaml-4.14-flambda
 ocurrent/opam-staging:debian-13-ocaml-4.14-flambda-riscv64, ocurrent/opam-staging:debian-13-ocaml-4.14-flambda-s390x, ocurrent/opam-staging:debian-13-ocaml-4.14-flambda-ppc64le, ocurrent/opam-staging:debian-13-ocaml-4.14-flambda-arm32v7, ocurrent/opam-staging:debian-13-ocaml-4.14-flambda-arm64, ocurrent/opam-staging:debian-13-ocaml-4.14-flambda-amd64, ocurrent/opam-staging:debian-13-ocaml-4.14-flambda-i386 -> ocaml/opam:debian-ocaml-4.14-flambda
-4.14.2+flambda+fp/amd64
+4.14.3+flambda+fp/amd64
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-13-opam-amd64
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.14 --packages=ocaml-variants.4.14.2+options,ocaml-options-only-flambda-fp
-	RUN opam pin add -k version ocaml-variants 4.14.2+options
+	RUN opam switch create 4.14 --packages=ocaml-variants.4.14.3+options,ocaml-options-only-flambda-fp
+	RUN opam pin add -k version ocaml-variants 4.14.3+options
 	RUN opam install -y opam-depext
 	ENTRYPOINT [ "opam", "exec", "--" ]
 	CMD bash
@@ -7231,13 +7245,13 @@ ocurrent/opam-staging:debian-13-ocaml-4.14-flambda-riscv64, ocurrent/opam-stagin
 
 ocurrent/opam-staging:debian-13-ocaml-4.14-flambda-fp-amd64 -> ocaml/opam:debian-13-ocaml-4.14-flambda-fp
 ocurrent/opam-staging:debian-13-ocaml-4.14-flambda-fp-amd64 -> ocaml/opam:debian-ocaml-4.14-flambda-fp
-4.14.2+fp/amd64
+4.14.3+fp/amd64
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-13-opam-amd64
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.14 --packages=ocaml-variants.4.14.2+options,ocaml-options-only-fp
-	RUN opam pin add -k version ocaml-variants 4.14.2+options
+	RUN opam switch create 4.14 --packages=ocaml-variants.4.14.3+options,ocaml-options-only-fp
+	RUN opam pin add -k version ocaml-variants 4.14.3+options
 	RUN opam install -y opam-depext
 	ENTRYPOINT [ "opam", "exec", "--" ]
 	CMD bash
@@ -7245,87 +7259,87 @@ ocurrent/opam-staging:debian-13-ocaml-4.14-flambda-fp-amd64 -> ocaml/opam:debian
 
 ocurrent/opam-staging:debian-13-ocaml-4.14-fp-amd64 -> ocaml/opam:debian-13-ocaml-4.14-fp
 ocurrent/opam-staging:debian-13-ocaml-4.14-fp-amd64 -> ocaml/opam:debian-ocaml-4.14-fp
-4.14.2+nnp/riscv64
+4.14.3+nnp/riscv64
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-13-opam-riscv64
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.14 --packages=ocaml-variants.4.14.2+options,ocaml-options-only-nnp
-	RUN opam pin add -k version ocaml-variants 4.14.2+options
+	RUN opam switch create 4.14 --packages=ocaml-variants.4.14.3+options,ocaml-options-only-nnp
+	RUN opam pin add -k version ocaml-variants 4.14.3+options
 	RUN opam install -y opam-depext
 	ENTRYPOINT [ "opam", "exec", "--" ]
 	CMD bash
 	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
 
-4.14.2+nnp/s390x
+4.14.3+nnp/s390x
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-13-opam-s390x
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.14 --packages=ocaml-variants.4.14.2+options,ocaml-options-only-nnp
-	RUN opam pin add -k version ocaml-variants 4.14.2+options
+	RUN opam switch create 4.14 --packages=ocaml-variants.4.14.3+options,ocaml-options-only-nnp
+	RUN opam pin add -k version ocaml-variants 4.14.3+options
 	RUN opam install -y opam-depext
 	ENTRYPOINT [ "opam", "exec", "--" ]
 	CMD bash
 	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
 
-4.14.2+nnp/ppc64le
+4.14.3+nnp/ppc64le
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-13-opam-ppc64le
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.14 --packages=ocaml-variants.4.14.2+options,ocaml-options-only-nnp
-	RUN opam pin add -k version ocaml-variants 4.14.2+options
+	RUN opam switch create 4.14 --packages=ocaml-variants.4.14.3+options,ocaml-options-only-nnp
+	RUN opam pin add -k version ocaml-variants 4.14.3+options
 	RUN opam install -y opam-depext
 	ENTRYPOINT [ "opam", "exec", "--" ]
 	CMD bash
 	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
 
-4.14.2+nnp/arm32v7
+4.14.3+nnp/arm32v7
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-13-opam-arm32v7
 	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.14 --packages=ocaml-variants.4.14.2+options,ocaml-options-only-nnp
-	RUN opam pin add -k version ocaml-variants 4.14.2+options
+	RUN opam switch create 4.14 --packages=ocaml-variants.4.14.3+options,ocaml-options-only-nnp
+	RUN opam pin add -k version ocaml-variants 4.14.3+options
 	RUN opam install -y opam-depext
 	ENTRYPOINT [ "/usr/bin/linux32", "opam", "exec", "--" ]
 	CMD bash
 	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
 
-4.14.2+nnp/arm64
+4.14.3+nnp/arm64
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-13-opam-arm64
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.14 --packages=ocaml-variants.4.14.2+options,ocaml-options-only-nnp
-	RUN opam pin add -k version ocaml-variants 4.14.2+options
+	RUN opam switch create 4.14 --packages=ocaml-variants.4.14.3+options,ocaml-options-only-nnp
+	RUN opam pin add -k version ocaml-variants 4.14.3+options
 	RUN opam install -y opam-depext
 	ENTRYPOINT [ "opam", "exec", "--" ]
 	CMD bash
 	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
 
-4.14.2+nnp/amd64
+4.14.3+nnp/amd64
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-13-opam-amd64
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.14 --packages=ocaml-variants.4.14.2+options,ocaml-options-only-nnp
-	RUN opam pin add -k version ocaml-variants 4.14.2+options
+	RUN opam switch create 4.14 --packages=ocaml-variants.4.14.3+options,ocaml-options-only-nnp
+	RUN opam pin add -k version ocaml-variants 4.14.3+options
 	RUN opam install -y opam-depext
 	ENTRYPOINT [ "opam", "exec", "--" ]
 	CMD bash
 	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
 
-4.14.2+nnp/i386
+4.14.3+nnp/i386
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-13-opam-i386
 	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.14 --packages=ocaml-variants.4.14.2+options,ocaml-options-only-nnp
-	RUN opam pin add -k version ocaml-variants 4.14.2+options
+	RUN opam switch create 4.14 --packages=ocaml-variants.4.14.3+options,ocaml-options-only-nnp
+	RUN opam pin add -k version ocaml-variants 4.14.3+options
 	RUN opam install -y opam-depext
 	ENTRYPOINT [ "/usr/bin/linux32", "opam", "exec", "--" ]
 	CMD bash
@@ -7333,13 +7347,13 @@ ocurrent/opam-staging:debian-13-ocaml-4.14-fp-amd64 -> ocaml/opam:debian-ocaml-4
 
 ocurrent/opam-staging:debian-13-ocaml-4.14-nnp-riscv64, ocurrent/opam-staging:debian-13-ocaml-4.14-nnp-s390x, ocurrent/opam-staging:debian-13-ocaml-4.14-nnp-ppc64le, ocurrent/opam-staging:debian-13-ocaml-4.14-nnp-arm32v7, ocurrent/opam-staging:debian-13-ocaml-4.14-nnp-arm64, ocurrent/opam-staging:debian-13-ocaml-4.14-nnp-amd64, ocurrent/opam-staging:debian-13-ocaml-4.14-nnp-i386 -> ocaml/opam:debian-13-ocaml-4.14-nnp
 ocurrent/opam-staging:debian-13-ocaml-4.14-nnp-riscv64, ocurrent/opam-staging:debian-13-ocaml-4.14-nnp-s390x, ocurrent/opam-staging:debian-13-ocaml-4.14-nnp-ppc64le, ocurrent/opam-staging:debian-13-ocaml-4.14-nnp-arm32v7, ocurrent/opam-staging:debian-13-ocaml-4.14-nnp-arm64, ocurrent/opam-staging:debian-13-ocaml-4.14-nnp-amd64, ocurrent/opam-staging:debian-13-ocaml-4.14-nnp-i386 -> ocaml/opam:debian-ocaml-4.14-nnp
-4.14.2+nnpchecker/amd64
+4.14.3+nnpchecker/amd64
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-13-opam-amd64
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.14 --packages=ocaml-variants.4.14.2+options,ocaml-options-only-nnpchecker
-	RUN opam pin add -k version ocaml-variants 4.14.2+options
+	RUN opam switch create 4.14 --packages=ocaml-variants.4.14.3+options,ocaml-options-only-nnpchecker
+	RUN opam pin add -k version ocaml-variants 4.14.3+options
 	RUN opam install -y opam-depext
 	ENTRYPOINT [ "opam", "exec", "--" ]
 	CMD bash
@@ -7347,87 +7361,87 @@ ocurrent/opam-staging:debian-13-ocaml-4.14-nnp-riscv64, ocurrent/opam-staging:de
 
 ocurrent/opam-staging:debian-13-ocaml-4.14-nnpchecker-amd64 -> ocaml/opam:debian-13-ocaml-4.14-nnpchecker
 ocurrent/opam-staging:debian-13-ocaml-4.14-nnpchecker-amd64 -> ocaml/opam:debian-ocaml-4.14-nnpchecker
-4.14.2+no-flat-float-array/riscv64
+4.14.3+no-flat-float-array/riscv64
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-13-opam-riscv64
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.14 --packages=ocaml-variants.4.14.2+options,ocaml-options-only-no-flat-float-array
-	RUN opam pin add -k version ocaml-variants 4.14.2+options
+	RUN opam switch create 4.14 --packages=ocaml-variants.4.14.3+options,ocaml-options-only-no-flat-float-array
+	RUN opam pin add -k version ocaml-variants 4.14.3+options
 	RUN opam install -y opam-depext
 	ENTRYPOINT [ "opam", "exec", "--" ]
 	CMD bash
 	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
 
-4.14.2+no-flat-float-array/s390x
+4.14.3+no-flat-float-array/s390x
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-13-opam-s390x
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.14 --packages=ocaml-variants.4.14.2+options,ocaml-options-only-no-flat-float-array
-	RUN opam pin add -k version ocaml-variants 4.14.2+options
+	RUN opam switch create 4.14 --packages=ocaml-variants.4.14.3+options,ocaml-options-only-no-flat-float-array
+	RUN opam pin add -k version ocaml-variants 4.14.3+options
 	RUN opam install -y opam-depext
 	ENTRYPOINT [ "opam", "exec", "--" ]
 	CMD bash
 	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
 
-4.14.2+no-flat-float-array/ppc64le
+4.14.3+no-flat-float-array/ppc64le
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-13-opam-ppc64le
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.14 --packages=ocaml-variants.4.14.2+options,ocaml-options-only-no-flat-float-array
-	RUN opam pin add -k version ocaml-variants 4.14.2+options
+	RUN opam switch create 4.14 --packages=ocaml-variants.4.14.3+options,ocaml-options-only-no-flat-float-array
+	RUN opam pin add -k version ocaml-variants 4.14.3+options
 	RUN opam install -y opam-depext
 	ENTRYPOINT [ "opam", "exec", "--" ]
 	CMD bash
 	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
 
-4.14.2+no-flat-float-array/arm32v7
+4.14.3+no-flat-float-array/arm32v7
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-13-opam-arm32v7
 	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.14 --packages=ocaml-variants.4.14.2+options,ocaml-options-only-no-flat-float-array
-	RUN opam pin add -k version ocaml-variants 4.14.2+options
+	RUN opam switch create 4.14 --packages=ocaml-variants.4.14.3+options,ocaml-options-only-no-flat-float-array
+	RUN opam pin add -k version ocaml-variants 4.14.3+options
 	RUN opam install -y opam-depext
 	ENTRYPOINT [ "/usr/bin/linux32", "opam", "exec", "--" ]
 	CMD bash
 	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
 
-4.14.2+no-flat-float-array/arm64
+4.14.3+no-flat-float-array/arm64
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-13-opam-arm64
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.14 --packages=ocaml-variants.4.14.2+options,ocaml-options-only-no-flat-float-array
-	RUN opam pin add -k version ocaml-variants 4.14.2+options
+	RUN opam switch create 4.14 --packages=ocaml-variants.4.14.3+options,ocaml-options-only-no-flat-float-array
+	RUN opam pin add -k version ocaml-variants 4.14.3+options
 	RUN opam install -y opam-depext
 	ENTRYPOINT [ "opam", "exec", "--" ]
 	CMD bash
 	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
 
-4.14.2+no-flat-float-array/amd64
+4.14.3+no-flat-float-array/amd64
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-13-opam-amd64
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.14 --packages=ocaml-variants.4.14.2+options,ocaml-options-only-no-flat-float-array
-	RUN opam pin add -k version ocaml-variants 4.14.2+options
+	RUN opam switch create 4.14 --packages=ocaml-variants.4.14.3+options,ocaml-options-only-no-flat-float-array
+	RUN opam pin add -k version ocaml-variants 4.14.3+options
 	RUN opam install -y opam-depext
 	ENTRYPOINT [ "opam", "exec", "--" ]
 	CMD bash
 	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
 
-4.14.2+no-flat-float-array/i386
+4.14.3+no-flat-float-array/i386
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-13-opam-i386
 	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.14 --packages=ocaml-variants.4.14.2+options,ocaml-options-only-no-flat-float-array
-	RUN opam pin add -k version ocaml-variants 4.14.2+options
+	RUN opam switch create 4.14 --packages=ocaml-variants.4.14.3+options,ocaml-options-only-no-flat-float-array
+	RUN opam pin add -k version ocaml-variants 4.14.3+options
 	RUN opam install -y opam-depext
 	ENTRYPOINT [ "/usr/bin/linux32", "opam", "exec", "--" ]
 	CMD bash
@@ -8617,7 +8631,7 @@ ocurrent/opam-staging:debian-13-ocaml-5.3-flambda-arm64, ocurrent/opam-staging:d
 
 ocurrent/opam-staging:debian-13-ocaml-5.3-no-flat-float-array-riscv64, ocurrent/opam-staging:debian-13-ocaml-5.3-no-flat-float-array-s390x, ocurrent/opam-staging:debian-13-ocaml-5.3-no-flat-float-array-ppc64le, ocurrent/opam-staging:debian-13-ocaml-5.3-no-flat-float-array-arm32v7, ocurrent/opam-staging:debian-13-ocaml-5.3-no-flat-float-array-arm64, ocurrent/opam-staging:debian-13-ocaml-5.3-no-flat-float-array-amd64, ocurrent/opam-staging:debian-13-ocaml-5.3-no-flat-float-array-i386 -> ocaml/opam:debian-13-ocaml-5.3-no-flat-float-array
 ocurrent/opam-staging:debian-13-ocaml-5.3-no-flat-float-array-riscv64, ocurrent/opam-staging:debian-13-ocaml-5.3-no-flat-float-array-s390x, ocurrent/opam-staging:debian-13-ocaml-5.3-no-flat-float-array-ppc64le, ocurrent/opam-staging:debian-13-ocaml-5.3-no-flat-float-array-arm32v7, ocurrent/opam-staging:debian-13-ocaml-5.3-no-flat-float-array-arm64, ocurrent/opam-staging:debian-13-ocaml-5.3-no-flat-float-array-amd64, ocurrent/opam-staging:debian-13-ocaml-5.3-no-flat-float-array-i386 -> ocaml/opam:debian-ocaml-5.3-no-flat-float-array
-5.4.0/riscv64
+5.4.1/riscv64
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-13-opam-riscv64
@@ -8627,14 +8641,14 @@ ocurrent/opam-staging:debian-13-ocaml-5.3-no-flat-float-array-riscv64, ocurrent/
 	RUN DEBIAN_FRONTEND=noninteractive apt-get -y upgrade
 	RUN DEBIAN_FRONTEND=noninteractive apt-get -y install libzstd-dev
 	USER opam
-	RUN opam switch create 5.4 --packages=ocaml-base-compiler.5.4.0
-	RUN opam pin add -k version ocaml-base-compiler 5.4.0
+	RUN opam switch create 5.4 --packages=ocaml-base-compiler.5.4.1
+	RUN opam pin add -k version ocaml-base-compiler 5.4.1
 	RUN opam install -y opam-depext
 	ENTRYPOINT [ "opam", "exec", "--" ]
 	CMD bash
 	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
 
-5.4.0/s390x
+5.4.1/s390x
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-13-opam-s390x
@@ -8644,14 +8658,14 @@ ocurrent/opam-staging:debian-13-ocaml-5.3-no-flat-float-array-riscv64, ocurrent/
 	RUN DEBIAN_FRONTEND=noninteractive apt-get -y upgrade
 	RUN DEBIAN_FRONTEND=noninteractive apt-get -y install libzstd-dev
 	USER opam
-	RUN opam switch create 5.4 --packages=ocaml-base-compiler.5.4.0
-	RUN opam pin add -k version ocaml-base-compiler 5.4.0
+	RUN opam switch create 5.4 --packages=ocaml-base-compiler.5.4.1
+	RUN opam pin add -k version ocaml-base-compiler 5.4.1
 	RUN opam install -y opam-depext
 	ENTRYPOINT [ "opam", "exec", "--" ]
 	CMD bash
 	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
 
-5.4.0/ppc64le
+5.4.1/ppc64le
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-13-opam-ppc64le
@@ -8661,14 +8675,14 @@ ocurrent/opam-staging:debian-13-ocaml-5.3-no-flat-float-array-riscv64, ocurrent/
 	RUN DEBIAN_FRONTEND=noninteractive apt-get -y upgrade
 	RUN DEBIAN_FRONTEND=noninteractive apt-get -y install libzstd-dev
 	USER opam
-	RUN opam switch create 5.4 --packages=ocaml-base-compiler.5.4.0
-	RUN opam pin add -k version ocaml-base-compiler 5.4.0
+	RUN opam switch create 5.4 --packages=ocaml-base-compiler.5.4.1
+	RUN opam pin add -k version ocaml-base-compiler 5.4.1
 	RUN opam install -y opam-depext
 	ENTRYPOINT [ "opam", "exec", "--" ]
 	CMD bash
 	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
 
-5.4.0/arm32v7
+5.4.1/arm32v7
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-13-opam-arm32v7
@@ -8679,14 +8693,14 @@ ocurrent/opam-staging:debian-13-ocaml-5.3-no-flat-float-array-riscv64, ocurrent/
 	RUN DEBIAN_FRONTEND=noninteractive apt-get -y upgrade
 	RUN DEBIAN_FRONTEND=noninteractive apt-get -y install libzstd-dev
 	USER opam
-	RUN opam switch create 5.4 --packages=ocaml-base-compiler.5.4.0
-	RUN opam pin add -k version ocaml-base-compiler 5.4.0
+	RUN opam switch create 5.4 --packages=ocaml-base-compiler.5.4.1
+	RUN opam pin add -k version ocaml-base-compiler 5.4.1
 	RUN opam install -y opam-depext
 	ENTRYPOINT [ "/usr/bin/linux32", "opam", "exec", "--" ]
 	CMD bash
 	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
 
-5.4.0/arm64
+5.4.1/arm64
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-13-opam-arm64
@@ -8696,14 +8710,14 @@ ocurrent/opam-staging:debian-13-ocaml-5.3-no-flat-float-array-riscv64, ocurrent/
 	RUN DEBIAN_FRONTEND=noninteractive apt-get -y upgrade
 	RUN DEBIAN_FRONTEND=noninteractive apt-get -y install libzstd-dev
 	USER opam
-	RUN opam switch create 5.4 --packages=ocaml-base-compiler.5.4.0
-	RUN opam pin add -k version ocaml-base-compiler 5.4.0
+	RUN opam switch create 5.4 --packages=ocaml-base-compiler.5.4.1
+	RUN opam pin add -k version ocaml-base-compiler 5.4.1
 	RUN opam install -y opam-depext
 	ENTRYPOINT [ "opam", "exec", "--" ]
 	CMD bash
 	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
 
-5.4.0/amd64
+5.4.1/amd64
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-13-opam-amd64
@@ -8713,14 +8727,14 @@ ocurrent/opam-staging:debian-13-ocaml-5.3-no-flat-float-array-riscv64, ocurrent/
 	RUN DEBIAN_FRONTEND=noninteractive apt-get -y upgrade
 	RUN DEBIAN_FRONTEND=noninteractive apt-get -y install libzstd-dev
 	USER opam
-	RUN opam switch create 5.4 --packages=ocaml-base-compiler.5.4.0
-	RUN opam pin add -k version ocaml-base-compiler 5.4.0
+	RUN opam switch create 5.4 --packages=ocaml-base-compiler.5.4.1
+	RUN opam pin add -k version ocaml-base-compiler 5.4.1
 	RUN opam install -y opam-depext
 	ENTRYPOINT [ "opam", "exec", "--" ]
 	CMD bash
 	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
 
-5.4.0/i386
+5.4.1/i386
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-13-opam-i386
@@ -8731,8 +8745,8 @@ ocurrent/opam-staging:debian-13-ocaml-5.3-no-flat-float-array-riscv64, ocurrent/
 	RUN DEBIAN_FRONTEND=noninteractive apt-get -y upgrade
 	RUN DEBIAN_FRONTEND=noninteractive apt-get -y install libzstd-dev
 	USER opam
-	RUN opam switch create 5.4 --packages=ocaml-base-compiler.5.4.0
-	RUN opam pin add -k version ocaml-base-compiler 5.4.0
+	RUN opam switch create 5.4 --packages=ocaml-base-compiler.5.4.1
+	RUN opam pin add -k version ocaml-base-compiler 5.4.1
 	RUN opam install -y opam-depext
 	ENTRYPOINT [ "/usr/bin/linux32", "opam", "exec", "--" ]
 	CMD bash
@@ -8743,7 +8757,7 @@ ocurrent/opam-staging:debian-13-ocaml-5.4-riscv64, ocurrent/opam-staging:debian-
 ocurrent/opam-staging:debian-13-ocaml-5.4-riscv64, ocurrent/opam-staging:debian-13-ocaml-5.4-s390x, ocurrent/opam-staging:debian-13-ocaml-5.4-ppc64le, ocurrent/opam-staging:debian-13-ocaml-5.4-arm32v7, ocurrent/opam-staging:debian-13-ocaml-5.4-arm64, ocurrent/opam-staging:debian-13-ocaml-5.4-amd64, ocurrent/opam-staging:debian-13-ocaml-5.4-i386 -> ocaml/opam:debian-13
 ocurrent/opam-staging:debian-13-ocaml-5.4-riscv64, ocurrent/opam-staging:debian-13-ocaml-5.4-s390x, ocurrent/opam-staging:debian-13-ocaml-5.4-ppc64le, ocurrent/opam-staging:debian-13-ocaml-5.4-arm32v7, ocurrent/opam-staging:debian-13-ocaml-5.4-arm64, ocurrent/opam-staging:debian-13-ocaml-5.4-amd64, ocurrent/opam-staging:debian-13-ocaml-5.4-i386 -> ocaml/opam:debian-13-ocaml-5.4
 ocurrent/opam-staging:debian-13-ocaml-5.4-riscv64, ocurrent/opam-staging:debian-13-ocaml-5.4-s390x, ocurrent/opam-staging:debian-13-ocaml-5.4-ppc64le, ocurrent/opam-staging:debian-13-ocaml-5.4-arm32v7, ocurrent/opam-staging:debian-13-ocaml-5.4-arm64, ocurrent/opam-staging:debian-13-ocaml-5.4-amd64, ocurrent/opam-staging:debian-13-ocaml-5.4-i386 -> ocaml/opam:debian-ocaml-5.4
-5.4.0+afl/arm64
+5.4.1+afl/arm64
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-13-opam-arm64
@@ -8753,14 +8767,14 @@ ocurrent/opam-staging:debian-13-ocaml-5.4-riscv64, ocurrent/opam-staging:debian-
 	RUN DEBIAN_FRONTEND=noninteractive apt-get -y upgrade
 	RUN DEBIAN_FRONTEND=noninteractive apt-get -y install libzstd-dev
 	USER opam
-	RUN opam switch create 5.4 --packages=ocaml-variants.5.4.0+options,ocaml-options-only-afl
-	RUN opam pin add -k version ocaml-variants 5.4.0+options
+	RUN opam switch create 5.4 --packages=ocaml-variants.5.4.1+options,ocaml-options-only-afl
+	RUN opam pin add -k version ocaml-variants 5.4.1+options
 	RUN opam install -y opam-depext
 	ENTRYPOINT [ "opam", "exec", "--" ]
 	CMD bash
 	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
 
-5.4.0+afl/amd64
+5.4.1+afl/amd64
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-13-opam-amd64
@@ -8770,8 +8784,8 @@ ocurrent/opam-staging:debian-13-ocaml-5.4-riscv64, ocurrent/opam-staging:debian-
 	RUN DEBIAN_FRONTEND=noninteractive apt-get -y upgrade
 	RUN DEBIAN_FRONTEND=noninteractive apt-get -y install libzstd-dev
 	USER opam
-	RUN opam switch create 5.4 --packages=ocaml-variants.5.4.0+options,ocaml-options-only-afl
-	RUN opam pin add -k version ocaml-variants 5.4.0+options
+	RUN opam switch create 5.4 --packages=ocaml-variants.5.4.1+options,ocaml-options-only-afl
+	RUN opam pin add -k version ocaml-variants 5.4.1+options
 	RUN opam install -y opam-depext
 	ENTRYPOINT [ "opam", "exec", "--" ]
 	CMD bash
@@ -8779,7 +8793,7 @@ ocurrent/opam-staging:debian-13-ocaml-5.4-riscv64, ocurrent/opam-staging:debian-
 
 ocurrent/opam-staging:debian-13-ocaml-5.4-afl-arm64, ocurrent/opam-staging:debian-13-ocaml-5.4-afl-amd64 -> ocaml/opam:debian-13-ocaml-5.4-afl
 ocurrent/opam-staging:debian-13-ocaml-5.4-afl-arm64, ocurrent/opam-staging:debian-13-ocaml-5.4-afl-amd64 -> ocaml/opam:debian-ocaml-5.4-afl
-5.4.0+flambda/arm64
+5.4.1+flambda/arm64
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-13-opam-arm64
@@ -8789,14 +8803,14 @@ ocurrent/opam-staging:debian-13-ocaml-5.4-afl-arm64, ocurrent/opam-staging:debia
 	RUN DEBIAN_FRONTEND=noninteractive apt-get -y upgrade
 	RUN DEBIAN_FRONTEND=noninteractive apt-get -y install libzstd-dev
 	USER opam
-	RUN opam switch create 5.4 --packages=ocaml-variants.5.4.0+options,ocaml-options-only-flambda
-	RUN opam pin add -k version ocaml-variants 5.4.0+options
+	RUN opam switch create 5.4 --packages=ocaml-variants.5.4.1+options,ocaml-options-only-flambda
+	RUN opam pin add -k version ocaml-variants 5.4.1+options
 	RUN opam install -y opam-depext
 	ENTRYPOINT [ "opam", "exec", "--" ]
 	CMD bash
 	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
 
-5.4.0+flambda/amd64
+5.4.1+flambda/amd64
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-13-opam-amd64
@@ -8806,8 +8820,8 @@ ocurrent/opam-staging:debian-13-ocaml-5.4-afl-arm64, ocurrent/opam-staging:debia
 	RUN DEBIAN_FRONTEND=noninteractive apt-get -y upgrade
 	RUN DEBIAN_FRONTEND=noninteractive apt-get -y install libzstd-dev
 	USER opam
-	RUN opam switch create 5.4 --packages=ocaml-variants.5.4.0+options,ocaml-options-only-flambda
-	RUN opam pin add -k version ocaml-variants 5.4.0+options
+	RUN opam switch create 5.4 --packages=ocaml-variants.5.4.1+options,ocaml-options-only-flambda
+	RUN opam pin add -k version ocaml-variants 5.4.1+options
 	RUN opam install -y opam-depext
 	ENTRYPOINT [ "opam", "exec", "--" ]
 	CMD bash
@@ -8815,7 +8829,7 @@ ocurrent/opam-staging:debian-13-ocaml-5.4-afl-arm64, ocurrent/opam-staging:debia
 
 ocurrent/opam-staging:debian-13-ocaml-5.4-flambda-arm64, ocurrent/opam-staging:debian-13-ocaml-5.4-flambda-amd64 -> ocaml/opam:debian-13-ocaml-5.4-flambda
 ocurrent/opam-staging:debian-13-ocaml-5.4-flambda-arm64, ocurrent/opam-staging:debian-13-ocaml-5.4-flambda-amd64 -> ocaml/opam:debian-ocaml-5.4-flambda
-5.4.0+no-flat-float-array/riscv64
+5.4.1+no-flat-float-array/riscv64
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-13-opam-riscv64
@@ -8825,14 +8839,14 @@ ocurrent/opam-staging:debian-13-ocaml-5.4-flambda-arm64, ocurrent/opam-staging:d
 	RUN DEBIAN_FRONTEND=noninteractive apt-get -y upgrade
 	RUN DEBIAN_FRONTEND=noninteractive apt-get -y install libzstd-dev
 	USER opam
-	RUN opam switch create 5.4 --packages=ocaml-variants.5.4.0+options,ocaml-options-only-no-flat-float-array
-	RUN opam pin add -k version ocaml-variants 5.4.0+options
+	RUN opam switch create 5.4 --packages=ocaml-variants.5.4.1+options,ocaml-options-only-no-flat-float-array
+	RUN opam pin add -k version ocaml-variants 5.4.1+options
 	RUN opam install -y opam-depext
 	ENTRYPOINT [ "opam", "exec", "--" ]
 	CMD bash
 	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
 
-5.4.0+no-flat-float-array/s390x
+5.4.1+no-flat-float-array/s390x
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-13-opam-s390x
@@ -8842,14 +8856,14 @@ ocurrent/opam-staging:debian-13-ocaml-5.4-flambda-arm64, ocurrent/opam-staging:d
 	RUN DEBIAN_FRONTEND=noninteractive apt-get -y upgrade
 	RUN DEBIAN_FRONTEND=noninteractive apt-get -y install libzstd-dev
 	USER opam
-	RUN opam switch create 5.4 --packages=ocaml-variants.5.4.0+options,ocaml-options-only-no-flat-float-array
-	RUN opam pin add -k version ocaml-variants 5.4.0+options
+	RUN opam switch create 5.4 --packages=ocaml-variants.5.4.1+options,ocaml-options-only-no-flat-float-array
+	RUN opam pin add -k version ocaml-variants 5.4.1+options
 	RUN opam install -y opam-depext
 	ENTRYPOINT [ "opam", "exec", "--" ]
 	CMD bash
 	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
 
-5.4.0+no-flat-float-array/ppc64le
+5.4.1+no-flat-float-array/ppc64le
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-13-opam-ppc64le
@@ -8859,14 +8873,14 @@ ocurrent/opam-staging:debian-13-ocaml-5.4-flambda-arm64, ocurrent/opam-staging:d
 	RUN DEBIAN_FRONTEND=noninteractive apt-get -y upgrade
 	RUN DEBIAN_FRONTEND=noninteractive apt-get -y install libzstd-dev
 	USER opam
-	RUN opam switch create 5.4 --packages=ocaml-variants.5.4.0+options,ocaml-options-only-no-flat-float-array
-	RUN opam pin add -k version ocaml-variants 5.4.0+options
+	RUN opam switch create 5.4 --packages=ocaml-variants.5.4.1+options,ocaml-options-only-no-flat-float-array
+	RUN opam pin add -k version ocaml-variants 5.4.1+options
 	RUN opam install -y opam-depext
 	ENTRYPOINT [ "opam", "exec", "--" ]
 	CMD bash
 	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
 
-5.4.0+no-flat-float-array/arm32v7
+5.4.1+no-flat-float-array/arm32v7
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-13-opam-arm32v7
@@ -8877,14 +8891,14 @@ ocurrent/opam-staging:debian-13-ocaml-5.4-flambda-arm64, ocurrent/opam-staging:d
 	RUN DEBIAN_FRONTEND=noninteractive apt-get -y upgrade
 	RUN DEBIAN_FRONTEND=noninteractive apt-get -y install libzstd-dev
 	USER opam
-	RUN opam switch create 5.4 --packages=ocaml-variants.5.4.0+options,ocaml-options-only-no-flat-float-array
-	RUN opam pin add -k version ocaml-variants 5.4.0+options
+	RUN opam switch create 5.4 --packages=ocaml-variants.5.4.1+options,ocaml-options-only-no-flat-float-array
+	RUN opam pin add -k version ocaml-variants 5.4.1+options
 	RUN opam install -y opam-depext
 	ENTRYPOINT [ "/usr/bin/linux32", "opam", "exec", "--" ]
 	CMD bash
 	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
 
-5.4.0+no-flat-float-array/arm64
+5.4.1+no-flat-float-array/arm64
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-13-opam-arm64
@@ -8894,14 +8908,14 @@ ocurrent/opam-staging:debian-13-ocaml-5.4-flambda-arm64, ocurrent/opam-staging:d
 	RUN DEBIAN_FRONTEND=noninteractive apt-get -y upgrade
 	RUN DEBIAN_FRONTEND=noninteractive apt-get -y install libzstd-dev
 	USER opam
-	RUN opam switch create 5.4 --packages=ocaml-variants.5.4.0+options,ocaml-options-only-no-flat-float-array
-	RUN opam pin add -k version ocaml-variants 5.4.0+options
+	RUN opam switch create 5.4 --packages=ocaml-variants.5.4.1+options,ocaml-options-only-no-flat-float-array
+	RUN opam pin add -k version ocaml-variants 5.4.1+options
 	RUN opam install -y opam-depext
 	ENTRYPOINT [ "opam", "exec", "--" ]
 	CMD bash
 	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
 
-5.4.0+no-flat-float-array/amd64
+5.4.1+no-flat-float-array/amd64
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-13-opam-amd64
@@ -8911,14 +8925,14 @@ ocurrent/opam-staging:debian-13-ocaml-5.4-flambda-arm64, ocurrent/opam-staging:d
 	RUN DEBIAN_FRONTEND=noninteractive apt-get -y upgrade
 	RUN DEBIAN_FRONTEND=noninteractive apt-get -y install libzstd-dev
 	USER opam
-	RUN opam switch create 5.4 --packages=ocaml-variants.5.4.0+options,ocaml-options-only-no-flat-float-array
-	RUN opam pin add -k version ocaml-variants 5.4.0+options
+	RUN opam switch create 5.4 --packages=ocaml-variants.5.4.1+options,ocaml-options-only-no-flat-float-array
+	RUN opam pin add -k version ocaml-variants 5.4.1+options
 	RUN opam install -y opam-depext
 	ENTRYPOINT [ "opam", "exec", "--" ]
 	CMD bash
 	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
 
-5.4.0+no-flat-float-array/i386
+5.4.1+no-flat-float-array/i386
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-13-opam-i386
@@ -8929,8 +8943,8 @@ ocurrent/opam-staging:debian-13-ocaml-5.4-flambda-arm64, ocurrent/opam-staging:d
 	RUN DEBIAN_FRONTEND=noninteractive apt-get -y upgrade
 	RUN DEBIAN_FRONTEND=noninteractive apt-get -y install libzstd-dev
 	USER opam
-	RUN opam switch create 5.4 --packages=ocaml-variants.5.4.0+options,ocaml-options-only-no-flat-float-array
-	RUN opam pin add -k version ocaml-variants 5.4.0+options
+	RUN opam switch create 5.4 --packages=ocaml-variants.5.4.1+options,ocaml-options-only-no-flat-float-array
+	RUN opam pin add -k version ocaml-variants 5.4.1+options
 	RUN opam install -y opam-depext
 	ENTRYPOINT [ "/usr/bin/linux32", "opam", "exec", "--" ]
 	CMD bash
@@ -9332,7 +9346,7 @@ debian-testing/amd64
 	RUN chmod 440 /etc/sudoers.d/opam
 	RUN chown root:root /etc/sudoers.d/opam
 	RUN if getent passwd 1000; then userdel -r $(id -nu 1000); fi
-	RUN adduser --uid 1000 --disabled-password --gecos '' opam
+	RUN useradd --uid 1000 --create-home --shell /bin/bash opam
 	RUN passwd -l opam
 	RUN chown -R opam:opam /home/opam
 	USER opam
@@ -9459,13 +9473,14 @@ ocurrent/opam-staging:debian-testing-ocaml-4.12-amd64 -> ocaml/opam:debian-testi
 	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
 
 ocurrent/opam-staging:debian-testing-ocaml-4.13-amd64 -> ocaml/opam:debian-testing-ocaml-4.13
-4.14.2/amd64
+4.14.3/amd64
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-testing-opam-amd64
+	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.14 --packages=ocaml-base-compiler.4.14.2
-	RUN opam pin add -k version ocaml-base-compiler 4.14.2
+	RUN opam switch create 4.14 --packages=ocaml-base-compiler.4.14.3
+	RUN opam pin add -k version ocaml-base-compiler 4.14.3
 	RUN opam install -y opam-depext
 	ENTRYPOINT [ "opam", "exec", "--" ]
 	CMD bash
@@ -9540,7 +9555,7 @@ ocurrent/opam-staging:debian-testing-ocaml-5.2-amd64 -> ocaml/opam:debian-testin
 	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
 
 ocurrent/opam-staging:debian-testing-ocaml-5.3-amd64 -> ocaml/opam:debian-testing-ocaml-5.3
-5.4.0/amd64
+5.4.1/amd64
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-testing-opam-amd64
@@ -9550,8 +9565,8 @@ ocurrent/opam-staging:debian-testing-ocaml-5.3-amd64 -> ocaml/opam:debian-testin
 	RUN DEBIAN_FRONTEND=noninteractive apt-get -y upgrade
 	RUN DEBIAN_FRONTEND=noninteractive apt-get -y install libzstd-dev
 	USER opam
-	RUN opam switch create 5.4 --packages=ocaml-base-compiler.5.4.0
-	RUN opam pin add -k version ocaml-base-compiler 5.4.0
+	RUN opam switch create 5.4 --packages=ocaml-base-compiler.5.4.1
+	RUN opam pin add -k version ocaml-base-compiler 5.4.1
 	RUN opam install -y opam-depext
 	ENTRYPOINT [ "opam", "exec", "--" ]
 	CMD bash
@@ -9622,7 +9637,7 @@ debian-unstable/amd64
 	RUN chmod 440 /etc/sudoers.d/opam
 	RUN chown root:root /etc/sudoers.d/opam
 	RUN if getent passwd 1000; then userdel -r $(id -nu 1000); fi
-	RUN adduser --uid 1000 --disabled-password --gecos '' opam
+	RUN useradd --uid 1000 --create-home --shell /bin/bash opam
 	RUN passwd -l opam
 	RUN chown -R opam:opam /home/opam
 	USER opam
@@ -9749,13 +9764,14 @@ ocurrent/opam-staging:debian-unstable-ocaml-4.12-amd64 -> ocaml/opam:debian-unst
 	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
 
 ocurrent/opam-staging:debian-unstable-ocaml-4.13-amd64 -> ocaml/opam:debian-unstable-ocaml-4.13
-4.14.2/amd64
+4.14.3/amd64
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-unstable-opam-amd64
+	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.14 --packages=ocaml-base-compiler.4.14.2
-	RUN opam pin add -k version ocaml-base-compiler 4.14.2
+	RUN opam switch create 4.14 --packages=ocaml-base-compiler.4.14.3
+	RUN opam pin add -k version ocaml-base-compiler 4.14.3
 	RUN opam install -y opam-depext
 	ENTRYPOINT [ "opam", "exec", "--" ]
 	CMD bash
@@ -9830,7 +9846,7 @@ ocurrent/opam-staging:debian-unstable-ocaml-5.2-amd64 -> ocaml/opam:debian-unsta
 	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
 
 ocurrent/opam-staging:debian-unstable-ocaml-5.3-amd64 -> ocaml/opam:debian-unstable-ocaml-5.3
-5.4.0/amd64
+5.4.1/amd64
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:debian-unstable-opam-amd64
@@ -9840,8 +9856,8 @@ ocurrent/opam-staging:debian-unstable-ocaml-5.3-amd64 -> ocaml/opam:debian-unsta
 	RUN DEBIAN_FRONTEND=noninteractive apt-get -y upgrade
 	RUN DEBIAN_FRONTEND=noninteractive apt-get -y install libzstd-dev
 	USER opam
-	RUN opam switch create 5.4 --packages=ocaml-base-compiler.5.4.0
-	RUN opam pin add -k version ocaml-base-compiler 5.4.0
+	RUN opam switch create 5.4 --packages=ocaml-base-compiler.5.4.1
+	RUN opam pin add -k version ocaml-base-compiler 5.4.1
 	RUN opam install -y opam-depext
 	ENTRYPOINT [ "opam", "exec", "--" ]
 	CMD bash
@@ -10198,25 +10214,27 @@ ocurrent/opam-staging:fedora-42-ocaml-4.12-arm64, ocurrent/opam-staging:fedora-4
 	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
 
 ocurrent/opam-staging:fedora-42-ocaml-4.13-arm64, ocurrent/opam-staging:fedora-42-ocaml-4.13-amd64 -> ocaml/opam:fedora-42-ocaml-4.13
-4.14.2/arm64
+4.14.3/arm64
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:fedora-42-opam-arm64
+	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.14 --packages=ocaml-base-compiler.4.14.2
-	RUN opam pin add -k version ocaml-base-compiler 4.14.2
+	RUN opam switch create 4.14 --packages=ocaml-base-compiler.4.14.3
+	RUN opam pin add -k version ocaml-base-compiler 4.14.3
 	RUN opam install -y opam-depext
 	ENTRYPOINT [ "opam", "exec", "--" ]
 	CMD bash
 	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
 
-4.14.2/amd64
+4.14.3/amd64
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:fedora-42-opam-amd64
+	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.14 --packages=ocaml-base-compiler.4.14.2
-	RUN opam pin add -k version ocaml-base-compiler 4.14.2
+	RUN opam switch create 4.14 --packages=ocaml-base-compiler.4.14.3
+	RUN opam pin add -k version ocaml-base-compiler 4.14.3
 	RUN opam install -y opam-depext
 	ENTRYPOINT [ "opam", "exec", "--" ]
 	CMD bash
@@ -10343,7 +10361,7 @@ ocurrent/opam-staging:fedora-42-ocaml-5.2-arm64, ocurrent/opam-staging:fedora-42
 	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
 
 ocurrent/opam-staging:fedora-42-ocaml-5.3-arm64, ocurrent/opam-staging:fedora-42-ocaml-5.3-amd64 -> ocaml/opam:fedora-42-ocaml-5.3
-5.4.0/arm64
+5.4.1/arm64
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:fedora-42-opam-arm64
@@ -10351,14 +10369,14 @@ ocurrent/opam-staging:fedora-42-ocaml-5.3-arm64, ocurrent/opam-staging:fedora-42
 	USER root
 	RUN yum install -y zstd && yum clean packages
 	USER opam
-	RUN opam switch create 5.4 --packages=ocaml-base-compiler.5.4.0
-	RUN opam pin add -k version ocaml-base-compiler 5.4.0
+	RUN opam switch create 5.4 --packages=ocaml-base-compiler.5.4.1
+	RUN opam pin add -k version ocaml-base-compiler 5.4.1
 	RUN opam install -y opam-depext
 	ENTRYPOINT [ "opam", "exec", "--" ]
 	CMD bash
 	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
 
-5.4.0/amd64
+5.4.1/amd64
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:fedora-42-opam-amd64
@@ -10366,8 +10384,8 @@ ocurrent/opam-staging:fedora-42-ocaml-5.3-arm64, ocurrent/opam-staging:fedora-42
 	USER root
 	RUN yum install -y zstd && yum clean packages
 	USER opam
-	RUN opam switch create 5.4 --packages=ocaml-base-compiler.5.4.0
-	RUN opam pin add -k version ocaml-base-compiler 5.4.0
+	RUN opam switch create 5.4 --packages=ocaml-base-compiler.5.4.1
+	RUN opam pin add -k version ocaml-base-compiler 5.4.1
 	RUN opam install -y opam-depext
 	ENTRYPOINT [ "opam", "exec", "--" ]
 	CMD bash
@@ -10744,25 +10762,27 @@ ocurrent/opam-staging:fedora-43-ocaml-4.12-arm64, ocurrent/opam-staging:fedora-4
 
 ocurrent/opam-staging:fedora-43-ocaml-4.13-arm64, ocurrent/opam-staging:fedora-43-ocaml-4.13-amd64 -> ocaml/opam:fedora-43-ocaml-4.13
 ocurrent/opam-staging:fedora-43-ocaml-4.13-arm64, ocurrent/opam-staging:fedora-43-ocaml-4.13-amd64 -> ocaml/opam:fedora-ocaml-4.13
-4.14.2/arm64
+4.14.3/arm64
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:fedora-43-opam-arm64
+	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.14 --packages=ocaml-base-compiler.4.14.2
-	RUN opam pin add -k version ocaml-base-compiler 4.14.2
+	RUN opam switch create 4.14 --packages=ocaml-base-compiler.4.14.3
+	RUN opam pin add -k version ocaml-base-compiler 4.14.3
 	RUN opam install -y opam-depext
 	ENTRYPOINT [ "opam", "exec", "--" ]
 	CMD bash
 	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
 
-4.14.2/amd64
+4.14.3/amd64
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:fedora-43-opam-amd64
+	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.14 --packages=ocaml-base-compiler.4.14.2
-	RUN opam pin add -k version ocaml-base-compiler 4.14.2
+	RUN opam switch create 4.14 --packages=ocaml-base-compiler.4.14.3
+	RUN opam pin add -k version ocaml-base-compiler 4.14.3
 	RUN opam install -y opam-depext
 	ENTRYPOINT [ "opam", "exec", "--" ]
 	CMD bash
@@ -10894,7 +10914,7 @@ ocurrent/opam-staging:fedora-43-ocaml-5.2-arm64, ocurrent/opam-staging:fedora-43
 
 ocurrent/opam-staging:fedora-43-ocaml-5.3-arm64, ocurrent/opam-staging:fedora-43-ocaml-5.3-amd64 -> ocaml/opam:fedora-43-ocaml-5.3
 ocurrent/opam-staging:fedora-43-ocaml-5.3-arm64, ocurrent/opam-staging:fedora-43-ocaml-5.3-amd64 -> ocaml/opam:fedora-ocaml-5.3
-5.4.0/arm64
+5.4.1/arm64
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:fedora-43-opam-arm64
@@ -10902,14 +10922,14 @@ ocurrent/opam-staging:fedora-43-ocaml-5.3-arm64, ocurrent/opam-staging:fedora-43
 	USER root
 	RUN yum install -y zstd && yum clean packages
 	USER opam
-	RUN opam switch create 5.4 --packages=ocaml-base-compiler.5.4.0
-	RUN opam pin add -k version ocaml-base-compiler 5.4.0
+	RUN opam switch create 5.4 --packages=ocaml-base-compiler.5.4.1
+	RUN opam pin add -k version ocaml-base-compiler 5.4.1
 	RUN opam install -y opam-depext
 	ENTRYPOINT [ "opam", "exec", "--" ]
 	CMD bash
 	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
 
-5.4.0/amd64
+5.4.1/amd64
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:fedora-43-opam-amd64
@@ -10917,8 +10937,8 @@ ocurrent/opam-staging:fedora-43-ocaml-5.3-arm64, ocurrent/opam-staging:fedora-43
 	USER root
 	RUN yum install -y zstd && yum clean packages
 	USER opam
-	RUN opam switch create 5.4 --packages=ocaml-base-compiler.5.4.0
-	RUN opam pin add -k version ocaml-base-compiler 5.4.0
+	RUN opam switch create 5.4 --packages=ocaml-base-compiler.5.4.1
+	RUN opam pin add -k version ocaml-base-compiler 5.4.1
 	RUN opam install -y opam-depext
 	ENTRYPOINT [ "opam", "exec", "--" ]
 	CMD bash
@@ -11131,13 +11151,13 @@ ocurrent/opam-staging:oraclelinux-10-ocaml-4.12-amd64 -> ocaml/opam:oraclelinux-
 
 ocurrent/opam-staging:oraclelinux-10-ocaml-4.13-amd64 -> ocaml/opam:oraclelinux-10-ocaml-4.13
 ocurrent/opam-staging:oraclelinux-10-ocaml-4.13-amd64 -> ocaml/opam:oraclelinux-ocaml-4.13
-4.14.2/amd64
+4.14.3/amd64
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:oraclelinux-10-opam-amd64
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.14 --packages=ocaml-base-compiler.4.14.2
-	RUN opam pin add -k version ocaml-base-compiler 4.14.2
+	RUN opam switch create 4.14 --packages=ocaml-base-compiler.4.14.3
+	RUN opam pin add -k version ocaml-base-compiler 4.14.3
 	RUN opam install -y opam-depext
 	ENTRYPOINT [ "opam", "exec", "--" ]
 	CMD bash
@@ -11210,7 +11230,7 @@ ocurrent/opam-staging:oraclelinux-10-ocaml-5.2-amd64 -> ocaml/opam:oraclelinux-o
 
 ocurrent/opam-staging:oraclelinux-10-ocaml-5.3-amd64 -> ocaml/opam:oraclelinux-10-ocaml-5.3
 ocurrent/opam-staging:oraclelinux-10-ocaml-5.3-amd64 -> ocaml/opam:oraclelinux-ocaml-5.3
-5.4.0/amd64
+5.4.1/amd64
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:oraclelinux-10-opam-amd64
@@ -11218,8 +11238,8 @@ ocurrent/opam-staging:oraclelinux-10-ocaml-5.3-amd64 -> ocaml/opam:oraclelinux-o
 	USER root
 	RUN yum install -y zstd && yum clean packages
 	USER opam
-	RUN opam switch create 5.4 --packages=ocaml-base-compiler.5.4.0
-	RUN opam pin add -k version ocaml-base-compiler 5.4.0
+	RUN opam switch create 5.4 --packages=ocaml-base-compiler.5.4.1
+	RUN opam pin add -k version ocaml-base-compiler 5.4.1
 	RUN opam install -y opam-depext
 	ENTRYPOINT [ "opam", "exec", "--" ]
 	CMD bash
@@ -11575,25 +11595,27 @@ ocurrent/opam-staging:opensuse-15.6-ocaml-4.12-arm64, ocurrent/opam-staging:open
 	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
 
 ocurrent/opam-staging:opensuse-15.6-ocaml-4.13-arm64, ocurrent/opam-staging:opensuse-15.6-ocaml-4.13-amd64 -> ocaml/opam:opensuse-15.6-ocaml-4.13
-4.14.2/arm64
+4.14.3/arm64
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:opensuse-15.6-opam-arm64
+	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.14 --packages=ocaml-base-compiler.4.14.2
-	RUN opam pin add -k version ocaml-base-compiler 4.14.2
+	RUN opam switch create 4.14 --packages=ocaml-base-compiler.4.14.3
+	RUN opam pin add -k version ocaml-base-compiler 4.14.3
 	RUN opam install -y opam-depext
 	ENTRYPOINT [ "opam", "exec", "--" ]
 	CMD bash
 	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
 
-4.14.2/amd64
+4.14.3/amd64
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:opensuse-15.6-opam-amd64
+	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.14 --packages=ocaml-base-compiler.4.14.2
-	RUN opam pin add -k version ocaml-base-compiler 4.14.2
+	RUN opam switch create 4.14 --packages=ocaml-base-compiler.4.14.3
+	RUN opam pin add -k version ocaml-base-compiler 4.14.3
 	RUN opam install -y opam-depext
 	ENTRYPOINT [ "opam", "exec", "--" ]
 	CMD bash
@@ -11732,7 +11754,7 @@ ocurrent/opam-staging:opensuse-15.6-ocaml-5.2-arm64, ocurrent/opam-staging:opens
 	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
 
 ocurrent/opam-staging:opensuse-15.6-ocaml-5.3-arm64, ocurrent/opam-staging:opensuse-15.6-ocaml-5.3-amd64 -> ocaml/opam:opensuse-15.6-ocaml-5.3
-5.4.0/arm64
+5.4.1/arm64
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:opensuse-15.6-opam-arm64
@@ -11742,14 +11764,14 @@ ocurrent/opam-staging:opensuse-15.6-ocaml-5.3-arm64, ocurrent/opam-staging:opens
 	RUN zypper update -y
 	RUN zypper install --force-resolution -y zstd
 	USER opam
-	RUN opam switch create 5.4 --packages=ocaml-base-compiler.5.4.0
-	RUN opam pin add -k version ocaml-base-compiler 5.4.0
+	RUN opam switch create 5.4 --packages=ocaml-base-compiler.5.4.1
+	RUN opam pin add -k version ocaml-base-compiler 5.4.1
 	RUN opam install -y opam-depext
 	ENTRYPOINT [ "opam", "exec", "--" ]
 	CMD bash
 	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
 
-5.4.0/amd64
+5.4.1/amd64
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:opensuse-15.6-opam-amd64
@@ -11759,8 +11781,8 @@ ocurrent/opam-staging:opensuse-15.6-ocaml-5.3-arm64, ocurrent/opam-staging:opens
 	RUN zypper update -y
 	RUN zypper install --force-resolution -y zstd
 	USER opam
-	RUN opam switch create 5.4 --packages=ocaml-base-compiler.5.4.0
-	RUN opam pin add -k version ocaml-base-compiler 5.4.0
+	RUN opam switch create 5.4 --packages=ocaml-base-compiler.5.4.1
+	RUN opam pin add -k version ocaml-base-compiler 5.4.1
 	RUN opam install -y opam-depext
 	ENTRYPOINT [ "opam", "exec", "--" ]
 	CMD bash
@@ -12139,25 +12161,27 @@ ocurrent/opam-staging:opensuse-16.0-ocaml-4.12-arm64, ocurrent/opam-staging:open
 
 ocurrent/opam-staging:opensuse-16.0-ocaml-4.13-arm64, ocurrent/opam-staging:opensuse-16.0-ocaml-4.13-amd64 -> ocaml/opam:opensuse-16.0-ocaml-4.13
 ocurrent/opam-staging:opensuse-16.0-ocaml-4.13-arm64, ocurrent/opam-staging:opensuse-16.0-ocaml-4.13-amd64 -> ocaml/opam:opensuse-ocaml-4.13
-4.14.2/arm64
+4.14.3/arm64
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:opensuse-16.0-opam-arm64
+	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.14 --packages=ocaml-base-compiler.4.14.2
-	RUN opam pin add -k version ocaml-base-compiler 4.14.2
+	RUN opam switch create 4.14 --packages=ocaml-base-compiler.4.14.3
+	RUN opam pin add -k version ocaml-base-compiler 4.14.3
 	RUN opam install -y opam-depext
 	ENTRYPOINT [ "opam", "exec", "--" ]
 	CMD bash
 	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
 
-4.14.2/amd64
+4.14.3/amd64
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:opensuse-16.0-opam-amd64
+	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.14 --packages=ocaml-base-compiler.4.14.2
-	RUN opam pin add -k version ocaml-base-compiler 4.14.2
+	RUN opam switch create 4.14 --packages=ocaml-base-compiler.4.14.3
+	RUN opam pin add -k version ocaml-base-compiler 4.14.3
 	RUN opam install -y opam-depext
 	ENTRYPOINT [ "opam", "exec", "--" ]
 	CMD bash
@@ -12301,7 +12325,7 @@ ocurrent/opam-staging:opensuse-16.0-ocaml-5.2-arm64, ocurrent/opam-staging:opens
 
 ocurrent/opam-staging:opensuse-16.0-ocaml-5.3-arm64, ocurrent/opam-staging:opensuse-16.0-ocaml-5.3-amd64 -> ocaml/opam:opensuse-16.0-ocaml-5.3
 ocurrent/opam-staging:opensuse-16.0-ocaml-5.3-arm64, ocurrent/opam-staging:opensuse-16.0-ocaml-5.3-amd64 -> ocaml/opam:opensuse-ocaml-5.3
-5.4.0/arm64
+5.4.1/arm64
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:opensuse-16.0-opam-arm64
@@ -12311,14 +12335,14 @@ ocurrent/opam-staging:opensuse-16.0-ocaml-5.3-arm64, ocurrent/opam-staging:opens
 	RUN zypper update -y
 	RUN zypper install --force-resolution -y zstd
 	USER opam
-	RUN opam switch create 5.4 --packages=ocaml-base-compiler.5.4.0
-	RUN opam pin add -k version ocaml-base-compiler 5.4.0
+	RUN opam switch create 5.4 --packages=ocaml-base-compiler.5.4.1
+	RUN opam pin add -k version ocaml-base-compiler 5.4.1
 	RUN opam install -y opam-depext
 	ENTRYPOINT [ "opam", "exec", "--" ]
 	CMD bash
 	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
 
-5.4.0/amd64
+5.4.1/amd64
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:opensuse-16.0-opam-amd64
@@ -12328,8 +12352,8 @@ ocurrent/opam-staging:opensuse-16.0-ocaml-5.3-arm64, ocurrent/opam-staging:opens
 	RUN zypper update -y
 	RUN zypper install --force-resolution -y zstd
 	USER opam
-	RUN opam switch create 5.4 --packages=ocaml-base-compiler.5.4.0
-	RUN opam pin add -k version ocaml-base-compiler 5.4.0
+	RUN opam switch create 5.4 --packages=ocaml-base-compiler.5.4.1
+	RUN opam pin add -k version ocaml-base-compiler 5.4.1
 	RUN opam install -y opam-depext
 	ENTRYPOINT [ "opam", "exec", "--" ]
 	CMD bash
@@ -12545,13 +12569,14 @@ ocurrent/opam-staging:opensuse-tumbleweed-ocaml-4.12-amd64 -> ocaml/opam:opensus
 	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
 
 ocurrent/opam-staging:opensuse-tumbleweed-ocaml-4.13-amd64 -> ocaml/opam:opensuse-tumbleweed-ocaml-4.13
-4.14.2/amd64
+4.14.3/amd64
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:opensuse-tumbleweed-opam-amd64
+	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.14 --packages=ocaml-base-compiler.4.14.2
-	RUN opam pin add -k version ocaml-base-compiler 4.14.2
+	RUN opam switch create 4.14 --packages=ocaml-base-compiler.4.14.3
+	RUN opam pin add -k version ocaml-base-compiler 4.14.3
 	RUN opam install -y opam-depext
 	ENTRYPOINT [ "opam", "exec", "--" ]
 	CMD bash
@@ -12626,7 +12651,7 @@ ocurrent/opam-staging:opensuse-tumbleweed-ocaml-5.2-amd64 -> ocaml/opam:opensuse
 	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
 
 ocurrent/opam-staging:opensuse-tumbleweed-ocaml-5.3-amd64 -> ocaml/opam:opensuse-tumbleweed-ocaml-5.3
-5.4.0/amd64
+5.4.1/amd64
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:opensuse-tumbleweed-opam-amd64
@@ -12636,8 +12661,8 @@ ocurrent/opam-staging:opensuse-tumbleweed-ocaml-5.3-amd64 -> ocaml/opam:opensuse
 	RUN zypper update -y
 	RUN zypper install --force-resolution -y zstd
 	USER opam
-	RUN opam switch create 5.4 --packages=ocaml-base-compiler.5.4.0
-	RUN opam pin add -k version ocaml-base-compiler 5.4.0
+	RUN opam switch create 5.4 --packages=ocaml-base-compiler.5.4.1
+	RUN opam pin add -k version ocaml-base-compiler 5.4.1
 	RUN opam install -y opam-depext
 	ENTRYPOINT [ "opam", "exec", "--" ]
 	CMD bash
@@ -12708,7 +12733,7 @@ ubuntu-22.04/s390x
 	RUN chmod 440 /etc/sudoers.d/opam
 	RUN chown root:root /etc/sudoers.d/opam
 	RUN if getent passwd 1000; then userdel -r $(id -nu 1000); fi
-	RUN adduser --uid 1000 --disabled-password --gecos '' opam
+	RUN useradd --uid 1000 --create-home --shell /bin/bash opam
 	RUN passwd -l opam
 	RUN chown -R opam:opam /home/opam
 	USER opam
@@ -12793,7 +12818,7 @@ ubuntu-22.04/ppc64le
 	RUN chmod 440 /etc/sudoers.d/opam
 	RUN chown root:root /etc/sudoers.d/opam
 	RUN if getent passwd 1000; then userdel -r $(id -nu 1000); fi
-	RUN adduser --uid 1000 --disabled-password --gecos '' opam
+	RUN useradd --uid 1000 --create-home --shell /bin/bash opam
 	RUN passwd -l opam
 	RUN chown -R opam:opam /home/opam
 	USER opam
@@ -12878,7 +12903,7 @@ ubuntu-22.04/arm64
 	RUN chmod 440 /etc/sudoers.d/opam
 	RUN chown root:root /etc/sudoers.d/opam
 	RUN if getent passwd 1000; then userdel -r $(id -nu 1000); fi
-	RUN adduser --uid 1000 --disabled-password --gecos '' opam
+	RUN useradd --uid 1000 --create-home --shell /bin/bash opam
 	RUN passwd -l opam
 	RUN chown -R opam:opam /home/opam
 	USER opam
@@ -12963,7 +12988,7 @@ ubuntu-22.04/amd64
 	RUN chmod 440 /etc/sudoers.d/opam
 	RUN chown root:root /etc/sudoers.d/opam
 	RUN if getent passwd 1000; then userdel -r $(id -nu 1000); fi
-	RUN adduser --uid 1000 --disabled-password --gecos '' opam
+	RUN useradd --uid 1000 --create-home --shell /bin/bash opam
 	RUN passwd -l opam
 	RUN chown -R opam:opam /home/opam
 	USER opam
@@ -13048,7 +13073,7 @@ ubuntu-22.04/riscv64
 	RUN chmod 440 /etc/sudoers.d/opam
 	RUN chown root:root /etc/sudoers.d/opam
 	RUN if getent passwd 1000; then userdel -r $(id -nu 1000); fi
-	RUN adduser --uid 1000 --disabled-password --gecos '' opam
+	RUN useradd --uid 1000 --create-home --shell /bin/bash opam
 	RUN passwd -l opam
 	RUN chown -R opam:opam /home/opam
 	USER opam
@@ -13421,61 +13446,61 @@ ocurrent/opam-staging:ubuntu-22.04-ocaml-4.12-s390x, ocurrent/opam-staging:ubunt
 	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
 
 ocurrent/opam-staging:ubuntu-22.04-ocaml-4.13-s390x, ocurrent/opam-staging:ubuntu-22.04-ocaml-4.13-ppc64le, ocurrent/opam-staging:ubuntu-22.04-ocaml-4.13-arm64, ocurrent/opam-staging:ubuntu-22.04-ocaml-4.13-amd64, ocurrent/opam-staging:ubuntu-22.04-ocaml-4.13-riscv64 -> ocaml/opam:ubuntu-22.04-ocaml-4.13
-4.14.2/s390x
+4.14.3/s390x
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-22.04-opam-s390x
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.14 --packages=ocaml-base-compiler.4.14.2
-	RUN opam pin add -k version ocaml-base-compiler 4.14.2
+	RUN opam switch create 4.14 --packages=ocaml-base-compiler.4.14.3
+	RUN opam pin add -k version ocaml-base-compiler 4.14.3
 	RUN opam install -y opam-depext
 	ENTRYPOINT [ "opam", "exec", "--" ]
 	CMD bash
 	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
 
-4.14.2/ppc64le
+4.14.3/ppc64le
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-22.04-opam-ppc64le
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.14 --packages=ocaml-base-compiler.4.14.2
-	RUN opam pin add -k version ocaml-base-compiler 4.14.2
+	RUN opam switch create 4.14 --packages=ocaml-base-compiler.4.14.3
+	RUN opam pin add -k version ocaml-base-compiler 4.14.3
 	RUN opam install -y opam-depext
 	ENTRYPOINT [ "opam", "exec", "--" ]
 	CMD bash
 	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
 
-4.14.2/arm64
+4.14.3/arm64
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-22.04-opam-arm64
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.14 --packages=ocaml-base-compiler.4.14.2
-	RUN opam pin add -k version ocaml-base-compiler 4.14.2
+	RUN opam switch create 4.14 --packages=ocaml-base-compiler.4.14.3
+	RUN opam pin add -k version ocaml-base-compiler 4.14.3
 	RUN opam install -y opam-depext
 	ENTRYPOINT [ "opam", "exec", "--" ]
 	CMD bash
 	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
 
-4.14.2/amd64
+4.14.3/amd64
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-22.04-opam-amd64
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.14 --packages=ocaml-base-compiler.4.14.2
-	RUN opam pin add -k version ocaml-base-compiler 4.14.2
+	RUN opam switch create 4.14 --packages=ocaml-base-compiler.4.14.3
+	RUN opam pin add -k version ocaml-base-compiler 4.14.3
 	RUN opam install -y opam-depext
 	ENTRYPOINT [ "opam", "exec", "--" ]
 	CMD bash
 	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
 
-4.14.2/riscv64
+4.14.3/riscv64
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-22.04-opam-riscv64
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.14 --packages=ocaml-base-compiler.4.14.2
-	RUN opam pin add -k version ocaml-base-compiler 4.14.2
+	RUN opam switch create 4.14 --packages=ocaml-base-compiler.4.14.3
+	RUN opam pin add -k version ocaml-base-compiler 4.14.3
 	RUN opam install -y opam-depext
 	ENTRYPOINT [ "opam", "exec", "--" ]
 	CMD bash
@@ -13801,7 +13826,7 @@ ocurrent/opam-staging:ubuntu-22.04-ocaml-5.2-s390x, ocurrent/opam-staging:ubuntu
 	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
 
 ocurrent/opam-staging:ubuntu-22.04-ocaml-5.3-s390x, ocurrent/opam-staging:ubuntu-22.04-ocaml-5.3-ppc64le, ocurrent/opam-staging:ubuntu-22.04-ocaml-5.3-arm64, ocurrent/opam-staging:ubuntu-22.04-ocaml-5.3-amd64, ocurrent/opam-staging:ubuntu-22.04-ocaml-5.3-riscv64 -> ocaml/opam:ubuntu-22.04-ocaml-5.3
-5.4.0/s390x
+5.4.1/s390x
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-22.04-opam-s390x
@@ -13811,14 +13836,14 @@ ocurrent/opam-staging:ubuntu-22.04-ocaml-5.3-s390x, ocurrent/opam-staging:ubuntu
 	RUN DEBIAN_FRONTEND=noninteractive apt-get -y upgrade
 	RUN DEBIAN_FRONTEND=noninteractive apt-get -y install libzstd-dev
 	USER opam
-	RUN opam switch create 5.4 --packages=ocaml-base-compiler.5.4.0
-	RUN opam pin add -k version ocaml-base-compiler 5.4.0
+	RUN opam switch create 5.4 --packages=ocaml-base-compiler.5.4.1
+	RUN opam pin add -k version ocaml-base-compiler 5.4.1
 	RUN opam install -y opam-depext
 	ENTRYPOINT [ "opam", "exec", "--" ]
 	CMD bash
 	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
 
-5.4.0/ppc64le
+5.4.1/ppc64le
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-22.04-opam-ppc64le
@@ -13828,14 +13853,14 @@ ocurrent/opam-staging:ubuntu-22.04-ocaml-5.3-s390x, ocurrent/opam-staging:ubuntu
 	RUN DEBIAN_FRONTEND=noninteractive apt-get -y upgrade
 	RUN DEBIAN_FRONTEND=noninteractive apt-get -y install libzstd-dev
 	USER opam
-	RUN opam switch create 5.4 --packages=ocaml-base-compiler.5.4.0
-	RUN opam pin add -k version ocaml-base-compiler 5.4.0
+	RUN opam switch create 5.4 --packages=ocaml-base-compiler.5.4.1
+	RUN opam pin add -k version ocaml-base-compiler 5.4.1
 	RUN opam install -y opam-depext
 	ENTRYPOINT [ "opam", "exec", "--" ]
 	CMD bash
 	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
 
-5.4.0/arm64
+5.4.1/arm64
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-22.04-opam-arm64
@@ -13845,14 +13870,14 @@ ocurrent/opam-staging:ubuntu-22.04-ocaml-5.3-s390x, ocurrent/opam-staging:ubuntu
 	RUN DEBIAN_FRONTEND=noninteractive apt-get -y upgrade
 	RUN DEBIAN_FRONTEND=noninteractive apt-get -y install libzstd-dev
 	USER opam
-	RUN opam switch create 5.4 --packages=ocaml-base-compiler.5.4.0
-	RUN opam pin add -k version ocaml-base-compiler 5.4.0
+	RUN opam switch create 5.4 --packages=ocaml-base-compiler.5.4.1
+	RUN opam pin add -k version ocaml-base-compiler 5.4.1
 	RUN opam install -y opam-depext
 	ENTRYPOINT [ "opam", "exec", "--" ]
 	CMD bash
 	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
 
-5.4.0/amd64
+5.4.1/amd64
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-22.04-opam-amd64
@@ -13862,14 +13887,14 @@ ocurrent/opam-staging:ubuntu-22.04-ocaml-5.3-s390x, ocurrent/opam-staging:ubuntu
 	RUN DEBIAN_FRONTEND=noninteractive apt-get -y upgrade
 	RUN DEBIAN_FRONTEND=noninteractive apt-get -y install libzstd-dev
 	USER opam
-	RUN opam switch create 5.4 --packages=ocaml-base-compiler.5.4.0
-	RUN opam pin add -k version ocaml-base-compiler 5.4.0
+	RUN opam switch create 5.4 --packages=ocaml-base-compiler.5.4.1
+	RUN opam pin add -k version ocaml-base-compiler 5.4.1
 	RUN opam install -y opam-depext
 	ENTRYPOINT [ "opam", "exec", "--" ]
 	CMD bash
 	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
 
-5.4.0/riscv64
+5.4.1/riscv64
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-22.04-opam-riscv64
@@ -13879,8 +13904,8 @@ ocurrent/opam-staging:ubuntu-22.04-ocaml-5.3-s390x, ocurrent/opam-staging:ubuntu
 	RUN DEBIAN_FRONTEND=noninteractive apt-get -y upgrade
 	RUN DEBIAN_FRONTEND=noninteractive apt-get -y install libzstd-dev
 	USER opam
-	RUN opam switch create 5.4 --packages=ocaml-base-compiler.5.4.0
-	RUN opam pin add -k version ocaml-base-compiler 5.4.0
+	RUN opam switch create 5.4 --packages=ocaml-base-compiler.5.4.1
+	RUN opam pin add -k version ocaml-base-compiler 5.4.1
 	RUN opam install -y opam-depext
 	ENTRYPOINT [ "opam", "exec", "--" ]
 	CMD bash
@@ -14023,7 +14048,7 @@ ubuntu-24.04/s390x
 	RUN chmod 440 /etc/sudoers.d/opam
 	RUN chown root:root /etc/sudoers.d/opam
 	RUN if getent passwd 1000; then userdel -r $(id -nu 1000); fi
-	RUN adduser --uid 1000 --disabled-password --gecos '' opam
+	RUN useradd --uid 1000 --create-home --shell /bin/bash opam
 	RUN passwd -l opam
 	RUN chown -R opam:opam /home/opam
 	USER opam
@@ -14108,7 +14133,7 @@ ubuntu-24.04/ppc64le
 	RUN chmod 440 /etc/sudoers.d/opam
 	RUN chown root:root /etc/sudoers.d/opam
 	RUN if getent passwd 1000; then userdel -r $(id -nu 1000); fi
-	RUN adduser --uid 1000 --disabled-password --gecos '' opam
+	RUN useradd --uid 1000 --create-home --shell /bin/bash opam
 	RUN passwd -l opam
 	RUN chown -R opam:opam /home/opam
 	USER opam
@@ -14193,7 +14218,7 @@ ubuntu-24.04/arm64
 	RUN chmod 440 /etc/sudoers.d/opam
 	RUN chown root:root /etc/sudoers.d/opam
 	RUN if getent passwd 1000; then userdel -r $(id -nu 1000); fi
-	RUN adduser --uid 1000 --disabled-password --gecos '' opam
+	RUN useradd --uid 1000 --create-home --shell /bin/bash opam
 	RUN passwd -l opam
 	RUN chown -R opam:opam /home/opam
 	USER opam
@@ -14278,7 +14303,7 @@ ubuntu-24.04/amd64
 	RUN chmod 440 /etc/sudoers.d/opam
 	RUN chown root:root /etc/sudoers.d/opam
 	RUN if getent passwd 1000; then userdel -r $(id -nu 1000); fi
-	RUN adduser --uid 1000 --disabled-password --gecos '' opam
+	RUN useradd --uid 1000 --create-home --shell /bin/bash opam
 	RUN passwd -l opam
 	RUN chown -R opam:opam /home/opam
 	USER opam
@@ -14363,7 +14388,7 @@ ubuntu-24.04/riscv64
 	RUN chmod 440 /etc/sudoers.d/opam
 	RUN chown root:root /etc/sudoers.d/opam
 	RUN if getent passwd 1000; then userdel -r $(id -nu 1000); fi
-	RUN adduser --uid 1000 --disabled-password --gecos '' opam
+	RUN useradd --uid 1000 --create-home --shell /bin/bash opam
 	RUN passwd -l opam
 	RUN chown -R opam:opam /home/opam
 	USER opam
@@ -14742,61 +14767,61 @@ ocurrent/opam-staging:ubuntu-24.04-ocaml-4.12-s390x, ocurrent/opam-staging:ubunt
 
 ocurrent/opam-staging:ubuntu-24.04-ocaml-4.13-s390x, ocurrent/opam-staging:ubuntu-24.04-ocaml-4.13-ppc64le, ocurrent/opam-staging:ubuntu-24.04-ocaml-4.13-arm64, ocurrent/opam-staging:ubuntu-24.04-ocaml-4.13-amd64, ocurrent/opam-staging:ubuntu-24.04-ocaml-4.13-riscv64 -> ocaml/opam:ubuntu-24.04-ocaml-4.13
 ocurrent/opam-staging:ubuntu-24.04-ocaml-4.13-s390x, ocurrent/opam-staging:ubuntu-24.04-ocaml-4.13-ppc64le, ocurrent/opam-staging:ubuntu-24.04-ocaml-4.13-arm64, ocurrent/opam-staging:ubuntu-24.04-ocaml-4.13-amd64, ocurrent/opam-staging:ubuntu-24.04-ocaml-4.13-riscv64 -> ocaml/opam:ubuntu-lts-ocaml-4.13
-4.14.2/s390x
+4.14.3/s390x
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-24.04-opam-s390x
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.14 --packages=ocaml-base-compiler.4.14.2
-	RUN opam pin add -k version ocaml-base-compiler 4.14.2
+	RUN opam switch create 4.14 --packages=ocaml-base-compiler.4.14.3
+	RUN opam pin add -k version ocaml-base-compiler 4.14.3
 	RUN opam install -y opam-depext
 	ENTRYPOINT [ "opam", "exec", "--" ]
 	CMD bash
 	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
 
-4.14.2/ppc64le
+4.14.3/ppc64le
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-24.04-opam-ppc64le
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.14 --packages=ocaml-base-compiler.4.14.2
-	RUN opam pin add -k version ocaml-base-compiler 4.14.2
+	RUN opam switch create 4.14 --packages=ocaml-base-compiler.4.14.3
+	RUN opam pin add -k version ocaml-base-compiler 4.14.3
 	RUN opam install -y opam-depext
 	ENTRYPOINT [ "opam", "exec", "--" ]
 	CMD bash
 	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
 
-4.14.2/arm64
+4.14.3/arm64
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-24.04-opam-arm64
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.14 --packages=ocaml-base-compiler.4.14.2
-	RUN opam pin add -k version ocaml-base-compiler 4.14.2
+	RUN opam switch create 4.14 --packages=ocaml-base-compiler.4.14.3
+	RUN opam pin add -k version ocaml-base-compiler 4.14.3
 	RUN opam install -y opam-depext
 	ENTRYPOINT [ "opam", "exec", "--" ]
 	CMD bash
 	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
 
-4.14.2/amd64
+4.14.3/amd64
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-24.04-opam-amd64
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.14 --packages=ocaml-base-compiler.4.14.2
-	RUN opam pin add -k version ocaml-base-compiler 4.14.2
+	RUN opam switch create 4.14 --packages=ocaml-base-compiler.4.14.3
+	RUN opam pin add -k version ocaml-base-compiler 4.14.3
 	RUN opam install -y opam-depext
 	ENTRYPOINT [ "opam", "exec", "--" ]
 	CMD bash
 	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
 
-4.14.2/riscv64
+4.14.3/riscv64
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-24.04-opam-riscv64
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.14 --packages=ocaml-base-compiler.4.14.2
-	RUN opam pin add -k version ocaml-base-compiler 4.14.2
+	RUN opam switch create 4.14 --packages=ocaml-base-compiler.4.14.3
+	RUN opam pin add -k version ocaml-base-compiler 4.14.3
 	RUN opam install -y opam-depext
 	ENTRYPOINT [ "opam", "exec", "--" ]
 	CMD bash
@@ -15127,7 +15152,7 @@ ocurrent/opam-staging:ubuntu-24.04-ocaml-5.2-s390x, ocurrent/opam-staging:ubuntu
 
 ocurrent/opam-staging:ubuntu-24.04-ocaml-5.3-s390x, ocurrent/opam-staging:ubuntu-24.04-ocaml-5.3-ppc64le, ocurrent/opam-staging:ubuntu-24.04-ocaml-5.3-arm64, ocurrent/opam-staging:ubuntu-24.04-ocaml-5.3-amd64, ocurrent/opam-staging:ubuntu-24.04-ocaml-5.3-riscv64 -> ocaml/opam:ubuntu-24.04-ocaml-5.3
 ocurrent/opam-staging:ubuntu-24.04-ocaml-5.3-s390x, ocurrent/opam-staging:ubuntu-24.04-ocaml-5.3-ppc64le, ocurrent/opam-staging:ubuntu-24.04-ocaml-5.3-arm64, ocurrent/opam-staging:ubuntu-24.04-ocaml-5.3-amd64, ocurrent/opam-staging:ubuntu-24.04-ocaml-5.3-riscv64 -> ocaml/opam:ubuntu-lts-ocaml-5.3
-5.4.0/s390x
+5.4.1/s390x
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-24.04-opam-s390x
@@ -15137,14 +15162,14 @@ ocurrent/opam-staging:ubuntu-24.04-ocaml-5.3-s390x, ocurrent/opam-staging:ubuntu
 	RUN DEBIAN_FRONTEND=noninteractive apt-get -y upgrade
 	RUN DEBIAN_FRONTEND=noninteractive apt-get -y install libzstd-dev
 	USER opam
-	RUN opam switch create 5.4 --packages=ocaml-base-compiler.5.4.0
-	RUN opam pin add -k version ocaml-base-compiler 5.4.0
+	RUN opam switch create 5.4 --packages=ocaml-base-compiler.5.4.1
+	RUN opam pin add -k version ocaml-base-compiler 5.4.1
 	RUN opam install -y opam-depext
 	ENTRYPOINT [ "opam", "exec", "--" ]
 	CMD bash
 	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
 
-5.4.0/ppc64le
+5.4.1/ppc64le
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-24.04-opam-ppc64le
@@ -15154,14 +15179,14 @@ ocurrent/opam-staging:ubuntu-24.04-ocaml-5.3-s390x, ocurrent/opam-staging:ubuntu
 	RUN DEBIAN_FRONTEND=noninteractive apt-get -y upgrade
 	RUN DEBIAN_FRONTEND=noninteractive apt-get -y install libzstd-dev
 	USER opam
-	RUN opam switch create 5.4 --packages=ocaml-base-compiler.5.4.0
-	RUN opam pin add -k version ocaml-base-compiler 5.4.0
+	RUN opam switch create 5.4 --packages=ocaml-base-compiler.5.4.1
+	RUN opam pin add -k version ocaml-base-compiler 5.4.1
 	RUN opam install -y opam-depext
 	ENTRYPOINT [ "opam", "exec", "--" ]
 	CMD bash
 	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
 
-5.4.0/arm64
+5.4.1/arm64
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-24.04-opam-arm64
@@ -15171,14 +15196,14 @@ ocurrent/opam-staging:ubuntu-24.04-ocaml-5.3-s390x, ocurrent/opam-staging:ubuntu
 	RUN DEBIAN_FRONTEND=noninteractive apt-get -y upgrade
 	RUN DEBIAN_FRONTEND=noninteractive apt-get -y install libzstd-dev
 	USER opam
-	RUN opam switch create 5.4 --packages=ocaml-base-compiler.5.4.0
-	RUN opam pin add -k version ocaml-base-compiler 5.4.0
+	RUN opam switch create 5.4 --packages=ocaml-base-compiler.5.4.1
+	RUN opam pin add -k version ocaml-base-compiler 5.4.1
 	RUN opam install -y opam-depext
 	ENTRYPOINT [ "opam", "exec", "--" ]
 	CMD bash
 	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
 
-5.4.0/amd64
+5.4.1/amd64
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-24.04-opam-amd64
@@ -15188,14 +15213,14 @@ ocurrent/opam-staging:ubuntu-24.04-ocaml-5.3-s390x, ocurrent/opam-staging:ubuntu
 	RUN DEBIAN_FRONTEND=noninteractive apt-get -y upgrade
 	RUN DEBIAN_FRONTEND=noninteractive apt-get -y install libzstd-dev
 	USER opam
-	RUN opam switch create 5.4 --packages=ocaml-base-compiler.5.4.0
-	RUN opam pin add -k version ocaml-base-compiler 5.4.0
+	RUN opam switch create 5.4 --packages=ocaml-base-compiler.5.4.1
+	RUN opam pin add -k version ocaml-base-compiler 5.4.1
 	RUN opam install -y opam-depext
 	ENTRYPOINT [ "opam", "exec", "--" ]
 	CMD bash
 	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
 
-5.4.0/riscv64
+5.4.1/riscv64
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-24.04-opam-riscv64
@@ -15205,8 +15230,8 @@ ocurrent/opam-staging:ubuntu-24.04-ocaml-5.3-s390x, ocurrent/opam-staging:ubuntu
 	RUN DEBIAN_FRONTEND=noninteractive apt-get -y upgrade
 	RUN DEBIAN_FRONTEND=noninteractive apt-get -y install libzstd-dev
 	USER opam
-	RUN opam switch create 5.4 --packages=ocaml-base-compiler.5.4.0
-	RUN opam pin add -k version ocaml-base-compiler 5.4.0
+	RUN opam switch create 5.4 --packages=ocaml-base-compiler.5.4.1
+	RUN opam pin add -k version ocaml-base-compiler 5.4.1
 	RUN opam install -y opam-depext
 	ENTRYPOINT [ "opam", "exec", "--" ]
 	CMD bash
@@ -15352,7 +15377,7 @@ ubuntu-25.04/s390x
 	RUN chmod 440 /etc/sudoers.d/opam
 	RUN chown root:root /etc/sudoers.d/opam
 	RUN if getent passwd 1000; then userdel -r $(id -nu 1000); fi
-	RUN adduser --uid 1000 --disabled-password --gecos '' opam
+	RUN useradd --uid 1000 --create-home --shell /bin/bash opam
 	RUN passwd -l opam
 	RUN chown -R opam:opam /home/opam
 	USER opam
@@ -15437,7 +15462,7 @@ ubuntu-25.04/ppc64le
 	RUN chmod 440 /etc/sudoers.d/opam
 	RUN chown root:root /etc/sudoers.d/opam
 	RUN if getent passwd 1000; then userdel -r $(id -nu 1000); fi
-	RUN adduser --uid 1000 --disabled-password --gecos '' opam
+	RUN useradd --uid 1000 --create-home --shell /bin/bash opam
 	RUN passwd -l opam
 	RUN chown -R opam:opam /home/opam
 	USER opam
@@ -15522,7 +15547,7 @@ ubuntu-25.04/arm64
 	RUN chmod 440 /etc/sudoers.d/opam
 	RUN chown root:root /etc/sudoers.d/opam
 	RUN if getent passwd 1000; then userdel -r $(id -nu 1000); fi
-	RUN adduser --uid 1000 --disabled-password --gecos '' opam
+	RUN useradd --uid 1000 --create-home --shell /bin/bash opam
 	RUN passwd -l opam
 	RUN chown -R opam:opam /home/opam
 	USER opam
@@ -15607,7 +15632,7 @@ ubuntu-25.04/amd64
 	RUN chmod 440 /etc/sudoers.d/opam
 	RUN chown root:root /etc/sudoers.d/opam
 	RUN if getent passwd 1000; then userdel -r $(id -nu 1000); fi
-	RUN adduser --uid 1000 --disabled-password --gecos '' opam
+	RUN useradd --uid 1000 --create-home --shell /bin/bash opam
 	RUN passwd -l opam
 	RUN chown -R opam:opam /home/opam
 	USER opam
@@ -15692,7 +15717,7 @@ ubuntu-25.04/riscv64
 	RUN chmod 440 /etc/sudoers.d/opam
 	RUN chown root:root /etc/sudoers.d/opam
 	RUN if getent passwd 1000; then userdel -r $(id -nu 1000); fi
-	RUN adduser --uid 1000 --disabled-password --gecos '' opam
+	RUN useradd --uid 1000 --create-home --shell /bin/bash opam
 	RUN passwd -l opam
 	RUN chown -R opam:opam /home/opam
 	USER opam
@@ -16092,61 +16117,66 @@ ocurrent/opam-staging:ubuntu-25.04-ocaml-4.12-s390x, ocurrent/opam-staging:ubunt
 	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
 
 ocurrent/opam-staging:ubuntu-25.04-ocaml-4.13-s390x, ocurrent/opam-staging:ubuntu-25.04-ocaml-4.13-ppc64le, ocurrent/opam-staging:ubuntu-25.04-ocaml-4.13-arm64, ocurrent/opam-staging:ubuntu-25.04-ocaml-4.13-amd64, ocurrent/opam-staging:ubuntu-25.04-ocaml-4.13-riscv64 -> ocaml/opam:ubuntu-25.04-ocaml-4.13
-4.14.2/s390x
+4.14.3/s390x
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-25.04-opam-s390x
+	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.14 --packages=ocaml-base-compiler.4.14.2
-	RUN opam pin add -k version ocaml-base-compiler 4.14.2
+	RUN opam switch create 4.14 --packages=ocaml-base-compiler.4.14.3
+	RUN opam pin add -k version ocaml-base-compiler 4.14.3
 	RUN opam install -y opam-depext
 	ENTRYPOINT [ "opam", "exec", "--" ]
 	CMD bash
 	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
 
-4.14.2/ppc64le
+4.14.3/ppc64le
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-25.04-opam-ppc64le
+	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.14 --packages=ocaml-base-compiler.4.14.2
-	RUN opam pin add -k version ocaml-base-compiler 4.14.2
+	RUN opam switch create 4.14 --packages=ocaml-base-compiler.4.14.3
+	RUN opam pin add -k version ocaml-base-compiler 4.14.3
 	RUN opam install -y opam-depext
 	ENTRYPOINT [ "opam", "exec", "--" ]
 	CMD bash
 	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
 
-4.14.2/arm64
+4.14.3/arm64
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-25.04-opam-arm64
+	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.14 --packages=ocaml-base-compiler.4.14.2
-	RUN opam pin add -k version ocaml-base-compiler 4.14.2
+	RUN opam switch create 4.14 --packages=ocaml-base-compiler.4.14.3
+	RUN opam pin add -k version ocaml-base-compiler 4.14.3
 	RUN opam install -y opam-depext
 	ENTRYPOINT [ "opam", "exec", "--" ]
 	CMD bash
 	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
 
-4.14.2/amd64
+4.14.3/amd64
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-25.04-opam-amd64
+	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.14 --packages=ocaml-base-compiler.4.14.2
-	RUN opam pin add -k version ocaml-base-compiler 4.14.2
+	RUN opam switch create 4.14 --packages=ocaml-base-compiler.4.14.3
+	RUN opam pin add -k version ocaml-base-compiler 4.14.3
 	RUN opam install -y opam-depext
 	ENTRYPOINT [ "opam", "exec", "--" ]
 	CMD bash
 	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
 
-4.14.2/riscv64
+4.14.3/riscv64
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-25.04-opam-riscv64
+	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.14 --packages=ocaml-base-compiler.4.14.2
-	RUN opam pin add -k version ocaml-base-compiler 4.14.2
+	RUN opam switch create 4.14 --packages=ocaml-base-compiler.4.14.3
+	RUN opam pin add -k version ocaml-base-compiler 4.14.3
 	RUN opam install -y opam-depext
 	ENTRYPOINT [ "opam", "exec", "--" ]
 	CMD bash
@@ -16477,7 +16507,7 @@ ocurrent/opam-staging:ubuntu-25.04-ocaml-5.2-s390x, ocurrent/opam-staging:ubuntu
 	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
 
 ocurrent/opam-staging:ubuntu-25.04-ocaml-5.3-s390x, ocurrent/opam-staging:ubuntu-25.04-ocaml-5.3-ppc64le, ocurrent/opam-staging:ubuntu-25.04-ocaml-5.3-arm64, ocurrent/opam-staging:ubuntu-25.04-ocaml-5.3-amd64, ocurrent/opam-staging:ubuntu-25.04-ocaml-5.3-riscv64 -> ocaml/opam:ubuntu-25.04-ocaml-5.3
-5.4.0/s390x
+5.4.1/s390x
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-25.04-opam-s390x
@@ -16487,14 +16517,14 @@ ocurrent/opam-staging:ubuntu-25.04-ocaml-5.3-s390x, ocurrent/opam-staging:ubuntu
 	RUN DEBIAN_FRONTEND=noninteractive apt-get -y upgrade
 	RUN DEBIAN_FRONTEND=noninteractive apt-get -y install libzstd-dev
 	USER opam
-	RUN opam switch create 5.4 --packages=ocaml-base-compiler.5.4.0
-	RUN opam pin add -k version ocaml-base-compiler 5.4.0
+	RUN opam switch create 5.4 --packages=ocaml-base-compiler.5.4.1
+	RUN opam pin add -k version ocaml-base-compiler 5.4.1
 	RUN opam install -y opam-depext
 	ENTRYPOINT [ "opam", "exec", "--" ]
 	CMD bash
 	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
 
-5.4.0/ppc64le
+5.4.1/ppc64le
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-25.04-opam-ppc64le
@@ -16504,14 +16534,14 @@ ocurrent/opam-staging:ubuntu-25.04-ocaml-5.3-s390x, ocurrent/opam-staging:ubuntu
 	RUN DEBIAN_FRONTEND=noninteractive apt-get -y upgrade
 	RUN DEBIAN_FRONTEND=noninteractive apt-get -y install libzstd-dev
 	USER opam
-	RUN opam switch create 5.4 --packages=ocaml-base-compiler.5.4.0
-	RUN opam pin add -k version ocaml-base-compiler 5.4.0
+	RUN opam switch create 5.4 --packages=ocaml-base-compiler.5.4.1
+	RUN opam pin add -k version ocaml-base-compiler 5.4.1
 	RUN opam install -y opam-depext
 	ENTRYPOINT [ "opam", "exec", "--" ]
 	CMD bash
 	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
 
-5.4.0/arm64
+5.4.1/arm64
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-25.04-opam-arm64
@@ -16521,14 +16551,14 @@ ocurrent/opam-staging:ubuntu-25.04-ocaml-5.3-s390x, ocurrent/opam-staging:ubuntu
 	RUN DEBIAN_FRONTEND=noninteractive apt-get -y upgrade
 	RUN DEBIAN_FRONTEND=noninteractive apt-get -y install libzstd-dev
 	USER opam
-	RUN opam switch create 5.4 --packages=ocaml-base-compiler.5.4.0
-	RUN opam pin add -k version ocaml-base-compiler 5.4.0
+	RUN opam switch create 5.4 --packages=ocaml-base-compiler.5.4.1
+	RUN opam pin add -k version ocaml-base-compiler 5.4.1
 	RUN opam install -y opam-depext
 	ENTRYPOINT [ "opam", "exec", "--" ]
 	CMD bash
 	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
 
-5.4.0/amd64
+5.4.1/amd64
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-25.04-opam-amd64
@@ -16538,14 +16568,14 @@ ocurrent/opam-staging:ubuntu-25.04-ocaml-5.3-s390x, ocurrent/opam-staging:ubuntu
 	RUN DEBIAN_FRONTEND=noninteractive apt-get -y upgrade
 	RUN DEBIAN_FRONTEND=noninteractive apt-get -y install libzstd-dev
 	USER opam
-	RUN opam switch create 5.4 --packages=ocaml-base-compiler.5.4.0
-	RUN opam pin add -k version ocaml-base-compiler 5.4.0
+	RUN opam switch create 5.4 --packages=ocaml-base-compiler.5.4.1
+	RUN opam pin add -k version ocaml-base-compiler 5.4.1
 	RUN opam install -y opam-depext
 	ENTRYPOINT [ "opam", "exec", "--" ]
 	CMD bash
 	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
 
-5.4.0/riscv64
+5.4.1/riscv64
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-25.04-opam-riscv64
@@ -16555,8 +16585,8 @@ ocurrent/opam-staging:ubuntu-25.04-ocaml-5.3-s390x, ocurrent/opam-staging:ubuntu
 	RUN DEBIAN_FRONTEND=noninteractive apt-get -y upgrade
 	RUN DEBIAN_FRONTEND=noninteractive apt-get -y install libzstd-dev
 	USER opam
-	RUN opam switch create 5.4 --packages=ocaml-base-compiler.5.4.0
-	RUN opam pin add -k version ocaml-base-compiler 5.4.0
+	RUN opam switch create 5.4 --packages=ocaml-base-compiler.5.4.1
+	RUN opam pin add -k version ocaml-base-compiler 5.4.1
 	RUN opam install -y opam-depext
 	ENTRYPOINT [ "opam", "exec", "--" ]
 	CMD bash
@@ -16700,7 +16730,7 @@ ubuntu-25.10/s390x
 	RUN chmod 440 /etc/sudoers.d/opam
 	RUN chown root:root /etc/sudoers.d/opam
 	RUN if getent passwd 1000; then userdel -r $(id -nu 1000); fi
-	RUN adduser --uid 1000 --disabled-password --gecos '' opam
+	RUN useradd --uid 1000 --create-home --shell /bin/bash opam
 	RUN passwd -l opam
 	RUN chown -R opam:opam /home/opam
 	USER opam
@@ -16786,7 +16816,7 @@ ubuntu-25.10/ppc64le
 	RUN chmod 440 /etc/sudoers.d/opam
 	RUN chown root:root /etc/sudoers.d/opam
 	RUN if getent passwd 1000; then userdel -r $(id -nu 1000); fi
-	RUN adduser --uid 1000 --disabled-password --gecos '' opam
+	RUN useradd --uid 1000 --create-home --shell /bin/bash opam
 	RUN passwd -l opam
 	RUN chown -R opam:opam /home/opam
 	USER opam
@@ -16872,7 +16902,7 @@ ubuntu-25.10/arm64
 	RUN chmod 440 /etc/sudoers.d/opam
 	RUN chown root:root /etc/sudoers.d/opam
 	RUN if getent passwd 1000; then userdel -r $(id -nu 1000); fi
-	RUN adduser --uid 1000 --disabled-password --gecos '' opam
+	RUN useradd --uid 1000 --create-home --shell /bin/bash opam
 	RUN passwd -l opam
 	RUN chown -R opam:opam /home/opam
 	USER opam
@@ -16958,7 +16988,7 @@ ubuntu-25.10/amd64
 	RUN chmod 440 /etc/sudoers.d/opam
 	RUN chown root:root /etc/sudoers.d/opam
 	RUN if getent passwd 1000; then userdel -r $(id -nu 1000); fi
-	RUN adduser --uid 1000 --disabled-password --gecos '' opam
+	RUN useradd --uid 1000 --create-home --shell /bin/bash opam
 	RUN passwd -l opam
 	RUN chown -R opam:opam /home/opam
 	USER opam
@@ -17325,49 +17355,53 @@ ocurrent/opam-staging:ubuntu-25.10-ocaml-4.12-s390x, ocurrent/opam-staging:ubunt
 
 ocurrent/opam-staging:ubuntu-25.10-ocaml-4.13-s390x, ocurrent/opam-staging:ubuntu-25.10-ocaml-4.13-ppc64le, ocurrent/opam-staging:ubuntu-25.10-ocaml-4.13-arm64, ocurrent/opam-staging:ubuntu-25.10-ocaml-4.13-amd64 -> ocaml/opam:ubuntu-25.10-ocaml-4.13
 ocurrent/opam-staging:ubuntu-25.10-ocaml-4.13-s390x, ocurrent/opam-staging:ubuntu-25.10-ocaml-4.13-ppc64le, ocurrent/opam-staging:ubuntu-25.10-ocaml-4.13-arm64, ocurrent/opam-staging:ubuntu-25.10-ocaml-4.13-amd64 -> ocaml/opam:ubuntu-ocaml-4.13
-4.14.2/s390x
+4.14.3/s390x
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-25.10-opam-s390x
+	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.14 --packages=ocaml-base-compiler.4.14.2
-	RUN opam pin add -k version ocaml-base-compiler 4.14.2
+	RUN opam switch create 4.14 --packages=ocaml-base-compiler.4.14.3
+	RUN opam pin add -k version ocaml-base-compiler 4.14.3
 	RUN opam install -y opam-depext
 	ENTRYPOINT [ "opam", "exec", "--" ]
 	CMD bash
 	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
 
-4.14.2/ppc64le
+4.14.3/ppc64le
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-25.10-opam-ppc64le
+	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.14 --packages=ocaml-base-compiler.4.14.2
-	RUN opam pin add -k version ocaml-base-compiler 4.14.2
+	RUN opam switch create 4.14 --packages=ocaml-base-compiler.4.14.3
+	RUN opam pin add -k version ocaml-base-compiler 4.14.3
 	RUN opam install -y opam-depext
 	ENTRYPOINT [ "opam", "exec", "--" ]
 	CMD bash
 	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
 
-4.14.2/arm64
+4.14.3/arm64
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-25.10-opam-arm64
+	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.14 --packages=ocaml-base-compiler.4.14.2
-	RUN opam pin add -k version ocaml-base-compiler 4.14.2
+	RUN opam switch create 4.14 --packages=ocaml-base-compiler.4.14.3
+	RUN opam pin add -k version ocaml-base-compiler 4.14.3
 	RUN opam install -y opam-depext
 	ENTRYPOINT [ "opam", "exec", "--" ]
 	CMD bash
 	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
 
-4.14.2/amd64
+4.14.3/amd64
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-25.10-opam-amd64
+	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.14 --packages=ocaml-base-compiler.4.14.2
-	RUN opam pin add -k version ocaml-base-compiler 4.14.2
+	RUN opam switch create 4.14 --packages=ocaml-base-compiler.4.14.3
+	RUN opam pin add -k version ocaml-base-compiler 4.14.3
 	RUN opam install -y opam-depext
 	ENTRYPOINT [ "opam", "exec", "--" ]
 	CMD bash
@@ -17639,7 +17673,7 @@ ocurrent/opam-staging:ubuntu-25.10-ocaml-5.2-s390x, ocurrent/opam-staging:ubuntu
 
 ocurrent/opam-staging:ubuntu-25.10-ocaml-5.3-s390x, ocurrent/opam-staging:ubuntu-25.10-ocaml-5.3-ppc64le, ocurrent/opam-staging:ubuntu-25.10-ocaml-5.3-arm64, ocurrent/opam-staging:ubuntu-25.10-ocaml-5.3-amd64 -> ocaml/opam:ubuntu-25.10-ocaml-5.3
 ocurrent/opam-staging:ubuntu-25.10-ocaml-5.3-s390x, ocurrent/opam-staging:ubuntu-25.10-ocaml-5.3-ppc64le, ocurrent/opam-staging:ubuntu-25.10-ocaml-5.3-arm64, ocurrent/opam-staging:ubuntu-25.10-ocaml-5.3-amd64 -> ocaml/opam:ubuntu-ocaml-5.3
-5.4.0/s390x
+5.4.1/s390x
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-25.10-opam-s390x
@@ -17649,14 +17683,14 @@ ocurrent/opam-staging:ubuntu-25.10-ocaml-5.3-s390x, ocurrent/opam-staging:ubuntu
 	RUN DEBIAN_FRONTEND=noninteractive apt-get -y upgrade
 	RUN DEBIAN_FRONTEND=noninteractive apt-get -y install libzstd-dev
 	USER opam
-	RUN opam switch create 5.4 --packages=ocaml-base-compiler.5.4.0
-	RUN opam pin add -k version ocaml-base-compiler 5.4.0
+	RUN opam switch create 5.4 --packages=ocaml-base-compiler.5.4.1
+	RUN opam pin add -k version ocaml-base-compiler 5.4.1
 	RUN opam install -y opam-depext
 	ENTRYPOINT [ "opam", "exec", "--" ]
 	CMD bash
 	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
 
-5.4.0/ppc64le
+5.4.1/ppc64le
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-25.10-opam-ppc64le
@@ -17666,14 +17700,14 @@ ocurrent/opam-staging:ubuntu-25.10-ocaml-5.3-s390x, ocurrent/opam-staging:ubuntu
 	RUN DEBIAN_FRONTEND=noninteractive apt-get -y upgrade
 	RUN DEBIAN_FRONTEND=noninteractive apt-get -y install libzstd-dev
 	USER opam
-	RUN opam switch create 5.4 --packages=ocaml-base-compiler.5.4.0
-	RUN opam pin add -k version ocaml-base-compiler 5.4.0
+	RUN opam switch create 5.4 --packages=ocaml-base-compiler.5.4.1
+	RUN opam pin add -k version ocaml-base-compiler 5.4.1
 	RUN opam install -y opam-depext
 	ENTRYPOINT [ "opam", "exec", "--" ]
 	CMD bash
 	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
 
-5.4.0/arm64
+5.4.1/arm64
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-25.10-opam-arm64
@@ -17683,14 +17717,14 @@ ocurrent/opam-staging:ubuntu-25.10-ocaml-5.3-s390x, ocurrent/opam-staging:ubuntu
 	RUN DEBIAN_FRONTEND=noninteractive apt-get -y upgrade
 	RUN DEBIAN_FRONTEND=noninteractive apt-get -y install libzstd-dev
 	USER opam
-	RUN opam switch create 5.4 --packages=ocaml-base-compiler.5.4.0
-	RUN opam pin add -k version ocaml-base-compiler 5.4.0
+	RUN opam switch create 5.4 --packages=ocaml-base-compiler.5.4.1
+	RUN opam pin add -k version ocaml-base-compiler 5.4.1
 	RUN opam install -y opam-depext
 	ENTRYPOINT [ "opam", "exec", "--" ]
 	CMD bash
 	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
 
-5.4.0/amd64
+5.4.1/amd64
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-25.10-opam-amd64
@@ -17700,8 +17734,8 @@ ocurrent/opam-staging:ubuntu-25.10-ocaml-5.3-s390x, ocurrent/opam-staging:ubuntu
 	RUN DEBIAN_FRONTEND=noninteractive apt-get -y upgrade
 	RUN DEBIAN_FRONTEND=noninteractive apt-get -y install libzstd-dev
 	USER opam
-	RUN opam switch create 5.4 --packages=ocaml-base-compiler.5.4.0
-	RUN opam pin add -k version ocaml-base-compiler 5.4.0
+	RUN opam switch create 5.4 --packages=ocaml-base-compiler.5.4.1
+	RUN opam pin add -k version ocaml-base-compiler 5.4.1
 	RUN opam install -y opam-depext
 	ENTRYPOINT [ "opam", "exec", "--" ]
 	CMD bash
@@ -17881,14 +17915,13 @@ windows-server-mingw-ltsc2025/amd64
 	RUN C:\cygwin64\bin\bash.exe --login -c "rm -rf /cygdrive/c/opam/.opam/repo/default/.git"
 	COPY [ "Dockerfile", "/Dockerfile.opam" ]
 
-5.4.0/amd64
+5.4.1/amd64
 	# escape=`
 
 	FROM ocurrent/opam-staging:windows-server-mingw-ltsc2025-opam-amd64
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 5.4 --packages=ocaml-base-compiler.5.4.0,system-mingw
-	RUN opam pin add -k version ocaml-base-compiler 5.4.0
-	RUN opam install -y depext depext-cygwinports
+	RUN opam switch create 5.4 --packages=ocaml-base-compiler.5.4.1,system-mingw
+	RUN opam pin add -k version ocaml-base-compiler 5.4.1
 	ENTRYPOINT [ "opam", "exec", "--" ]
 	CMD [ "cmd.exe" ]
 	COPY [ "Dockerfile", "/Dockerfile.ocaml" ]
@@ -17988,14 +18021,13 @@ windows-server-mingw-ltsc2022/amd64
 	RUN C:\cygwin64\bin\bash.exe --login -c "rm -rf /cygdrive/c/opam/.opam/repo/default/.git"
 	COPY [ "Dockerfile", "/Dockerfile.opam" ]
 
-5.4.0/amd64
+5.4.1/amd64
 	# escape=`
 
 	FROM ocurrent/opam-staging:windows-server-mingw-ltsc2022-opam-amd64
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 5.4 --packages=ocaml-base-compiler.5.4.0,system-mingw
-	RUN opam pin add -k version ocaml-base-compiler 5.4.0
-	RUN opam install -y depext depext-cygwinports
+	RUN opam switch create 5.4 --packages=ocaml-base-compiler.5.4.1,system-mingw
+	RUN opam pin add -k version ocaml-base-compiler 5.4.1
 	ENTRYPOINT [ "opam", "exec", "--" ]
 	CMD [ "cmd.exe" ]
 	COPY [ "Dockerfile", "/Dockerfile.ocaml" ]
@@ -18096,14 +18128,13 @@ windows-mingw-ltsc2019/amd64
 	RUN C:\cygwin64\bin\bash.exe --login -c "rm -rf /cygdrive/c/opam/.opam/repo/default/.git"
 	COPY [ "Dockerfile", "/Dockerfile.opam" ]
 
-5.4.0/amd64
+5.4.1/amd64
 	# escape=`
 
 	FROM ocurrent/opam-staging:windows-mingw-ltsc2019-opam-amd64
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 5.4 --packages=ocaml-base-compiler.5.4.0,system-mingw
-	RUN opam pin add -k version ocaml-base-compiler 5.4.0
-	RUN opam install -y depext depext-cygwinports
+	RUN opam switch create 5.4 --packages=ocaml-base-compiler.5.4.1,system-mingw
+	RUN opam pin add -k version ocaml-base-compiler 5.4.1
 	ENTRYPOINT [ "opam", "exec", "--" ]
 	CMD [ "cmd.exe" ]
 	COPY [ "Dockerfile", "/Dockerfile.ocaml" ]
@@ -18117,7 +18148,6 @@ ocurrent/opam-staging:windows-server-mingw-ltsc2025-ocaml-5.4-amd64, ocurrent/op
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 5.3 --packages=ocaml-base-compiler.5.3.0,system-mingw
 	RUN opam pin add -k version ocaml-base-compiler 5.3.0
-	RUN opam install -y depext depext-cygwinports
 	ENTRYPOINT [ "opam", "exec", "--" ]
 	CMD [ "cmd.exe" ]
 	COPY [ "Dockerfile", "/Dockerfile.ocaml" ]
@@ -18129,7 +18159,6 @@ ocurrent/opam-staging:windows-server-mingw-ltsc2025-ocaml-5.4-amd64, ocurrent/op
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 5.3 --packages=ocaml-base-compiler.5.3.0,system-mingw
 	RUN opam pin add -k version ocaml-base-compiler 5.3.0
-	RUN opam install -y depext depext-cygwinports
 	ENTRYPOINT [ "opam", "exec", "--" ]
 	CMD [ "cmd.exe" ]
 	COPY [ "Dockerfile", "/Dockerfile.ocaml" ]
@@ -18141,7 +18170,6 @@ ocurrent/opam-staging:windows-server-mingw-ltsc2025-ocaml-5.4-amd64, ocurrent/op
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 5.3 --packages=ocaml-base-compiler.5.3.0,system-mingw
 	RUN opam pin add -k version ocaml-base-compiler 5.3.0
-	RUN opam install -y depext depext-cygwinports
 	ENTRYPOINT [ "opam", "exec", "--" ]
 	CMD [ "cmd.exe" ]
 	COPY [ "Dockerfile", "/Dockerfile.ocaml" ]
@@ -18154,7 +18182,6 @@ ocurrent/opam-staging:windows-server-mingw-ltsc2025-ocaml-5.3-amd64, ocurrent/op
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 5.2 --packages=ocaml-base-compiler.5.2.1,system-mingw
 	RUN opam pin add -k version ocaml-base-compiler 5.2.1
-	RUN opam install -y depext depext-cygwinports
 	ENTRYPOINT [ "opam", "exec", "--" ]
 	CMD [ "cmd.exe" ]
 	COPY [ "Dockerfile", "/Dockerfile.ocaml" ]
@@ -18166,7 +18193,6 @@ ocurrent/opam-staging:windows-server-mingw-ltsc2025-ocaml-5.3-amd64, ocurrent/op
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 5.2 --packages=ocaml-base-compiler.5.2.1,system-mingw
 	RUN opam pin add -k version ocaml-base-compiler 5.2.1
-	RUN opam install -y depext depext-cygwinports
 	ENTRYPOINT [ "opam", "exec", "--" ]
 	CMD [ "cmd.exe" ]
 	COPY [ "Dockerfile", "/Dockerfile.ocaml" ]
@@ -18178,7 +18204,6 @@ ocurrent/opam-staging:windows-server-mingw-ltsc2025-ocaml-5.3-amd64, ocurrent/op
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 5.2 --packages=ocaml-base-compiler.5.2.1,system-mingw
 	RUN opam pin add -k version ocaml-base-compiler 5.2.1
-	RUN opam install -y depext depext-cygwinports
 	ENTRYPOINT [ "opam", "exec", "--" ]
 	CMD [ "cmd.exe" ]
 	COPY [ "Dockerfile", "/Dockerfile.ocaml" ]
@@ -18191,7 +18216,6 @@ ocurrent/opam-staging:windows-server-mingw-ltsc2025-ocaml-5.2-amd64, ocurrent/op
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 5.1 --packages=ocaml-base-compiler.5.1.1,system-mingw
 	RUN opam pin add -k version ocaml-base-compiler 5.1.1
-	RUN opam install -y depext depext-cygwinports
 	ENTRYPOINT [ "opam", "exec", "--" ]
 	CMD [ "cmd.exe" ]
 	COPY [ "Dockerfile", "/Dockerfile.ocaml" ]
@@ -18203,7 +18227,6 @@ ocurrent/opam-staging:windows-server-mingw-ltsc2025-ocaml-5.2-amd64, ocurrent/op
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 5.1 --packages=ocaml-base-compiler.5.1.1,system-mingw
 	RUN opam pin add -k version ocaml-base-compiler 5.1.1
-	RUN opam install -y depext depext-cygwinports
 	ENTRYPOINT [ "opam", "exec", "--" ]
 	CMD [ "cmd.exe" ]
 	COPY [ "Dockerfile", "/Dockerfile.ocaml" ]
@@ -18215,7 +18238,6 @@ ocurrent/opam-staging:windows-server-mingw-ltsc2025-ocaml-5.2-amd64, ocurrent/op
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 5.1 --packages=ocaml-base-compiler.5.1.1,system-mingw
 	RUN opam pin add -k version ocaml-base-compiler 5.1.1
-	RUN opam install -y depext depext-cygwinports
 	ENTRYPOINT [ "opam", "exec", "--" ]
 	CMD [ "cmd.exe" ]
 	COPY [ "Dockerfile", "/Dockerfile.ocaml" ]
@@ -18228,7 +18250,6 @@ ocurrent/opam-staging:windows-server-mingw-ltsc2025-ocaml-5.1-amd64, ocurrent/op
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 5.0 --packages=ocaml-base-compiler.5.0.0,system-mingw
 	RUN opam pin add -k version ocaml-base-compiler 5.0.0
-	RUN opam install -y depext depext-cygwinports
 	ENTRYPOINT [ "opam", "exec", "--" ]
 	CMD [ "cmd.exe" ]
 	COPY [ "Dockerfile", "/Dockerfile.ocaml" ]
@@ -18240,7 +18261,6 @@ ocurrent/opam-staging:windows-server-mingw-ltsc2025-ocaml-5.1-amd64, ocurrent/op
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 5.0 --packages=ocaml-base-compiler.5.0.0,system-mingw
 	RUN opam pin add -k version ocaml-base-compiler 5.0.0
-	RUN opam install -y depext depext-cygwinports
 	ENTRYPOINT [ "opam", "exec", "--" ]
 	CMD [ "cmd.exe" ]
 	COPY [ "Dockerfile", "/Dockerfile.ocaml" ]
@@ -18252,44 +18272,40 @@ ocurrent/opam-staging:windows-server-mingw-ltsc2025-ocaml-5.1-amd64, ocurrent/op
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 5.0 --packages=ocaml-base-compiler.5.0.0,system-mingw
 	RUN opam pin add -k version ocaml-base-compiler 5.0.0
-	RUN opam install -y depext depext-cygwinports
 	ENTRYPOINT [ "opam", "exec", "--" ]
 	CMD [ "cmd.exe" ]
 	COPY [ "Dockerfile", "/Dockerfile.ocaml" ]
 
 ocurrent/opam-staging:windows-server-mingw-ltsc2025-ocaml-5.0-amd64, ocurrent/opam-staging:windows-server-mingw-ltsc2022-ocaml-5.0-amd64, ocurrent/opam-staging:windows-mingw-ltsc2019-ocaml-5.0-amd64 -> ocaml/opam:windows-all-mingw-ocaml-5.0
-4.14.2/amd64
+4.14.3/amd64
 	# escape=`
 
 	FROM ocurrent/opam-staging:windows-server-mingw-ltsc2025-opam-amd64
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.14 --packages=ocaml-base-compiler.4.14.2,system-mingw
-	RUN opam pin add -k version ocaml-base-compiler 4.14.2
-	RUN opam install -y depext depext-cygwinports
+	RUN opam switch create 4.14 --packages=ocaml-base-compiler.4.14.3,system-mingw
+	RUN opam pin add -k version ocaml-base-compiler 4.14.3
 	ENTRYPOINT [ "opam", "exec", "--" ]
 	CMD [ "cmd.exe" ]
 	COPY [ "Dockerfile", "/Dockerfile.ocaml" ]
 
-4.14.2/amd64
+4.14.3/amd64
 	# escape=`
 
 	FROM ocurrent/opam-staging:windows-server-mingw-ltsc2022-opam-amd64
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.14 --packages=ocaml-base-compiler.4.14.2,system-mingw
-	RUN opam pin add -k version ocaml-base-compiler 4.14.2
-	RUN opam install -y depext depext-cygwinports
+	RUN opam switch create 4.14 --packages=ocaml-base-compiler.4.14.3,system-mingw
+	RUN opam pin add -k version ocaml-base-compiler 4.14.3
 	ENTRYPOINT [ "opam", "exec", "--" ]
 	CMD [ "cmd.exe" ]
 	COPY [ "Dockerfile", "/Dockerfile.ocaml" ]
 
-4.14.2/amd64
+4.14.3/amd64
 	# escape=`
 
 	FROM ocurrent/opam-staging:windows-mingw-ltsc2019-opam-amd64
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.14 --packages=ocaml-base-compiler.4.14.2,system-mingw
-	RUN opam pin add -k version ocaml-base-compiler 4.14.2
-	RUN opam install -y depext depext-cygwinports
+	RUN opam switch create 4.14 --packages=ocaml-base-compiler.4.14.3,system-mingw
+	RUN opam pin add -k version ocaml-base-compiler 4.14.3
 	ENTRYPOINT [ "opam", "exec", "--" ]
 	CMD [ "cmd.exe" ]
 	COPY [ "Dockerfile", "/Dockerfile.ocaml" ]
@@ -18302,7 +18318,6 @@ ocurrent/opam-staging:windows-server-mingw-ltsc2025-ocaml-4.14-amd64, ocurrent/o
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.13 --packages=ocaml-base-compiler.4.13.1,system-mingw
 	RUN opam pin add -k version ocaml-base-compiler 4.13.1
-	RUN opam install -y depext depext-cygwinports
 	ENTRYPOINT [ "opam", "exec", "--" ]
 	CMD [ "cmd.exe" ]
 	COPY [ "Dockerfile", "/Dockerfile.ocaml" ]
@@ -18314,7 +18329,6 @@ ocurrent/opam-staging:windows-server-mingw-ltsc2025-ocaml-4.14-amd64, ocurrent/o
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.13 --packages=ocaml-base-compiler.4.13.1,system-mingw
 	RUN opam pin add -k version ocaml-base-compiler 4.13.1
-	RUN opam install -y depext depext-cygwinports
 	ENTRYPOINT [ "opam", "exec", "--" ]
 	CMD [ "cmd.exe" ]
 	COPY [ "Dockerfile", "/Dockerfile.ocaml" ]
@@ -18326,7 +18340,6 @@ ocurrent/opam-staging:windows-server-mingw-ltsc2025-ocaml-4.14-amd64, ocurrent/o
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.13 --packages=ocaml-base-compiler.4.13.1,system-mingw
 	RUN opam pin add -k version ocaml-base-compiler 4.13.1
-	RUN opam install -y depext depext-cygwinports
 	ENTRYPOINT [ "opam", "exec", "--" ]
 	CMD [ "cmd.exe" ]
 	COPY [ "Dockerfile", "/Dockerfile.ocaml" ]
@@ -18476,14 +18489,13 @@ windows-server-msvc-ltsc2025/amd64
 	RUN C:\cygwin64\bin\bash.exe --login -c "rm -rf /cygdrive/c/opam/.opam/repo/default/.git"
 	COPY [ "Dockerfile", "/Dockerfile.opam" ]
 
-5.4.0/amd64
+5.4.1/amd64
 	# escape=`
 
 	FROM ocurrent/opam-staging:windows-server-msvc-ltsc2025-opam-amd64
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 5.4 --packages=ocaml-base-compiler.5.4.0,system-msvc
-	RUN opam pin add -k version ocaml-base-compiler 5.4.0
-	RUN opam install -y depext
+	RUN opam switch create 5.4 --packages=ocaml-base-compiler.5.4.1,system-msvc
+	RUN opam pin add -k version ocaml-base-compiler 5.4.1
 	ENTRYPOINT [ "opam", "exec", "--" ]
 	CMD [ "cmd.exe" ]
 	COPY [ "Dockerfile", "/Dockerfile.ocaml" ]
@@ -18590,14 +18602,13 @@ windows-server-msvc-ltsc2022/amd64
 	RUN C:\cygwin64\bin\bash.exe --login -c "rm -rf /cygdrive/c/opam/.opam/repo/default/.git"
 	COPY [ "Dockerfile", "/Dockerfile.opam" ]
 
-5.4.0/amd64
+5.4.1/amd64
 	# escape=`
 
 	FROM ocurrent/opam-staging:windows-server-msvc-ltsc2022-opam-amd64
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 5.4 --packages=ocaml-base-compiler.5.4.0,system-msvc
-	RUN opam pin add -k version ocaml-base-compiler 5.4.0
-	RUN opam install -y depext
+	RUN opam switch create 5.4 --packages=ocaml-base-compiler.5.4.1,system-msvc
+	RUN opam pin add -k version ocaml-base-compiler 5.4.1
 	ENTRYPOINT [ "opam", "exec", "--" ]
 	CMD [ "cmd.exe" ]
 	COPY [ "Dockerfile", "/Dockerfile.ocaml" ]
@@ -18704,14 +18715,13 @@ windows-msvc-ltsc2019/amd64
 	RUN C:\cygwin64\bin\bash.exe --login -c "rm -rf /cygdrive/c/opam/.opam/repo/default/.git"
 	COPY [ "Dockerfile", "/Dockerfile.opam" ]
 
-5.4.0/amd64
+5.4.1/amd64
 	# escape=`
 
 	FROM ocurrent/opam-staging:windows-msvc-ltsc2019-opam-amd64
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 5.4 --packages=ocaml-base-compiler.5.4.0,system-msvc
-	RUN opam pin add -k version ocaml-base-compiler 5.4.0
-	RUN opam install -y depext
+	RUN opam switch create 5.4 --packages=ocaml-base-compiler.5.4.1,system-msvc
+	RUN opam pin add -k version ocaml-base-compiler 5.4.1
 	ENTRYPOINT [ "opam", "exec", "--" ]
 	CMD [ "cmd.exe" ]
 	COPY [ "Dockerfile", "/Dockerfile.ocaml" ]
@@ -18725,7 +18735,6 @@ ocurrent/opam-staging:windows-server-msvc-ltsc2025-ocaml-5.4-amd64, ocurrent/opa
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 5.3 --packages=ocaml-base-compiler.5.3.0,system-msvc
 	RUN opam pin add -k version ocaml-base-compiler 5.3.0
-	RUN opam install -y depext
 	ENTRYPOINT [ "opam", "exec", "--" ]
 	CMD [ "cmd.exe" ]
 	COPY [ "Dockerfile", "/Dockerfile.ocaml" ]
@@ -18737,7 +18746,6 @@ ocurrent/opam-staging:windows-server-msvc-ltsc2025-ocaml-5.4-amd64, ocurrent/opa
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 5.3 --packages=ocaml-base-compiler.5.3.0,system-msvc
 	RUN opam pin add -k version ocaml-base-compiler 5.3.0
-	RUN opam install -y depext
 	ENTRYPOINT [ "opam", "exec", "--" ]
 	CMD [ "cmd.exe" ]
 	COPY [ "Dockerfile", "/Dockerfile.ocaml" ]
@@ -18749,44 +18757,40 @@ ocurrent/opam-staging:windows-server-msvc-ltsc2025-ocaml-5.4-amd64, ocurrent/opa
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 5.3 --packages=ocaml-base-compiler.5.3.0,system-msvc
 	RUN opam pin add -k version ocaml-base-compiler 5.3.0
-	RUN opam install -y depext
 	ENTRYPOINT [ "opam", "exec", "--" ]
 	CMD [ "cmd.exe" ]
 	COPY [ "Dockerfile", "/Dockerfile.ocaml" ]
 
 ocurrent/opam-staging:windows-server-msvc-ltsc2025-ocaml-5.3-amd64, ocurrent/opam-staging:windows-server-msvc-ltsc2022-ocaml-5.3-amd64, ocurrent/opam-staging:windows-msvc-ltsc2019-ocaml-5.3-amd64 -> ocaml/opam:windows-all-msvc-ocaml-5.3
-4.14.2/amd64
+4.14.3/amd64
 	# escape=`
 
 	FROM ocurrent/opam-staging:windows-server-msvc-ltsc2025-opam-amd64
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.14 --packages=ocaml-base-compiler.4.14.2,system-msvc
-	RUN opam pin add -k version ocaml-base-compiler 4.14.2
-	RUN opam install -y depext
+	RUN opam switch create 4.14 --packages=ocaml-base-compiler.4.14.3,system-msvc
+	RUN opam pin add -k version ocaml-base-compiler 4.14.3
 	ENTRYPOINT [ "opam", "exec", "--" ]
 	CMD [ "cmd.exe" ]
 	COPY [ "Dockerfile", "/Dockerfile.ocaml" ]
 
-4.14.2/amd64
+4.14.3/amd64
 	# escape=`
 
 	FROM ocurrent/opam-staging:windows-server-msvc-ltsc2022-opam-amd64
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.14 --packages=ocaml-base-compiler.4.14.2,system-msvc
-	RUN opam pin add -k version ocaml-base-compiler 4.14.2
-	RUN opam install -y depext
+	RUN opam switch create 4.14 --packages=ocaml-base-compiler.4.14.3,system-msvc
+	RUN opam pin add -k version ocaml-base-compiler 4.14.3
 	ENTRYPOINT [ "opam", "exec", "--" ]
 	CMD [ "cmd.exe" ]
 	COPY [ "Dockerfile", "/Dockerfile.ocaml" ]
 
-4.14.2/amd64
+4.14.3/amd64
 	# escape=`
 
 	FROM ocurrent/opam-staging:windows-msvc-ltsc2019-opam-amd64
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.14 --packages=ocaml-base-compiler.4.14.2,system-msvc
-	RUN opam pin add -k version ocaml-base-compiler 4.14.2
-	RUN opam install -y depext
+	RUN opam switch create 4.14 --packages=ocaml-base-compiler.4.14.3,system-msvc
+	RUN opam pin add -k version ocaml-base-compiler 4.14.3
 	ENTRYPOINT [ "opam", "exec", "--" ]
 	CMD [ "cmd.exe" ]
 	COPY [ "Dockerfile", "/Dockerfile.ocaml" ]
@@ -18799,7 +18803,6 @@ ocurrent/opam-staging:windows-server-msvc-ltsc2025-ocaml-4.14-amd64, ocurrent/op
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.13 --packages=ocaml-base-compiler.4.13.1,system-msvc
 	RUN opam pin add -k version ocaml-base-compiler 4.13.1
-	RUN opam install -y depext
 	ENTRYPOINT [ "opam", "exec", "--" ]
 	CMD [ "cmd.exe" ]
 	COPY [ "Dockerfile", "/Dockerfile.ocaml" ]
@@ -18811,7 +18814,6 @@ ocurrent/opam-staging:windows-server-msvc-ltsc2025-ocaml-4.14-amd64, ocurrent/op
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.13 --packages=ocaml-base-compiler.4.13.1,system-msvc
 	RUN opam pin add -k version ocaml-base-compiler 4.13.1
-	RUN opam install -y depext
 	ENTRYPOINT [ "opam", "exec", "--" ]
 	CMD [ "cmd.exe" ]
 	COPY [ "Dockerfile", "/Dockerfile.ocaml" ]
@@ -18823,7 +18825,6 @@ ocurrent/opam-staging:windows-server-msvc-ltsc2025-ocaml-4.14-amd64, ocurrent/op
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.13 --packages=ocaml-base-compiler.4.13.1,system-msvc
 	RUN opam pin add -k version ocaml-base-compiler 4.13.1
-	RUN opam install -y depext
 	ENTRYPOINT [ "opam", "exec", "--" ]
 	CMD [ "cmd.exe" ]
 	COPY [ "Dockerfile", "/Dockerfile.ocaml" ]


### PR DESCRIPTION
Bump opam-repository SHA and update builds.expected for the new ocaml-version 4.0.4 release which adds OCaml 4.14.3 and 5.4.1.