### PR TITLE
Thin compiler matrix and add Ubuntu 26.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     libssl-dev \
     m4 \
     pkg-config
-RUN cd ~/opam-repository && git fetch -q origin master && git reset --hard 4375a073acc0d5f99f83516238d79308cefa9cab && opam update
+RUN cd ~/opam-repository && git fetch -q origin master && git reset --hard cf76b487b68928b40a49920699bd7419e8e0e184 && opam update
 COPY --chown=opam --link base-images.opam /src/
 WORKDIR /src
 ENV OPAMSOLVERTIMEOUT=600

--- a/builds.expected
+++ b/builds.expected
@@ -263,204 +263,6 @@ ocurrent/opam-staging:alpine-3.23-ocaml-4.08-flambda-arm64, ocurrent/opam-stagin
 
 ocurrent/opam-staging:alpine-3.23-ocaml-4.08-fp-amd64 -> ocaml/opam:alpine-3.23-ocaml-4.08-fp
 ocurrent/opam-staging:alpine-3.23-ocaml-4.08-fp-amd64 -> ocaml/opam:alpine-ocaml-4.08-fp
-4.09.1/arm64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:alpine-3.23-opam-arm64
-	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.09 --packages=ocaml-base-compiler.4.09.1
-	RUN opam pin add -k version ocaml-base-compiler 4.09.1
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.09.1/amd64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:alpine-3.23-opam-amd64
-	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.09 --packages=ocaml-base-compiler.4.09.1
-	RUN opam pin add -k version ocaml-base-compiler 4.09.1
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-ocurrent/opam-staging:alpine-3.23-ocaml-4.09-arm64, ocurrent/opam-staging:alpine-3.23-ocaml-4.09-amd64 -> ocaml/opam:alpine-3.23-ocaml-4.09
-ocurrent/opam-staging:alpine-3.23-ocaml-4.09-arm64, ocurrent/opam-staging:alpine-3.23-ocaml-4.09-amd64 -> ocaml/opam:alpine-ocaml-4.09
-4.09.1+afl/arm64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:alpine-3.23-opam-arm64
-	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.09 --packages=ocaml-variants.4.09.1+afl
-	RUN opam pin add -k version ocaml-variants 4.09.1+afl
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.09.1+afl/amd64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:alpine-3.23-opam-amd64
-	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.09 --packages=ocaml-variants.4.09.1+afl
-	RUN opam pin add -k version ocaml-variants 4.09.1+afl
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-ocurrent/opam-staging:alpine-3.23-ocaml-4.09-afl-arm64, ocurrent/opam-staging:alpine-3.23-ocaml-4.09-afl-amd64 -> ocaml/opam:alpine-3.23-ocaml-4.09-afl
-ocurrent/opam-staging:alpine-3.23-ocaml-4.09-afl-arm64, ocurrent/opam-staging:alpine-3.23-ocaml-4.09-afl-amd64 -> ocaml/opam:alpine-ocaml-4.09-afl
-4.09.1+flambda/arm64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:alpine-3.23-opam-arm64
-	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.09 --packages=ocaml-variants.4.09.1+flambda
-	RUN opam pin add -k version ocaml-variants 4.09.1+flambda
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.09.1+flambda/amd64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:alpine-3.23-opam-amd64
-	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.09 --packages=ocaml-variants.4.09.1+flambda
-	RUN opam pin add -k version ocaml-variants 4.09.1+flambda
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-ocurrent/opam-staging:alpine-3.23-ocaml-4.09-flambda-arm64, ocurrent/opam-staging:alpine-3.23-ocaml-4.09-flambda-amd64 -> ocaml/opam:alpine-3.23-ocaml-4.09-flambda
-ocurrent/opam-staging:alpine-3.23-ocaml-4.09-flambda-arm64, ocurrent/opam-staging:alpine-3.23-ocaml-4.09-flambda-amd64 -> ocaml/opam:alpine-ocaml-4.09-flambda
-4.09.1+fp/amd64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:alpine-3.23-opam-amd64
-	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.09 --packages=ocaml-variants.4.09.1+fp
-	RUN opam pin add -k version ocaml-variants 4.09.1+fp
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-ocurrent/opam-staging:alpine-3.23-ocaml-4.09-fp-amd64 -> ocaml/opam:alpine-3.23-ocaml-4.09-fp
-ocurrent/opam-staging:alpine-3.23-ocaml-4.09-fp-amd64 -> ocaml/opam:alpine-ocaml-4.09-fp
-4.10.2/arm64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:alpine-3.23-opam-arm64
-	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.10 --packages=ocaml-base-compiler.4.10.2
-	RUN opam pin add -k version ocaml-base-compiler 4.10.2
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.10.2/amd64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:alpine-3.23-opam-amd64
-	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.10 --packages=ocaml-base-compiler.4.10.2
-	RUN opam pin add -k version ocaml-base-compiler 4.10.2
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-ocurrent/opam-staging:alpine-3.23-ocaml-4.10-arm64, ocurrent/opam-staging:alpine-3.23-ocaml-4.10-amd64 -> ocaml/opam:alpine-3.23-ocaml-4.10
-ocurrent/opam-staging:alpine-3.23-ocaml-4.10-arm64, ocurrent/opam-staging:alpine-3.23-ocaml-4.10-amd64 -> ocaml/opam:alpine-ocaml-4.10
-4.10.2+afl/arm64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:alpine-3.23-opam-arm64
-	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.10 --packages=ocaml-variants.4.10.2+afl
-	RUN opam pin add -k version ocaml-variants 4.10.2+afl
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.10.2+afl/amd64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:alpine-3.23-opam-amd64
-	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.10 --packages=ocaml-variants.4.10.2+afl
-	RUN opam pin add -k version ocaml-variants 4.10.2+afl
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-ocurrent/opam-staging:alpine-3.23-ocaml-4.10-afl-arm64, ocurrent/opam-staging:alpine-3.23-ocaml-4.10-afl-amd64 -> ocaml/opam:alpine-3.23-ocaml-4.10-afl
-ocurrent/opam-staging:alpine-3.23-ocaml-4.10-afl-arm64, ocurrent/opam-staging:alpine-3.23-ocaml-4.10-afl-amd64 -> ocaml/opam:alpine-ocaml-4.10-afl
-4.10.2+flambda/arm64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:alpine-3.23-opam-arm64
-	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.10 --packages=ocaml-variants.4.10.2+flambda
-	RUN opam pin add -k version ocaml-variants 4.10.2+flambda
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.10.2+flambda/amd64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:alpine-3.23-opam-amd64
-	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.10 --packages=ocaml-variants.4.10.2+flambda
-	RUN opam pin add -k version ocaml-variants 4.10.2+flambda
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-ocurrent/opam-staging:alpine-3.23-ocaml-4.10-flambda-arm64, ocurrent/opam-staging:alpine-3.23-ocaml-4.10-flambda-amd64 -> ocaml/opam:alpine-3.23-ocaml-4.10-flambda
-ocurrent/opam-staging:alpine-3.23-ocaml-4.10-flambda-arm64, ocurrent/opam-staging:alpine-3.23-ocaml-4.10-flambda-amd64 -> ocaml/opam:alpine-ocaml-4.10-flambda
-4.10.2+fp/amd64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:alpine-3.23-opam-amd64
-	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.10 --packages=ocaml-variants.4.10.2+fp
-	RUN opam pin add -k version ocaml-variants 4.10.2+fp
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-ocurrent/opam-staging:alpine-3.23-ocaml-4.10-fp-amd64 -> ocaml/opam:alpine-3.23-ocaml-4.10-fp
-ocurrent/opam-staging:alpine-3.23-ocaml-4.10-fp-amd64 -> ocaml/opam:alpine-ocaml-4.10-fp
 4.11.2/arm64
 	# syntax=docker/dockerfile:1
 
@@ -560,376 +362,6 @@ ocurrent/opam-staging:alpine-3.23-ocaml-4.11-flambda-arm64, ocurrent/opam-stagin
 
 ocurrent/opam-staging:alpine-3.23-ocaml-4.11-fp-amd64 -> ocaml/opam:alpine-3.23-ocaml-4.11-fp
 ocurrent/opam-staging:alpine-3.23-ocaml-4.11-fp-amd64 -> ocaml/opam:alpine-ocaml-4.11-fp
-4.12.1/arm64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:alpine-3.23-opam-arm64
-	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.12 --packages=ocaml-base-compiler.4.12.1
-	RUN opam pin add -k version ocaml-base-compiler 4.12.1
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.12.1/amd64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:alpine-3.23-opam-amd64
-	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.12 --packages=ocaml-base-compiler.4.12.1
-	RUN opam pin add -k version ocaml-base-compiler 4.12.1
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-ocurrent/opam-staging:alpine-3.23-ocaml-4.12-arm64, ocurrent/opam-staging:alpine-3.23-ocaml-4.12-amd64 -> ocaml/opam:alpine-3.23-ocaml-4.12
-ocurrent/opam-staging:alpine-3.23-ocaml-4.12-arm64, ocurrent/opam-staging:alpine-3.23-ocaml-4.12-amd64 -> ocaml/opam:alpine-ocaml-4.12
-4.12.1+afl/arm64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:alpine-3.23-opam-arm64
-	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.12 --packages=ocaml-variants.4.12.1+options,ocaml-options-only-afl
-	RUN opam pin add -k version ocaml-variants 4.12.1+options
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.12.1+afl/amd64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:alpine-3.23-opam-amd64
-	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.12 --packages=ocaml-variants.4.12.1+options,ocaml-options-only-afl
-	RUN opam pin add -k version ocaml-variants 4.12.1+options
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-ocurrent/opam-staging:alpine-3.23-ocaml-4.12-afl-arm64, ocurrent/opam-staging:alpine-3.23-ocaml-4.12-afl-amd64 -> ocaml/opam:alpine-3.23-ocaml-4.12-afl
-ocurrent/opam-staging:alpine-3.23-ocaml-4.12-afl-arm64, ocurrent/opam-staging:alpine-3.23-ocaml-4.12-afl-amd64 -> ocaml/opam:alpine-ocaml-4.12-afl
-4.12.1+flambda/arm64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:alpine-3.23-opam-arm64
-	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.12 --packages=ocaml-variants.4.12.1+options,ocaml-options-only-flambda
-	RUN opam pin add -k version ocaml-variants 4.12.1+options
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.12.1+flambda/amd64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:alpine-3.23-opam-amd64
-	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.12 --packages=ocaml-variants.4.12.1+options,ocaml-options-only-flambda
-	RUN opam pin add -k version ocaml-variants 4.12.1+options
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-ocurrent/opam-staging:alpine-3.23-ocaml-4.12-flambda-arm64, ocurrent/opam-staging:alpine-3.23-ocaml-4.12-flambda-amd64 -> ocaml/opam:alpine-3.23-ocaml-4.12-flambda
-ocurrent/opam-staging:alpine-3.23-ocaml-4.12-flambda-arm64, ocurrent/opam-staging:alpine-3.23-ocaml-4.12-flambda-amd64 -> ocaml/opam:alpine-ocaml-4.12-flambda
-4.12.1+flambda+fp/amd64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:alpine-3.23-opam-amd64
-	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.12 --packages=ocaml-variants.4.12.1+options,ocaml-options-only-flambda-fp
-	RUN opam pin add -k version ocaml-variants 4.12.1+options
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-ocurrent/opam-staging:alpine-3.23-ocaml-4.12-flambda-fp-amd64 -> ocaml/opam:alpine-3.23-ocaml-4.12-flambda-fp
-ocurrent/opam-staging:alpine-3.23-ocaml-4.12-flambda-fp-amd64 -> ocaml/opam:alpine-ocaml-4.12-flambda-fp
-4.12.1+fp/amd64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:alpine-3.23-opam-amd64
-	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.12 --packages=ocaml-variants.4.12.1+options,ocaml-options-only-fp
-	RUN opam pin add -k version ocaml-variants 4.12.1+options
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-ocurrent/opam-staging:alpine-3.23-ocaml-4.12-fp-amd64 -> ocaml/opam:alpine-3.23-ocaml-4.12-fp
-ocurrent/opam-staging:alpine-3.23-ocaml-4.12-fp-amd64 -> ocaml/opam:alpine-ocaml-4.12-fp
-4.12.1+nnp/arm64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:alpine-3.23-opam-arm64
-	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.12 --packages=ocaml-variants.4.12.1+options,ocaml-options-only-nnp
-	RUN opam pin add -k version ocaml-variants 4.12.1+options
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.12.1+nnp/amd64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:alpine-3.23-opam-amd64
-	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.12 --packages=ocaml-variants.4.12.1+options,ocaml-options-only-nnp
-	RUN opam pin add -k version ocaml-variants 4.12.1+options
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-ocurrent/opam-staging:alpine-3.23-ocaml-4.12-nnp-arm64, ocurrent/opam-staging:alpine-3.23-ocaml-4.12-nnp-amd64 -> ocaml/opam:alpine-3.23-ocaml-4.12-nnp
-ocurrent/opam-staging:alpine-3.23-ocaml-4.12-nnp-arm64, ocurrent/opam-staging:alpine-3.23-ocaml-4.12-nnp-amd64 -> ocaml/opam:alpine-ocaml-4.12-nnp
-4.12.1+nnpchecker/amd64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:alpine-3.23-opam-amd64
-	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.12 --packages=ocaml-variants.4.12.1+options,ocaml-options-only-nnpchecker
-	RUN opam pin add -k version ocaml-variants 4.12.1+options
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-ocurrent/opam-staging:alpine-3.23-ocaml-4.12-nnpchecker-amd64 -> ocaml/opam:alpine-3.23-ocaml-4.12-nnpchecker
-ocurrent/opam-staging:alpine-3.23-ocaml-4.12-nnpchecker-amd64 -> ocaml/opam:alpine-ocaml-4.12-nnpchecker
-4.12.1+no-flat-float-array/arm64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:alpine-3.23-opam-arm64
-	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.12 --packages=ocaml-variants.4.12.1+options,ocaml-options-only-no-flat-float-array
-	RUN opam pin add -k version ocaml-variants 4.12.1+options
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.12.1+no-flat-float-array/amd64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:alpine-3.23-opam-amd64
-	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.12 --packages=ocaml-variants.4.12.1+options,ocaml-options-only-no-flat-float-array
-	RUN opam pin add -k version ocaml-variants 4.12.1+options
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-ocurrent/opam-staging:alpine-3.23-ocaml-4.12-no-flat-float-array-arm64, ocurrent/opam-staging:alpine-3.23-ocaml-4.12-no-flat-float-array-amd64 -> ocaml/opam:alpine-3.23-ocaml-4.12-no-flat-float-array
-ocurrent/opam-staging:alpine-3.23-ocaml-4.12-no-flat-float-array-arm64, ocurrent/opam-staging:alpine-3.23-ocaml-4.12-no-flat-float-array-amd64 -> ocaml/opam:alpine-ocaml-4.12-no-flat-float-array
-4.13.1/arm64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:alpine-3.23-opam-arm64
-	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.13 --packages=ocaml-base-compiler.4.13.1
-	RUN opam pin add -k version ocaml-base-compiler 4.13.1
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.13.1/amd64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:alpine-3.23-opam-amd64
-	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.13 --packages=ocaml-base-compiler.4.13.1
-	RUN opam pin add -k version ocaml-base-compiler 4.13.1
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-ocurrent/opam-staging:alpine-3.23-ocaml-4.13-arm64, ocurrent/opam-staging:alpine-3.23-ocaml-4.13-amd64 -> ocaml/opam:alpine-3.23-ocaml-4.13
-ocurrent/opam-staging:alpine-3.23-ocaml-4.13-arm64, ocurrent/opam-staging:alpine-3.23-ocaml-4.13-amd64 -> ocaml/opam:alpine-ocaml-4.13
-4.13.1+afl/arm64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:alpine-3.23-opam-arm64
-	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.13 --packages=ocaml-variants.4.13.1+options,ocaml-options-only-afl
-	RUN opam pin add -k version ocaml-variants 4.13.1+options
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.13.1+afl/amd64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:alpine-3.23-opam-amd64
-	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.13 --packages=ocaml-variants.4.13.1+options,ocaml-options-only-afl
-	RUN opam pin add -k version ocaml-variants 4.13.1+options
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-ocurrent/opam-staging:alpine-3.23-ocaml-4.13-afl-arm64, ocurrent/opam-staging:alpine-3.23-ocaml-4.13-afl-amd64 -> ocaml/opam:alpine-3.23-ocaml-4.13-afl
-ocurrent/opam-staging:alpine-3.23-ocaml-4.13-afl-arm64, ocurrent/opam-staging:alpine-3.23-ocaml-4.13-afl-amd64 -> ocaml/opam:alpine-ocaml-4.13-afl
-4.13.1+flambda/arm64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:alpine-3.23-opam-arm64
-	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.13 --packages=ocaml-variants.4.13.1+options,ocaml-options-only-flambda
-	RUN opam pin add -k version ocaml-variants 4.13.1+options
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.13.1+flambda/amd64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:alpine-3.23-opam-amd64
-	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.13 --packages=ocaml-variants.4.13.1+options,ocaml-options-only-flambda
-	RUN opam pin add -k version ocaml-variants 4.13.1+options
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-ocurrent/opam-staging:alpine-3.23-ocaml-4.13-flambda-arm64, ocurrent/opam-staging:alpine-3.23-ocaml-4.13-flambda-amd64 -> ocaml/opam:alpine-3.23-ocaml-4.13-flambda
-ocurrent/opam-staging:alpine-3.23-ocaml-4.13-flambda-arm64, ocurrent/opam-staging:alpine-3.23-ocaml-4.13-flambda-amd64 -> ocaml/opam:alpine-ocaml-4.13-flambda
-4.13.1+flambda+fp/amd64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:alpine-3.23-opam-amd64
-	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.13 --packages=ocaml-variants.4.13.1+options,ocaml-options-only-flambda-fp
-	RUN opam pin add -k version ocaml-variants 4.13.1+options
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-ocurrent/opam-staging:alpine-3.23-ocaml-4.13-flambda-fp-amd64 -> ocaml/opam:alpine-3.23-ocaml-4.13-flambda-fp
-ocurrent/opam-staging:alpine-3.23-ocaml-4.13-flambda-fp-amd64 -> ocaml/opam:alpine-ocaml-4.13-flambda-fp
-4.13.1+fp/amd64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:alpine-3.23-opam-amd64
-	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.13 --packages=ocaml-variants.4.13.1+options,ocaml-options-only-fp
-	RUN opam pin add -k version ocaml-variants 4.13.1+options
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-ocurrent/opam-staging:alpine-3.23-ocaml-4.13-fp-amd64 -> ocaml/opam:alpine-3.23-ocaml-4.13-fp
-ocurrent/opam-staging:alpine-3.23-ocaml-4.13-fp-amd64 -> ocaml/opam:alpine-ocaml-4.13-fp
-4.13.1+nnp/arm64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:alpine-3.23-opam-arm64
-	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.13 --packages=ocaml-variants.4.13.1+options,ocaml-options-only-nnp
-	RUN opam pin add -k version ocaml-variants 4.13.1+options
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.13.1+nnp/amd64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:alpine-3.23-opam-amd64
-	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.13 --packages=ocaml-variants.4.13.1+options,ocaml-options-only-nnp
-	RUN opam pin add -k version ocaml-variants 4.13.1+options
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-ocurrent/opam-staging:alpine-3.23-ocaml-4.13-nnp-arm64, ocurrent/opam-staging:alpine-3.23-ocaml-4.13-nnp-amd64 -> ocaml/opam:alpine-3.23-ocaml-4.13-nnp
-ocurrent/opam-staging:alpine-3.23-ocaml-4.13-nnp-arm64, ocurrent/opam-staging:alpine-3.23-ocaml-4.13-nnp-amd64 -> ocaml/opam:alpine-ocaml-4.13-nnp
-4.13.1+nnpchecker/amd64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:alpine-3.23-opam-amd64
-	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.13 --packages=ocaml-variants.4.13.1+options,ocaml-options-only-nnpchecker
-	RUN opam pin add -k version ocaml-variants 4.13.1+options
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-ocurrent/opam-staging:alpine-3.23-ocaml-4.13-nnpchecker-amd64 -> ocaml/opam:alpine-3.23-ocaml-4.13-nnpchecker
-ocurrent/opam-staging:alpine-3.23-ocaml-4.13-nnpchecker-amd64 -> ocaml/opam:alpine-ocaml-4.13-nnpchecker
-4.13.1+no-flat-float-array/arm64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:alpine-3.23-opam-arm64
-	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.13 --packages=ocaml-variants.4.13.1+options,ocaml-options-only-no-flat-float-array
-	RUN opam pin add -k version ocaml-variants 4.13.1+options
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.13.1+no-flat-float-array/amd64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:alpine-3.23-opam-amd64
-	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.13 --packages=ocaml-variants.4.13.1+options,ocaml-options-only-no-flat-float-array
-	RUN opam pin add -k version ocaml-variants 4.13.1+options
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-ocurrent/opam-staging:alpine-3.23-ocaml-4.13-no-flat-float-array-arm64, ocurrent/opam-staging:alpine-3.23-ocaml-4.13-no-flat-float-array-amd64 -> ocaml/opam:alpine-3.23-ocaml-4.13-no-flat-float-array
-ocurrent/opam-staging:alpine-3.23-ocaml-4.13-no-flat-float-array-arm64, ocurrent/opam-staging:alpine-3.23-ocaml-4.13-no-flat-float-array-amd64 -> ocaml/opam:alpine-ocaml-4.13-no-flat-float-array
 4.14.3/arm64
 	# syntax=docker/dockerfile:1
 
@@ -1115,254 +547,6 @@ ocurrent/opam-staging:alpine-3.23-ocaml-4.14-nnpchecker-amd64 -> ocaml/opam:alpi
 
 ocurrent/opam-staging:alpine-3.23-ocaml-4.14-no-flat-float-array-arm64, ocurrent/opam-staging:alpine-3.23-ocaml-4.14-no-flat-float-array-amd64 -> ocaml/opam:alpine-3.23-ocaml-4.14-no-flat-float-array
 ocurrent/opam-staging:alpine-3.23-ocaml-4.14-no-flat-float-array-arm64, ocurrent/opam-staging:alpine-3.23-ocaml-4.14-no-flat-float-array-amd64 -> ocaml/opam:alpine-ocaml-4.14-no-flat-float-array
-5.0.0/arm64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:alpine-3.23-opam-arm64
-	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 5.0 --packages=ocaml-base-compiler.5.0.0
-	RUN opam pin add -k version ocaml-base-compiler 5.0.0
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-5.0.0/amd64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:alpine-3.23-opam-amd64
-	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 5.0 --packages=ocaml-base-compiler.5.0.0
-	RUN opam pin add -k version ocaml-base-compiler 5.0.0
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-ocurrent/opam-staging:alpine-3.23-ocaml-5.0-arm64, ocurrent/opam-staging:alpine-3.23-ocaml-5.0-amd64 -> ocaml/opam:alpine-3.23-ocaml-5.0
-ocurrent/opam-staging:alpine-3.23-ocaml-5.0-arm64, ocurrent/opam-staging:alpine-3.23-ocaml-5.0-amd64 -> ocaml/opam:alpine-ocaml-5.0
-5.0.0+afl/arm64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:alpine-3.23-opam-arm64
-	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 5.0 --packages=ocaml-variants.5.0.0+options,ocaml-options-only-afl
-	RUN opam pin add -k version ocaml-variants 5.0.0+options
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-5.0.0+afl/amd64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:alpine-3.23-opam-amd64
-	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 5.0 --packages=ocaml-variants.5.0.0+options,ocaml-options-only-afl
-	RUN opam pin add -k version ocaml-variants 5.0.0+options
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-ocurrent/opam-staging:alpine-3.23-ocaml-5.0-afl-arm64, ocurrent/opam-staging:alpine-3.23-ocaml-5.0-afl-amd64 -> ocaml/opam:alpine-3.23-ocaml-5.0-afl
-ocurrent/opam-staging:alpine-3.23-ocaml-5.0-afl-arm64, ocurrent/opam-staging:alpine-3.23-ocaml-5.0-afl-amd64 -> ocaml/opam:alpine-ocaml-5.0-afl
-5.0.0+flambda/arm64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:alpine-3.23-opam-arm64
-	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 5.0 --packages=ocaml-variants.5.0.0+options,ocaml-options-only-flambda
-	RUN opam pin add -k version ocaml-variants 5.0.0+options
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-5.0.0+flambda/amd64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:alpine-3.23-opam-amd64
-	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 5.0 --packages=ocaml-variants.5.0.0+options,ocaml-options-only-flambda
-	RUN opam pin add -k version ocaml-variants 5.0.0+options
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-ocurrent/opam-staging:alpine-3.23-ocaml-5.0-flambda-arm64, ocurrent/opam-staging:alpine-3.23-ocaml-5.0-flambda-amd64 -> ocaml/opam:alpine-3.23-ocaml-5.0-flambda
-ocurrent/opam-staging:alpine-3.23-ocaml-5.0-flambda-arm64, ocurrent/opam-staging:alpine-3.23-ocaml-5.0-flambda-amd64 -> ocaml/opam:alpine-ocaml-5.0-flambda
-5.0.0+no-flat-float-array/arm64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:alpine-3.23-opam-arm64
-	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 5.0 --packages=ocaml-variants.5.0.0+options,ocaml-options-only-no-flat-float-array
-	RUN opam pin add -k version ocaml-variants 5.0.0+options
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-5.0.0+no-flat-float-array/amd64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:alpine-3.23-opam-amd64
-	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 5.0 --packages=ocaml-variants.5.0.0+options,ocaml-options-only-no-flat-float-array
-	RUN opam pin add -k version ocaml-variants 5.0.0+options
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-ocurrent/opam-staging:alpine-3.23-ocaml-5.0-no-flat-float-array-arm64, ocurrent/opam-staging:alpine-3.23-ocaml-5.0-no-flat-float-array-amd64 -> ocaml/opam:alpine-3.23-ocaml-5.0-no-flat-float-array
-ocurrent/opam-staging:alpine-3.23-ocaml-5.0-no-flat-float-array-arm64, ocurrent/opam-staging:alpine-3.23-ocaml-5.0-no-flat-float-array-amd64 -> ocaml/opam:alpine-ocaml-5.0-no-flat-float-array
-5.1.1/arm64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:alpine-3.23-opam-arm64
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	USER root
-	RUN apk update && apk upgrade
-	RUN apk add zstd
-	USER opam
-	RUN opam switch create 5.1 --packages=ocaml-base-compiler.5.1.1
-	RUN opam pin add -k version ocaml-base-compiler 5.1.1
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-5.1.1/amd64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:alpine-3.23-opam-amd64
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	USER root
-	RUN apk update && apk upgrade
-	RUN apk add zstd
-	USER opam
-	RUN opam switch create 5.1 --packages=ocaml-base-compiler.5.1.1
-	RUN opam pin add -k version ocaml-base-compiler 5.1.1
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-ocurrent/opam-staging:alpine-3.23-ocaml-5.1-arm64, ocurrent/opam-staging:alpine-3.23-ocaml-5.1-amd64 -> ocaml/opam:alpine-3.23-ocaml-5.1
-ocurrent/opam-staging:alpine-3.23-ocaml-5.1-arm64, ocurrent/opam-staging:alpine-3.23-ocaml-5.1-amd64 -> ocaml/opam:alpine-ocaml-5.1
-5.1.1+afl/arm64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:alpine-3.23-opam-arm64
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	USER root
-	RUN apk update && apk upgrade
-	RUN apk add zstd
-	USER opam
-	RUN opam switch create 5.1 --packages=ocaml-variants.5.1.1+options,ocaml-options-only-afl
-	RUN opam pin add -k version ocaml-variants 5.1.1+options
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-5.1.1+afl/amd64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:alpine-3.23-opam-amd64
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	USER root
-	RUN apk update && apk upgrade
-	RUN apk add zstd
-	USER opam
-	RUN opam switch create 5.1 --packages=ocaml-variants.5.1.1+options,ocaml-options-only-afl
-	RUN opam pin add -k version ocaml-variants 5.1.1+options
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-ocurrent/opam-staging:alpine-3.23-ocaml-5.1-afl-arm64, ocurrent/opam-staging:alpine-3.23-ocaml-5.1-afl-amd64 -> ocaml/opam:alpine-3.23-ocaml-5.1-afl
-ocurrent/opam-staging:alpine-3.23-ocaml-5.1-afl-arm64, ocurrent/opam-staging:alpine-3.23-ocaml-5.1-afl-amd64 -> ocaml/opam:alpine-ocaml-5.1-afl
-5.1.1+flambda/arm64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:alpine-3.23-opam-arm64
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	USER root
-	RUN apk update && apk upgrade
-	RUN apk add zstd
-	USER opam
-	RUN opam switch create 5.1 --packages=ocaml-variants.5.1.1+options,ocaml-options-only-flambda
-	RUN opam pin add -k version ocaml-variants 5.1.1+options
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-5.1.1+flambda/amd64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:alpine-3.23-opam-amd64
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	USER root
-	RUN apk update && apk upgrade
-	RUN apk add zstd
-	USER opam
-	RUN opam switch create 5.1 --packages=ocaml-variants.5.1.1+options,ocaml-options-only-flambda
-	RUN opam pin add -k version ocaml-variants 5.1.1+options
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-ocurrent/opam-staging:alpine-3.23-ocaml-5.1-flambda-arm64, ocurrent/opam-staging:alpine-3.23-ocaml-5.1-flambda-amd64 -> ocaml/opam:alpine-3.23-ocaml-5.1-flambda
-ocurrent/opam-staging:alpine-3.23-ocaml-5.1-flambda-arm64, ocurrent/opam-staging:alpine-3.23-ocaml-5.1-flambda-amd64 -> ocaml/opam:alpine-ocaml-5.1-flambda
-5.1.1+no-flat-float-array/arm64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:alpine-3.23-opam-arm64
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	USER root
-	RUN apk update && apk upgrade
-	RUN apk add zstd
-	USER opam
-	RUN opam switch create 5.1 --packages=ocaml-variants.5.1.1+options,ocaml-options-only-no-flat-float-array
-	RUN opam pin add -k version ocaml-variants 5.1.1+options
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-5.1.1+no-flat-float-array/amd64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:alpine-3.23-opam-amd64
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	USER root
-	RUN apk update && apk upgrade
-	RUN apk add zstd
-	USER opam
-	RUN opam switch create 5.1 --packages=ocaml-variants.5.1.1+options,ocaml-options-only-no-flat-float-array
-	RUN opam pin add -k version ocaml-variants 5.1.1+options
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-ocurrent/opam-staging:alpine-3.23-ocaml-5.1-no-flat-float-array-arm64, ocurrent/opam-staging:alpine-3.23-ocaml-5.1-no-flat-float-array-amd64 -> ocaml/opam:alpine-3.23-ocaml-5.1-no-flat-float-array
-ocurrent/opam-staging:alpine-3.23-ocaml-5.1-no-flat-float-array-arm64, ocurrent/opam-staging:alpine-3.23-ocaml-5.1-no-flat-float-array-amd64 -> ocaml/opam:alpine-ocaml-5.1-no-flat-float-array
 5.2.1/arm64
 	# syntax=docker/dockerfile:1
 
@@ -2294,34 +1478,6 @@ ocurrent/opam-staging:archlinux-opam-amd64 -> ocaml/opam:archlinux-opam
 	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
 
 ocurrent/opam-staging:archlinux-ocaml-4.08-amd64 -> ocaml/opam:archlinux-ocaml-4.08
-4.09.1/amd64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:archlinux-opam-amd64
-	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.09 --packages=ocaml-base-compiler.4.09.1
-	RUN opam pin add -k version ocaml-base-compiler 4.09.1
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-ocurrent/opam-staging:archlinux-ocaml-4.09-amd64 -> ocaml/opam:archlinux-ocaml-4.09
-4.10.2/amd64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:archlinux-opam-amd64
-	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.10 --packages=ocaml-base-compiler.4.10.2
-	RUN opam pin add -k version ocaml-base-compiler 4.10.2
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-ocurrent/opam-staging:archlinux-ocaml-4.10-amd64 -> ocaml/opam:archlinux-ocaml-4.10
 4.11.2/amd64
 	# syntax=docker/dockerfile:1
 
@@ -2336,34 +1492,6 @@ ocurrent/opam-staging:archlinux-ocaml-4.10-amd64 -> ocaml/opam:archlinux-ocaml-4
 	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
 
 ocurrent/opam-staging:archlinux-ocaml-4.11-amd64 -> ocaml/opam:archlinux-ocaml-4.11
-4.12.1/amd64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:archlinux-opam-amd64
-	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.12 --packages=ocaml-base-compiler.4.12.1
-	RUN opam pin add -k version ocaml-base-compiler 4.12.1
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-ocurrent/opam-staging:archlinux-ocaml-4.12-amd64 -> ocaml/opam:archlinux-ocaml-4.12
-4.13.1/amd64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:archlinux-opam-amd64
-	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.13 --packages=ocaml-base-compiler.4.13.1
-	RUN opam pin add -k version ocaml-base-compiler 4.13.1
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-ocurrent/opam-staging:archlinux-ocaml-4.13-amd64 -> ocaml/opam:archlinux-ocaml-4.13
 4.14.3/amd64
 	# syntax=docker/dockerfile:1
 
@@ -2378,36 +1506,6 @@ ocurrent/opam-staging:archlinux-ocaml-4.13-amd64 -> ocaml/opam:archlinux-ocaml-4
 	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
 
 ocurrent/opam-staging:archlinux-ocaml-4.14-amd64 -> ocaml/opam:archlinux-ocaml-4.14
-5.0.0/amd64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:archlinux-opam-amd64
-	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 5.0 --packages=ocaml-base-compiler.5.0.0
-	RUN opam pin add -k version ocaml-base-compiler 5.0.0
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-ocurrent/opam-staging:archlinux-ocaml-5.0-amd64 -> ocaml/opam:archlinux-ocaml-5.0
-5.1.1/amd64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:archlinux-opam-amd64
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	USER root
-	RUN pacman -Syu --noconfirm zstd && yes | pacman -Scc
-	USER opam
-	RUN opam switch create 5.1 --packages=ocaml-base-compiler.5.1.1
-	RUN opam pin add -k version ocaml-base-compiler 5.1.1
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-ocurrent/opam-staging:archlinux-ocaml-5.1-amd64 -> ocaml/opam:archlinux-ocaml-5.1
 5.2.1/amd64
 	# syntax=docker/dockerfile:1
 
@@ -2608,32 +1706,6 @@ ocurrent/opam-staging:centos-9-opam-amd64 -> ocaml/opam:centos-9-opam
 	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
 
 ocurrent/opam-staging:centos-9-ocaml-4.08-amd64 -> ocaml/opam:centos-9-ocaml-4.08
-4.09.1/amd64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:centos-9-opam-amd64
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.09 --packages=ocaml-base-compiler.4.09.1
-	RUN opam pin add -k version ocaml-base-compiler 4.09.1
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-ocurrent/opam-staging:centos-9-ocaml-4.09-amd64 -> ocaml/opam:centos-9-ocaml-4.09
-4.10.2/amd64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:centos-9-opam-amd64
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.10 --packages=ocaml-base-compiler.4.10.2
-	RUN opam pin add -k version ocaml-base-compiler 4.10.2
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-ocurrent/opam-staging:centos-9-ocaml-4.10-amd64 -> ocaml/opam:centos-9-ocaml-4.10
 4.11.2/amd64
 	# syntax=docker/dockerfile:1
 
@@ -2647,32 +1719,6 @@ ocurrent/opam-staging:centos-9-ocaml-4.10-amd64 -> ocaml/opam:centos-9-ocaml-4.1
 	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
 
 ocurrent/opam-staging:centos-9-ocaml-4.11-amd64 -> ocaml/opam:centos-9-ocaml-4.11
-4.12.1/amd64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:centos-9-opam-amd64
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.12 --packages=ocaml-base-compiler.4.12.1
-	RUN opam pin add -k version ocaml-base-compiler 4.12.1
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-ocurrent/opam-staging:centos-9-ocaml-4.12-amd64 -> ocaml/opam:centos-9-ocaml-4.12
-4.13.1/amd64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:centos-9-opam-amd64
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.13 --packages=ocaml-base-compiler.4.13.1
-	RUN opam pin add -k version ocaml-base-compiler 4.13.1
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-ocurrent/opam-staging:centos-9-ocaml-4.13-amd64 -> ocaml/opam:centos-9-ocaml-4.13
 4.14.3/amd64
 	# syntax=docker/dockerfile:1
 
@@ -2686,35 +1732,6 @@ ocurrent/opam-staging:centos-9-ocaml-4.13-amd64 -> ocaml/opam:centos-9-ocaml-4.1
 	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
 
 ocurrent/opam-staging:centos-9-ocaml-4.14-amd64 -> ocaml/opam:centos-9-ocaml-4.14
-5.0.0/amd64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:centos-9-opam-amd64
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 5.0 --packages=ocaml-base-compiler.5.0.0
-	RUN opam pin add -k version ocaml-base-compiler 5.0.0
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-ocurrent/opam-staging:centos-9-ocaml-5.0-amd64 -> ocaml/opam:centos-9-ocaml-5.0
-5.1.1/amd64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:centos-9-opam-amd64
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	USER root
-	RUN yum install -y zstd && yum clean packages
-	USER opam
-	RUN opam switch create 5.1 --packages=ocaml-base-compiler.5.1.1
-	RUN opam pin add -k version ocaml-base-compiler 5.1.1
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-ocurrent/opam-staging:centos-9-ocaml-5.1-amd64 -> ocaml/opam:centos-9-ocaml-5.1
 5.2.1/amd64
 	# syntax=docker/dockerfile:1
 
@@ -2916,34 +1933,6 @@ ocurrent/opam-staging:centos-10-opam-amd64 -> ocaml/opam:centos-10-opam
 
 ocurrent/opam-staging:centos-10-ocaml-4.08-amd64 -> ocaml/opam:centos-10-ocaml-4.08
 ocurrent/opam-staging:centos-10-ocaml-4.08-amd64 -> ocaml/opam:centos-ocaml-4.08
-4.09.1/amd64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:centos-10-opam-amd64
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.09 --packages=ocaml-base-compiler.4.09.1
-	RUN opam pin add -k version ocaml-base-compiler 4.09.1
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-ocurrent/opam-staging:centos-10-ocaml-4.09-amd64 -> ocaml/opam:centos-10-ocaml-4.09
-ocurrent/opam-staging:centos-10-ocaml-4.09-amd64 -> ocaml/opam:centos-ocaml-4.09
-4.10.2/amd64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:centos-10-opam-amd64
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.10 --packages=ocaml-base-compiler.4.10.2
-	RUN opam pin add -k version ocaml-base-compiler 4.10.2
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-ocurrent/opam-staging:centos-10-ocaml-4.10-amd64 -> ocaml/opam:centos-10-ocaml-4.10
-ocurrent/opam-staging:centos-10-ocaml-4.10-amd64 -> ocaml/opam:centos-ocaml-4.10
 4.11.2/amd64
 	# syntax=docker/dockerfile:1
 
@@ -2958,34 +1947,6 @@ ocurrent/opam-staging:centos-10-ocaml-4.10-amd64 -> ocaml/opam:centos-ocaml-4.10
 
 ocurrent/opam-staging:centos-10-ocaml-4.11-amd64 -> ocaml/opam:centos-10-ocaml-4.11
 ocurrent/opam-staging:centos-10-ocaml-4.11-amd64 -> ocaml/opam:centos-ocaml-4.11
-4.12.1/amd64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:centos-10-opam-amd64
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.12 --packages=ocaml-base-compiler.4.12.1
-	RUN opam pin add -k version ocaml-base-compiler 4.12.1
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-ocurrent/opam-staging:centos-10-ocaml-4.12-amd64 -> ocaml/opam:centos-10-ocaml-4.12
-ocurrent/opam-staging:centos-10-ocaml-4.12-amd64 -> ocaml/opam:centos-ocaml-4.12
-4.13.1/amd64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:centos-10-opam-amd64
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.13 --packages=ocaml-base-compiler.4.13.1
-	RUN opam pin add -k version ocaml-base-compiler 4.13.1
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-ocurrent/opam-staging:centos-10-ocaml-4.13-amd64 -> ocaml/opam:centos-10-ocaml-4.13
-ocurrent/opam-staging:centos-10-ocaml-4.13-amd64 -> ocaml/opam:centos-ocaml-4.13
 4.14.3/amd64
 	# syntax=docker/dockerfile:1
 
@@ -3000,37 +1961,6 @@ ocurrent/opam-staging:centos-10-ocaml-4.13-amd64 -> ocaml/opam:centos-ocaml-4.13
 
 ocurrent/opam-staging:centos-10-ocaml-4.14-amd64 -> ocaml/opam:centos-10-ocaml-4.14
 ocurrent/opam-staging:centos-10-ocaml-4.14-amd64 -> ocaml/opam:centos-ocaml-4.14
-5.0.0/amd64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:centos-10-opam-amd64
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 5.0 --packages=ocaml-base-compiler.5.0.0
-	RUN opam pin add -k version ocaml-base-compiler 5.0.0
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-ocurrent/opam-staging:centos-10-ocaml-5.0-amd64 -> ocaml/opam:centos-10-ocaml-5.0
-ocurrent/opam-staging:centos-10-ocaml-5.0-amd64 -> ocaml/opam:centos-ocaml-5.0
-5.1.1/amd64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:centos-10-opam-amd64
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	USER root
-	RUN yum install -y zstd && yum clean packages
-	USER opam
-	RUN opam switch create 5.1 --packages=ocaml-base-compiler.5.1.1
-	RUN opam pin add -k version ocaml-base-compiler 5.1.1
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-ocurrent/opam-staging:centos-10-ocaml-5.1-amd64 -> ocaml/opam:centos-10-ocaml-5.1
-ocurrent/opam-staging:centos-10-ocaml-5.1-amd64 -> ocaml/opam:centos-ocaml-5.1
 5.2.1/amd64
 	# syntax=docker/dockerfile:1
 
@@ -3731,156 +2661,6 @@ ocurrent/opam-staging:debian-12-opam-s390x, ocurrent/opam-staging:debian-12-opam
 	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
 
 ocurrent/opam-staging:debian-12-ocaml-4.08-s390x, ocurrent/opam-staging:debian-12-ocaml-4.08-ppc64le, ocurrent/opam-staging:debian-12-ocaml-4.08-arm32v7, ocurrent/opam-staging:debian-12-ocaml-4.08-arm64, ocurrent/opam-staging:debian-12-ocaml-4.08-amd64, ocurrent/opam-staging:debian-12-ocaml-4.08-i386 -> ocaml/opam:debian-12-ocaml-4.08
-4.09.1/s390x
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-12-opam-s390x
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.09 --packages=ocaml-base-compiler.4.09.1
-	RUN opam pin add -k version ocaml-base-compiler 4.09.1
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.09.1/ppc64le
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-12-opam-ppc64le
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.09 --packages=ocaml-base-compiler.4.09.1
-	RUN opam pin add -k version ocaml-base-compiler 4.09.1
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.09.1/arm32v7
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-12-opam-arm32v7
-	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.09 --packages=ocaml-base-compiler.4.09.1
-	RUN opam pin add -k version ocaml-base-compiler 4.09.1
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "/usr/bin/linux32", "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.09.1/arm64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-12-opam-arm64
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.09 --packages=ocaml-base-compiler.4.09.1
-	RUN opam pin add -k version ocaml-base-compiler 4.09.1
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.09.1/amd64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-12-opam-amd64
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.09 --packages=ocaml-base-compiler.4.09.1
-	RUN opam pin add -k version ocaml-base-compiler 4.09.1
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.09.1/i386
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-12-opam-i386
-	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.09 --packages=ocaml-base-compiler.4.09.1
-	RUN opam pin add -k version ocaml-base-compiler 4.09.1
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "/usr/bin/linux32", "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-ocurrent/opam-staging:debian-12-ocaml-4.09-s390x, ocurrent/opam-staging:debian-12-ocaml-4.09-ppc64le, ocurrent/opam-staging:debian-12-ocaml-4.09-arm32v7, ocurrent/opam-staging:debian-12-ocaml-4.09-arm64, ocurrent/opam-staging:debian-12-ocaml-4.09-amd64, ocurrent/opam-staging:debian-12-ocaml-4.09-i386 -> ocaml/opam:debian-12-ocaml-4.09
-4.10.2/s390x
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-12-opam-s390x
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.10 --packages=ocaml-base-compiler.4.10.2
-	RUN opam pin add -k version ocaml-base-compiler 4.10.2
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.10.2/ppc64le
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-12-opam-ppc64le
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.10 --packages=ocaml-base-compiler.4.10.2
-	RUN opam pin add -k version ocaml-base-compiler 4.10.2
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.10.2/arm32v7
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-12-opam-arm32v7
-	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.10 --packages=ocaml-base-compiler.4.10.2
-	RUN opam pin add -k version ocaml-base-compiler 4.10.2
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "/usr/bin/linux32", "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.10.2/arm64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-12-opam-arm64
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.10 --packages=ocaml-base-compiler.4.10.2
-	RUN opam pin add -k version ocaml-base-compiler 4.10.2
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.10.2/amd64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-12-opam-amd64
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.10 --packages=ocaml-base-compiler.4.10.2
-	RUN opam pin add -k version ocaml-base-compiler 4.10.2
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.10.2/i386
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-12-opam-i386
-	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.10 --packages=ocaml-base-compiler.4.10.2
-	RUN opam pin add -k version ocaml-base-compiler 4.10.2
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "/usr/bin/linux32", "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-ocurrent/opam-staging:debian-12-ocaml-4.10-s390x, ocurrent/opam-staging:debian-12-ocaml-4.10-ppc64le, ocurrent/opam-staging:debian-12-ocaml-4.10-arm32v7, ocurrent/opam-staging:debian-12-ocaml-4.10-arm64, ocurrent/opam-staging:debian-12-ocaml-4.10-amd64, ocurrent/opam-staging:debian-12-ocaml-4.10-i386 -> ocaml/opam:debian-12-ocaml-4.10
 4.11.2/s390x
 	# syntax=docker/dockerfile:1
 
@@ -3956,156 +2736,6 @@ ocurrent/opam-staging:debian-12-ocaml-4.10-s390x, ocurrent/opam-staging:debian-1
 	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
 
 ocurrent/opam-staging:debian-12-ocaml-4.11-s390x, ocurrent/opam-staging:debian-12-ocaml-4.11-ppc64le, ocurrent/opam-staging:debian-12-ocaml-4.11-arm32v7, ocurrent/opam-staging:debian-12-ocaml-4.11-arm64, ocurrent/opam-staging:debian-12-ocaml-4.11-amd64, ocurrent/opam-staging:debian-12-ocaml-4.11-i386 -> ocaml/opam:debian-12-ocaml-4.11
-4.12.1/s390x
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-12-opam-s390x
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.12 --packages=ocaml-base-compiler.4.12.1
-	RUN opam pin add -k version ocaml-base-compiler 4.12.1
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.12.1/ppc64le
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-12-opam-ppc64le
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.12 --packages=ocaml-base-compiler.4.12.1
-	RUN opam pin add -k version ocaml-base-compiler 4.12.1
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.12.1/arm32v7
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-12-opam-arm32v7
-	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.12 --packages=ocaml-base-compiler.4.12.1
-	RUN opam pin add -k version ocaml-base-compiler 4.12.1
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "/usr/bin/linux32", "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.12.1/arm64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-12-opam-arm64
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.12 --packages=ocaml-base-compiler.4.12.1
-	RUN opam pin add -k version ocaml-base-compiler 4.12.1
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.12.1/amd64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-12-opam-amd64
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.12 --packages=ocaml-base-compiler.4.12.1
-	RUN opam pin add -k version ocaml-base-compiler 4.12.1
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.12.1/i386
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-12-opam-i386
-	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.12 --packages=ocaml-base-compiler.4.12.1
-	RUN opam pin add -k version ocaml-base-compiler 4.12.1
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "/usr/bin/linux32", "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-ocurrent/opam-staging:debian-12-ocaml-4.12-s390x, ocurrent/opam-staging:debian-12-ocaml-4.12-ppc64le, ocurrent/opam-staging:debian-12-ocaml-4.12-arm32v7, ocurrent/opam-staging:debian-12-ocaml-4.12-arm64, ocurrent/opam-staging:debian-12-ocaml-4.12-amd64, ocurrent/opam-staging:debian-12-ocaml-4.12-i386 -> ocaml/opam:debian-12-ocaml-4.12
-4.13.1/s390x
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-12-opam-s390x
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.13 --packages=ocaml-base-compiler.4.13.1
-	RUN opam pin add -k version ocaml-base-compiler 4.13.1
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.13.1/ppc64le
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-12-opam-ppc64le
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.13 --packages=ocaml-base-compiler.4.13.1
-	RUN opam pin add -k version ocaml-base-compiler 4.13.1
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.13.1/arm32v7
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-12-opam-arm32v7
-	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.13 --packages=ocaml-base-compiler.4.13.1
-	RUN opam pin add -k version ocaml-base-compiler 4.13.1
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "/usr/bin/linux32", "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.13.1/arm64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-12-opam-arm64
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.13 --packages=ocaml-base-compiler.4.13.1
-	RUN opam pin add -k version ocaml-base-compiler 4.13.1
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.13.1/amd64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-12-opam-amd64
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.13 --packages=ocaml-base-compiler.4.13.1
-	RUN opam pin add -k version ocaml-base-compiler 4.13.1
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.13.1/i386
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-12-opam-i386
-	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.13 --packages=ocaml-base-compiler.4.13.1
-	RUN opam pin add -k version ocaml-base-compiler 4.13.1
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "/usr/bin/linux32", "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-ocurrent/opam-staging:debian-12-ocaml-4.13-s390x, ocurrent/opam-staging:debian-12-ocaml-4.13-ppc64le, ocurrent/opam-staging:debian-12-ocaml-4.13-arm32v7, ocurrent/opam-staging:debian-12-ocaml-4.13-arm64, ocurrent/opam-staging:debian-12-ocaml-4.13-amd64, ocurrent/opam-staging:debian-12-ocaml-4.13-i386 -> ocaml/opam:debian-12-ocaml-4.13
 4.14.3/s390x
 	# syntax=docker/dockerfile:1
 
@@ -4181,186 +2811,6 @@ ocurrent/opam-staging:debian-12-ocaml-4.13-s390x, ocurrent/opam-staging:debian-1
 	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
 
 ocurrent/opam-staging:debian-12-ocaml-4.14-s390x, ocurrent/opam-staging:debian-12-ocaml-4.14-ppc64le, ocurrent/opam-staging:debian-12-ocaml-4.14-arm32v7, ocurrent/opam-staging:debian-12-ocaml-4.14-arm64, ocurrent/opam-staging:debian-12-ocaml-4.14-amd64, ocurrent/opam-staging:debian-12-ocaml-4.14-i386 -> ocaml/opam:debian-12-ocaml-4.14
-5.0.0/s390x
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-12-opam-s390x
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 5.0 --packages=ocaml-base-compiler.5.0.0
-	RUN opam pin add -k version ocaml-base-compiler 5.0.0
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-5.0.0/ppc64le
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-12-opam-ppc64le
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 5.0 --packages=ocaml-base-compiler.5.0.0
-	RUN opam pin add -k version ocaml-base-compiler 5.0.0
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-5.0.0/arm32v7
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-12-opam-arm32v7
-	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 5.0 --packages=ocaml-base-compiler.5.0.0
-	RUN opam pin add -k version ocaml-base-compiler 5.0.0
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "/usr/bin/linux32", "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-5.0.0/arm64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-12-opam-arm64
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 5.0 --packages=ocaml-base-compiler.5.0.0
-	RUN opam pin add -k version ocaml-base-compiler 5.0.0
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-5.0.0/amd64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-12-opam-amd64
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 5.0 --packages=ocaml-base-compiler.5.0.0
-	RUN opam pin add -k version ocaml-base-compiler 5.0.0
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-5.0.0/i386
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-12-opam-i386
-	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 5.0 --packages=ocaml-base-compiler.5.0.0
-	RUN opam pin add -k version ocaml-base-compiler 5.0.0
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "/usr/bin/linux32", "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-ocurrent/opam-staging:debian-12-ocaml-5.0-s390x, ocurrent/opam-staging:debian-12-ocaml-5.0-ppc64le, ocurrent/opam-staging:debian-12-ocaml-5.0-arm32v7, ocurrent/opam-staging:debian-12-ocaml-5.0-arm64, ocurrent/opam-staging:debian-12-ocaml-5.0-amd64, ocurrent/opam-staging:debian-12-ocaml-5.0-i386 -> ocaml/opam:debian-12-ocaml-5.0
-5.1.1/s390x
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-12-opam-s390x
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	USER root
-	RUN apt-get -y update
-	RUN DEBIAN_FRONTEND=noninteractive apt-get -y upgrade
-	RUN DEBIAN_FRONTEND=noninteractive apt-get -y install libzstd-dev
-	USER opam
-	RUN opam switch create 5.1 --packages=ocaml-base-compiler.5.1.1
-	RUN opam pin add -k version ocaml-base-compiler 5.1.1
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-5.1.1/ppc64le
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-12-opam-ppc64le
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	USER root
-	RUN apt-get -y update
-	RUN DEBIAN_FRONTEND=noninteractive apt-get -y upgrade
-	RUN DEBIAN_FRONTEND=noninteractive apt-get -y install libzstd-dev
-	USER opam
-	RUN opam switch create 5.1 --packages=ocaml-base-compiler.5.1.1
-	RUN opam pin add -k version ocaml-base-compiler 5.1.1
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-5.1.1/arm32v7
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-12-opam-arm32v7
-	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	USER root
-	RUN apt-get -y update
-	RUN DEBIAN_FRONTEND=noninteractive apt-get -y upgrade
-	RUN DEBIAN_FRONTEND=noninteractive apt-get -y install libzstd-dev
-	USER opam
-	RUN opam switch create 5.1 --packages=ocaml-base-compiler.5.1.1
-	RUN opam pin add -k version ocaml-base-compiler 5.1.1
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "/usr/bin/linux32", "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-5.1.1/arm64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-12-opam-arm64
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	USER root
-	RUN apt-get -y update
-	RUN DEBIAN_FRONTEND=noninteractive apt-get -y upgrade
-	RUN DEBIAN_FRONTEND=noninteractive apt-get -y install libzstd-dev
-	USER opam
-	RUN opam switch create 5.1 --packages=ocaml-base-compiler.5.1.1
-	RUN opam pin add -k version ocaml-base-compiler 5.1.1
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-5.1.1/amd64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-12-opam-amd64
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	USER root
-	RUN apt-get -y update
-	RUN DEBIAN_FRONTEND=noninteractive apt-get -y upgrade
-	RUN DEBIAN_FRONTEND=noninteractive apt-get -y install libzstd-dev
-	USER opam
-	RUN opam switch create 5.1 --packages=ocaml-base-compiler.5.1.1
-	RUN opam pin add -k version ocaml-base-compiler 5.1.1
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-5.1.1/i386
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-12-opam-i386
-	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	USER root
-	RUN apt-get -y update
-	RUN DEBIAN_FRONTEND=noninteractive apt-get -y upgrade
-	RUN DEBIAN_FRONTEND=noninteractive apt-get -y install libzstd-dev
-	USER opam
-	RUN opam switch create 5.1 --packages=ocaml-base-compiler.5.1.1
-	RUN opam pin add -k version ocaml-base-compiler 5.1.1
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "/usr/bin/linux32", "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-ocurrent/opam-staging:debian-12-ocaml-5.1-s390x, ocurrent/opam-staging:debian-12-ocaml-5.1-ppc64le, ocurrent/opam-staging:debian-12-ocaml-5.1-arm32v7, ocurrent/opam-staging:debian-12-ocaml-5.1-arm64, ocurrent/opam-staging:debian-12-ocaml-5.1-amd64, ocurrent/opam-staging:debian-12-ocaml-5.1-i386 -> ocaml/opam:debian-12-ocaml-5.1
 5.2.1/s390x
 	# syntax=docker/dockerfile:1
 
@@ -5855,490 +4305,6 @@ ocurrent/opam-staging:debian-13-ocaml-4.08-flambda-s390x, ocurrent/opam-staging:
 
 ocurrent/opam-staging:debian-13-ocaml-4.08-fp-amd64 -> ocaml/opam:debian-13-ocaml-4.08-fp
 ocurrent/opam-staging:debian-13-ocaml-4.08-fp-amd64 -> ocaml/opam:debian-ocaml-4.08-fp
-4.09.1/s390x
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-13-opam-s390x
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.09 --packages=ocaml-base-compiler.4.09.1
-	RUN opam pin add -k version ocaml-base-compiler 4.09.1
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.09.1/ppc64le
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-13-opam-ppc64le
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.09 --packages=ocaml-base-compiler.4.09.1
-	RUN opam pin add -k version ocaml-base-compiler 4.09.1
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.09.1/arm32v7
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-13-opam-arm32v7
-	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.09 --packages=ocaml-base-compiler.4.09.1
-	RUN opam pin add -k version ocaml-base-compiler 4.09.1
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "/usr/bin/linux32", "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.09.1/arm64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-13-opam-arm64
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.09 --packages=ocaml-base-compiler.4.09.1
-	RUN opam pin add -k version ocaml-base-compiler 4.09.1
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.09.1/amd64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-13-opam-amd64
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.09 --packages=ocaml-base-compiler.4.09.1
-	RUN opam pin add -k version ocaml-base-compiler 4.09.1
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.09.1/i386
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-13-opam-i386
-	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.09 --packages=ocaml-base-compiler.4.09.1
-	RUN opam pin add -k version ocaml-base-compiler 4.09.1
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "/usr/bin/linux32", "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-ocurrent/opam-staging:debian-13-ocaml-4.09-s390x, ocurrent/opam-staging:debian-13-ocaml-4.09-ppc64le, ocurrent/opam-staging:debian-13-ocaml-4.09-arm32v7, ocurrent/opam-staging:debian-13-ocaml-4.09-arm64, ocurrent/opam-staging:debian-13-ocaml-4.09-amd64, ocurrent/opam-staging:debian-13-ocaml-4.09-i386 -> ocaml/opam:debian-13-ocaml-4.09
-ocurrent/opam-staging:debian-13-ocaml-4.09-s390x, ocurrent/opam-staging:debian-13-ocaml-4.09-ppc64le, ocurrent/opam-staging:debian-13-ocaml-4.09-arm32v7, ocurrent/opam-staging:debian-13-ocaml-4.09-arm64, ocurrent/opam-staging:debian-13-ocaml-4.09-amd64, ocurrent/opam-staging:debian-13-ocaml-4.09-i386 -> ocaml/opam:debian-ocaml-4.09
-4.09.1+afl/s390x
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-13-opam-s390x
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.09 --packages=ocaml-variants.4.09.1+afl
-	RUN opam pin add -k version ocaml-variants 4.09.1+afl
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.09.1+afl/ppc64le
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-13-opam-ppc64le
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.09 --packages=ocaml-variants.4.09.1+afl
-	RUN opam pin add -k version ocaml-variants 4.09.1+afl
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.09.1+afl/arm32v7
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-13-opam-arm32v7
-	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.09 --packages=ocaml-variants.4.09.1+afl
-	RUN opam pin add -k version ocaml-variants 4.09.1+afl
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "/usr/bin/linux32", "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.09.1+afl/arm64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-13-opam-arm64
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.09 --packages=ocaml-variants.4.09.1+afl
-	RUN opam pin add -k version ocaml-variants 4.09.1+afl
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.09.1+afl/amd64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-13-opam-amd64
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.09 --packages=ocaml-variants.4.09.1+afl
-	RUN opam pin add -k version ocaml-variants 4.09.1+afl
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.09.1+afl/i386
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-13-opam-i386
-	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.09 --packages=ocaml-variants.4.09.1+afl
-	RUN opam pin add -k version ocaml-variants 4.09.1+afl
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "/usr/bin/linux32", "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-ocurrent/opam-staging:debian-13-ocaml-4.09-afl-s390x, ocurrent/opam-staging:debian-13-ocaml-4.09-afl-ppc64le, ocurrent/opam-staging:debian-13-ocaml-4.09-afl-arm32v7, ocurrent/opam-staging:debian-13-ocaml-4.09-afl-arm64, ocurrent/opam-staging:debian-13-ocaml-4.09-afl-amd64, ocurrent/opam-staging:debian-13-ocaml-4.09-afl-i386 -> ocaml/opam:debian-13-ocaml-4.09-afl
-ocurrent/opam-staging:debian-13-ocaml-4.09-afl-s390x, ocurrent/opam-staging:debian-13-ocaml-4.09-afl-ppc64le, ocurrent/opam-staging:debian-13-ocaml-4.09-afl-arm32v7, ocurrent/opam-staging:debian-13-ocaml-4.09-afl-arm64, ocurrent/opam-staging:debian-13-ocaml-4.09-afl-amd64, ocurrent/opam-staging:debian-13-ocaml-4.09-afl-i386 -> ocaml/opam:debian-ocaml-4.09-afl
-4.09.1+flambda/s390x
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-13-opam-s390x
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.09 --packages=ocaml-variants.4.09.1+flambda
-	RUN opam pin add -k version ocaml-variants 4.09.1+flambda
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.09.1+flambda/ppc64le
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-13-opam-ppc64le
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.09 --packages=ocaml-variants.4.09.1+flambda
-	RUN opam pin add -k version ocaml-variants 4.09.1+flambda
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.09.1+flambda/arm32v7
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-13-opam-arm32v7
-	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.09 --packages=ocaml-variants.4.09.1+flambda
-	RUN opam pin add -k version ocaml-variants 4.09.1+flambda
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "/usr/bin/linux32", "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.09.1+flambda/arm64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-13-opam-arm64
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.09 --packages=ocaml-variants.4.09.1+flambda
-	RUN opam pin add -k version ocaml-variants 4.09.1+flambda
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.09.1+flambda/amd64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-13-opam-amd64
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.09 --packages=ocaml-variants.4.09.1+flambda
-	RUN opam pin add -k version ocaml-variants 4.09.1+flambda
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.09.1+flambda/i386
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-13-opam-i386
-	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.09 --packages=ocaml-variants.4.09.1+flambda
-	RUN opam pin add -k version ocaml-variants 4.09.1+flambda
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "/usr/bin/linux32", "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-ocurrent/opam-staging:debian-13-ocaml-4.09-flambda-s390x, ocurrent/opam-staging:debian-13-ocaml-4.09-flambda-ppc64le, ocurrent/opam-staging:debian-13-ocaml-4.09-flambda-arm32v7, ocurrent/opam-staging:debian-13-ocaml-4.09-flambda-arm64, ocurrent/opam-staging:debian-13-ocaml-4.09-flambda-amd64, ocurrent/opam-staging:debian-13-ocaml-4.09-flambda-i386 -> ocaml/opam:debian-13-ocaml-4.09-flambda
-ocurrent/opam-staging:debian-13-ocaml-4.09-flambda-s390x, ocurrent/opam-staging:debian-13-ocaml-4.09-flambda-ppc64le, ocurrent/opam-staging:debian-13-ocaml-4.09-flambda-arm32v7, ocurrent/opam-staging:debian-13-ocaml-4.09-flambda-arm64, ocurrent/opam-staging:debian-13-ocaml-4.09-flambda-amd64, ocurrent/opam-staging:debian-13-ocaml-4.09-flambda-i386 -> ocaml/opam:debian-ocaml-4.09-flambda
-4.09.1+fp/amd64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-13-opam-amd64
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.09 --packages=ocaml-variants.4.09.1+fp
-	RUN opam pin add -k version ocaml-variants 4.09.1+fp
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-ocurrent/opam-staging:debian-13-ocaml-4.09-fp-amd64 -> ocaml/opam:debian-13-ocaml-4.09-fp
-ocurrent/opam-staging:debian-13-ocaml-4.09-fp-amd64 -> ocaml/opam:debian-ocaml-4.09-fp
-4.10.2/s390x
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-13-opam-s390x
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.10 --packages=ocaml-base-compiler.4.10.2
-	RUN opam pin add -k version ocaml-base-compiler 4.10.2
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.10.2/ppc64le
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-13-opam-ppc64le
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.10 --packages=ocaml-base-compiler.4.10.2
-	RUN opam pin add -k version ocaml-base-compiler 4.10.2
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.10.2/arm32v7
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-13-opam-arm32v7
-	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.10 --packages=ocaml-base-compiler.4.10.2
-	RUN opam pin add -k version ocaml-base-compiler 4.10.2
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "/usr/bin/linux32", "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.10.2/arm64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-13-opam-arm64
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.10 --packages=ocaml-base-compiler.4.10.2
-	RUN opam pin add -k version ocaml-base-compiler 4.10.2
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.10.2/amd64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-13-opam-amd64
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.10 --packages=ocaml-base-compiler.4.10.2
-	RUN opam pin add -k version ocaml-base-compiler 4.10.2
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.10.2/i386
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-13-opam-i386
-	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.10 --packages=ocaml-base-compiler.4.10.2
-	RUN opam pin add -k version ocaml-base-compiler 4.10.2
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "/usr/bin/linux32", "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-ocurrent/opam-staging:debian-13-ocaml-4.10-s390x, ocurrent/opam-staging:debian-13-ocaml-4.10-ppc64le, ocurrent/opam-staging:debian-13-ocaml-4.10-arm32v7, ocurrent/opam-staging:debian-13-ocaml-4.10-arm64, ocurrent/opam-staging:debian-13-ocaml-4.10-amd64, ocurrent/opam-staging:debian-13-ocaml-4.10-i386 -> ocaml/opam:debian-13-ocaml-4.10
-ocurrent/opam-staging:debian-13-ocaml-4.10-s390x, ocurrent/opam-staging:debian-13-ocaml-4.10-ppc64le, ocurrent/opam-staging:debian-13-ocaml-4.10-arm32v7, ocurrent/opam-staging:debian-13-ocaml-4.10-arm64, ocurrent/opam-staging:debian-13-ocaml-4.10-amd64, ocurrent/opam-staging:debian-13-ocaml-4.10-i386 -> ocaml/opam:debian-ocaml-4.10
-4.10.2+afl/s390x
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-13-opam-s390x
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.10 --packages=ocaml-variants.4.10.2+afl
-	RUN opam pin add -k version ocaml-variants 4.10.2+afl
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.10.2+afl/ppc64le
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-13-opam-ppc64le
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.10 --packages=ocaml-variants.4.10.2+afl
-	RUN opam pin add -k version ocaml-variants 4.10.2+afl
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.10.2+afl/arm32v7
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-13-opam-arm32v7
-	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.10 --packages=ocaml-variants.4.10.2+afl
-	RUN opam pin add -k version ocaml-variants 4.10.2+afl
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "/usr/bin/linux32", "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.10.2+afl/arm64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-13-opam-arm64
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.10 --packages=ocaml-variants.4.10.2+afl
-	RUN opam pin add -k version ocaml-variants 4.10.2+afl
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.10.2+afl/amd64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-13-opam-amd64
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.10 --packages=ocaml-variants.4.10.2+afl
-	RUN opam pin add -k version ocaml-variants 4.10.2+afl
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.10.2+afl/i386
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-13-opam-i386
-	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.10 --packages=ocaml-variants.4.10.2+afl
-	RUN opam pin add -k version ocaml-variants 4.10.2+afl
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "/usr/bin/linux32", "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-ocurrent/opam-staging:debian-13-ocaml-4.10-afl-s390x, ocurrent/opam-staging:debian-13-ocaml-4.10-afl-ppc64le, ocurrent/opam-staging:debian-13-ocaml-4.10-afl-arm32v7, ocurrent/opam-staging:debian-13-ocaml-4.10-afl-arm64, ocurrent/opam-staging:debian-13-ocaml-4.10-afl-amd64, ocurrent/opam-staging:debian-13-ocaml-4.10-afl-i386 -> ocaml/opam:debian-13-ocaml-4.10-afl
-ocurrent/opam-staging:debian-13-ocaml-4.10-afl-s390x, ocurrent/opam-staging:debian-13-ocaml-4.10-afl-ppc64le, ocurrent/opam-staging:debian-13-ocaml-4.10-afl-arm32v7, ocurrent/opam-staging:debian-13-ocaml-4.10-afl-arm64, ocurrent/opam-staging:debian-13-ocaml-4.10-afl-amd64, ocurrent/opam-staging:debian-13-ocaml-4.10-afl-i386 -> ocaml/opam:debian-ocaml-4.10-afl
-4.10.2+flambda/s390x
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-13-opam-s390x
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.10 --packages=ocaml-variants.4.10.2+flambda
-	RUN opam pin add -k version ocaml-variants 4.10.2+flambda
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.10.2+flambda/ppc64le
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-13-opam-ppc64le
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.10 --packages=ocaml-variants.4.10.2+flambda
-	RUN opam pin add -k version ocaml-variants 4.10.2+flambda
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.10.2+flambda/arm32v7
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-13-opam-arm32v7
-	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.10 --packages=ocaml-variants.4.10.2+flambda
-	RUN opam pin add -k version ocaml-variants 4.10.2+flambda
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "/usr/bin/linux32", "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.10.2+flambda/arm64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-13-opam-arm64
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.10 --packages=ocaml-variants.4.10.2+flambda
-	RUN opam pin add -k version ocaml-variants 4.10.2+flambda
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.10.2+flambda/amd64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-13-opam-amd64
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.10 --packages=ocaml-variants.4.10.2+flambda
-	RUN opam pin add -k version ocaml-variants 4.10.2+flambda
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.10.2+flambda/i386
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-13-opam-i386
-	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.10 --packages=ocaml-variants.4.10.2+flambda
-	RUN opam pin add -k version ocaml-variants 4.10.2+flambda
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "/usr/bin/linux32", "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-ocurrent/opam-staging:debian-13-ocaml-4.10-flambda-s390x, ocurrent/opam-staging:debian-13-ocaml-4.10-flambda-ppc64le, ocurrent/opam-staging:debian-13-ocaml-4.10-flambda-arm32v7, ocurrent/opam-staging:debian-13-ocaml-4.10-flambda-arm64, ocurrent/opam-staging:debian-13-ocaml-4.10-flambda-amd64, ocurrent/opam-staging:debian-13-ocaml-4.10-flambda-i386 -> ocaml/opam:debian-13-ocaml-4.10-flambda
-ocurrent/opam-staging:debian-13-ocaml-4.10-flambda-s390x, ocurrent/opam-staging:debian-13-ocaml-4.10-flambda-ppc64le, ocurrent/opam-staging:debian-13-ocaml-4.10-flambda-arm32v7, ocurrent/opam-staging:debian-13-ocaml-4.10-flambda-arm64, ocurrent/opam-staging:debian-13-ocaml-4.10-flambda-amd64, ocurrent/opam-staging:debian-13-ocaml-4.10-flambda-i386 -> ocaml/opam:debian-ocaml-4.10-flambda
-4.10.2+fp/amd64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-13-opam-amd64
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.10 --packages=ocaml-variants.4.10.2+fp
-	RUN opam pin add -k version ocaml-variants 4.10.2+fp
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-ocurrent/opam-staging:debian-13-ocaml-4.10-fp-amd64 -> ocaml/opam:debian-13-ocaml-4.10-fp
-ocurrent/opam-staging:debian-13-ocaml-4.10-fp-amd64 -> ocaml/opam:debian-ocaml-4.10-fp
 4.11.2/riscv64
 	# syntax=docker/dockerfile:1
 
@@ -6617,970 +4583,6 @@ ocurrent/opam-staging:debian-13-ocaml-4.11-flambda-riscv64, ocurrent/opam-stagin
 
 ocurrent/opam-staging:debian-13-ocaml-4.11-fp-amd64 -> ocaml/opam:debian-13-ocaml-4.11-fp
 ocurrent/opam-staging:debian-13-ocaml-4.11-fp-amd64 -> ocaml/opam:debian-ocaml-4.11-fp
-4.12.1/riscv64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-13-opam-riscv64
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.12 --packages=ocaml-base-compiler.4.12.1
-	RUN opam pin add -k version ocaml-base-compiler 4.12.1
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.12.1/s390x
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-13-opam-s390x
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.12 --packages=ocaml-base-compiler.4.12.1
-	RUN opam pin add -k version ocaml-base-compiler 4.12.1
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.12.1/ppc64le
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-13-opam-ppc64le
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.12 --packages=ocaml-base-compiler.4.12.1
-	RUN opam pin add -k version ocaml-base-compiler 4.12.1
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.12.1/arm32v7
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-13-opam-arm32v7
-	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.12 --packages=ocaml-base-compiler.4.12.1
-	RUN opam pin add -k version ocaml-base-compiler 4.12.1
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "/usr/bin/linux32", "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.12.1/arm64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-13-opam-arm64
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.12 --packages=ocaml-base-compiler.4.12.1
-	RUN opam pin add -k version ocaml-base-compiler 4.12.1
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.12.1/amd64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-13-opam-amd64
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.12 --packages=ocaml-base-compiler.4.12.1
-	RUN opam pin add -k version ocaml-base-compiler 4.12.1
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.12.1/i386
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-13-opam-i386
-	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.12 --packages=ocaml-base-compiler.4.12.1
-	RUN opam pin add -k version ocaml-base-compiler 4.12.1
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "/usr/bin/linux32", "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-ocurrent/opam-staging:debian-13-ocaml-4.12-riscv64, ocurrent/opam-staging:debian-13-ocaml-4.12-s390x, ocurrent/opam-staging:debian-13-ocaml-4.12-ppc64le, ocurrent/opam-staging:debian-13-ocaml-4.12-arm32v7, ocurrent/opam-staging:debian-13-ocaml-4.12-arm64, ocurrent/opam-staging:debian-13-ocaml-4.12-amd64, ocurrent/opam-staging:debian-13-ocaml-4.12-i386 -> ocaml/opam:debian-13-ocaml-4.12
-ocurrent/opam-staging:debian-13-ocaml-4.12-riscv64, ocurrent/opam-staging:debian-13-ocaml-4.12-s390x, ocurrent/opam-staging:debian-13-ocaml-4.12-ppc64le, ocurrent/opam-staging:debian-13-ocaml-4.12-arm32v7, ocurrent/opam-staging:debian-13-ocaml-4.12-arm64, ocurrent/opam-staging:debian-13-ocaml-4.12-amd64, ocurrent/opam-staging:debian-13-ocaml-4.12-i386 -> ocaml/opam:debian-ocaml-4.12
-4.12.1+afl/riscv64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-13-opam-riscv64
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.12 --packages=ocaml-variants.4.12.1+options,ocaml-options-only-afl
-	RUN opam pin add -k version ocaml-variants 4.12.1+options
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.12.1+afl/s390x
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-13-opam-s390x
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.12 --packages=ocaml-variants.4.12.1+options,ocaml-options-only-afl
-	RUN opam pin add -k version ocaml-variants 4.12.1+options
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.12.1+afl/ppc64le
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-13-opam-ppc64le
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.12 --packages=ocaml-variants.4.12.1+options,ocaml-options-only-afl
-	RUN opam pin add -k version ocaml-variants 4.12.1+options
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.12.1+afl/arm32v7
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-13-opam-arm32v7
-	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.12 --packages=ocaml-variants.4.12.1+options,ocaml-options-only-afl
-	RUN opam pin add -k version ocaml-variants 4.12.1+options
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "/usr/bin/linux32", "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.12.1+afl/arm64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-13-opam-arm64
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.12 --packages=ocaml-variants.4.12.1+options,ocaml-options-only-afl
-	RUN opam pin add -k version ocaml-variants 4.12.1+options
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.12.1+afl/amd64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-13-opam-amd64
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.12 --packages=ocaml-variants.4.12.1+options,ocaml-options-only-afl
-	RUN opam pin add -k version ocaml-variants 4.12.1+options
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.12.1+afl/i386
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-13-opam-i386
-	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.12 --packages=ocaml-variants.4.12.1+options,ocaml-options-only-afl
-	RUN opam pin add -k version ocaml-variants 4.12.1+options
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "/usr/bin/linux32", "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-ocurrent/opam-staging:debian-13-ocaml-4.12-afl-riscv64, ocurrent/opam-staging:debian-13-ocaml-4.12-afl-s390x, ocurrent/opam-staging:debian-13-ocaml-4.12-afl-ppc64le, ocurrent/opam-staging:debian-13-ocaml-4.12-afl-arm32v7, ocurrent/opam-staging:debian-13-ocaml-4.12-afl-arm64, ocurrent/opam-staging:debian-13-ocaml-4.12-afl-amd64, ocurrent/opam-staging:debian-13-ocaml-4.12-afl-i386 -> ocaml/opam:debian-13-ocaml-4.12-afl
-ocurrent/opam-staging:debian-13-ocaml-4.12-afl-riscv64, ocurrent/opam-staging:debian-13-ocaml-4.12-afl-s390x, ocurrent/opam-staging:debian-13-ocaml-4.12-afl-ppc64le, ocurrent/opam-staging:debian-13-ocaml-4.12-afl-arm32v7, ocurrent/opam-staging:debian-13-ocaml-4.12-afl-arm64, ocurrent/opam-staging:debian-13-ocaml-4.12-afl-amd64, ocurrent/opam-staging:debian-13-ocaml-4.12-afl-i386 -> ocaml/opam:debian-ocaml-4.12-afl
-4.12.1+flambda/riscv64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-13-opam-riscv64
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.12 --packages=ocaml-variants.4.12.1+options,ocaml-options-only-flambda
-	RUN opam pin add -k version ocaml-variants 4.12.1+options
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.12.1+flambda/s390x
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-13-opam-s390x
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.12 --packages=ocaml-variants.4.12.1+options,ocaml-options-only-flambda
-	RUN opam pin add -k version ocaml-variants 4.12.1+options
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.12.1+flambda/ppc64le
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-13-opam-ppc64le
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.12 --packages=ocaml-variants.4.12.1+options,ocaml-options-only-flambda
-	RUN opam pin add -k version ocaml-variants 4.12.1+options
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.12.1+flambda/arm32v7
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-13-opam-arm32v7
-	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.12 --packages=ocaml-variants.4.12.1+options,ocaml-options-only-flambda
-	RUN opam pin add -k version ocaml-variants 4.12.1+options
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "/usr/bin/linux32", "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.12.1+flambda/arm64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-13-opam-arm64
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.12 --packages=ocaml-variants.4.12.1+options,ocaml-options-only-flambda
-	RUN opam pin add -k version ocaml-variants 4.12.1+options
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.12.1+flambda/amd64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-13-opam-amd64
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.12 --packages=ocaml-variants.4.12.1+options,ocaml-options-only-flambda
-	RUN opam pin add -k version ocaml-variants 4.12.1+options
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.12.1+flambda/i386
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-13-opam-i386
-	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.12 --packages=ocaml-variants.4.12.1+options,ocaml-options-only-flambda
-	RUN opam pin add -k version ocaml-variants 4.12.1+options
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "/usr/bin/linux32", "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-ocurrent/opam-staging:debian-13-ocaml-4.12-flambda-riscv64, ocurrent/opam-staging:debian-13-ocaml-4.12-flambda-s390x, ocurrent/opam-staging:debian-13-ocaml-4.12-flambda-ppc64le, ocurrent/opam-staging:debian-13-ocaml-4.12-flambda-arm32v7, ocurrent/opam-staging:debian-13-ocaml-4.12-flambda-arm64, ocurrent/opam-staging:debian-13-ocaml-4.12-flambda-amd64, ocurrent/opam-staging:debian-13-ocaml-4.12-flambda-i386 -> ocaml/opam:debian-13-ocaml-4.12-flambda
-ocurrent/opam-staging:debian-13-ocaml-4.12-flambda-riscv64, ocurrent/opam-staging:debian-13-ocaml-4.12-flambda-s390x, ocurrent/opam-staging:debian-13-ocaml-4.12-flambda-ppc64le, ocurrent/opam-staging:debian-13-ocaml-4.12-flambda-arm32v7, ocurrent/opam-staging:debian-13-ocaml-4.12-flambda-arm64, ocurrent/opam-staging:debian-13-ocaml-4.12-flambda-amd64, ocurrent/opam-staging:debian-13-ocaml-4.12-flambda-i386 -> ocaml/opam:debian-ocaml-4.12-flambda
-4.12.1+flambda+fp/amd64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-13-opam-amd64
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.12 --packages=ocaml-variants.4.12.1+options,ocaml-options-only-flambda-fp
-	RUN opam pin add -k version ocaml-variants 4.12.1+options
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-ocurrent/opam-staging:debian-13-ocaml-4.12-flambda-fp-amd64 -> ocaml/opam:debian-13-ocaml-4.12-flambda-fp
-ocurrent/opam-staging:debian-13-ocaml-4.12-flambda-fp-amd64 -> ocaml/opam:debian-ocaml-4.12-flambda-fp
-4.12.1+fp/amd64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-13-opam-amd64
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.12 --packages=ocaml-variants.4.12.1+options,ocaml-options-only-fp
-	RUN opam pin add -k version ocaml-variants 4.12.1+options
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-ocurrent/opam-staging:debian-13-ocaml-4.12-fp-amd64 -> ocaml/opam:debian-13-ocaml-4.12-fp
-ocurrent/opam-staging:debian-13-ocaml-4.12-fp-amd64 -> ocaml/opam:debian-ocaml-4.12-fp
-4.12.1+nnp/riscv64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-13-opam-riscv64
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.12 --packages=ocaml-variants.4.12.1+options,ocaml-options-only-nnp
-	RUN opam pin add -k version ocaml-variants 4.12.1+options
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.12.1+nnp/s390x
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-13-opam-s390x
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.12 --packages=ocaml-variants.4.12.1+options,ocaml-options-only-nnp
-	RUN opam pin add -k version ocaml-variants 4.12.1+options
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.12.1+nnp/ppc64le
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-13-opam-ppc64le
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.12 --packages=ocaml-variants.4.12.1+options,ocaml-options-only-nnp
-	RUN opam pin add -k version ocaml-variants 4.12.1+options
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.12.1+nnp/arm32v7
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-13-opam-arm32v7
-	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.12 --packages=ocaml-variants.4.12.1+options,ocaml-options-only-nnp
-	RUN opam pin add -k version ocaml-variants 4.12.1+options
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "/usr/bin/linux32", "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.12.1+nnp/arm64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-13-opam-arm64
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.12 --packages=ocaml-variants.4.12.1+options,ocaml-options-only-nnp
-	RUN opam pin add -k version ocaml-variants 4.12.1+options
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.12.1+nnp/amd64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-13-opam-amd64
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.12 --packages=ocaml-variants.4.12.1+options,ocaml-options-only-nnp
-	RUN opam pin add -k version ocaml-variants 4.12.1+options
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.12.1+nnp/i386
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-13-opam-i386
-	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.12 --packages=ocaml-variants.4.12.1+options,ocaml-options-only-nnp
-	RUN opam pin add -k version ocaml-variants 4.12.1+options
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "/usr/bin/linux32", "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-ocurrent/opam-staging:debian-13-ocaml-4.12-nnp-riscv64, ocurrent/opam-staging:debian-13-ocaml-4.12-nnp-s390x, ocurrent/opam-staging:debian-13-ocaml-4.12-nnp-ppc64le, ocurrent/opam-staging:debian-13-ocaml-4.12-nnp-arm32v7, ocurrent/opam-staging:debian-13-ocaml-4.12-nnp-arm64, ocurrent/opam-staging:debian-13-ocaml-4.12-nnp-amd64, ocurrent/opam-staging:debian-13-ocaml-4.12-nnp-i386 -> ocaml/opam:debian-13-ocaml-4.12-nnp
-ocurrent/opam-staging:debian-13-ocaml-4.12-nnp-riscv64, ocurrent/opam-staging:debian-13-ocaml-4.12-nnp-s390x, ocurrent/opam-staging:debian-13-ocaml-4.12-nnp-ppc64le, ocurrent/opam-staging:debian-13-ocaml-4.12-nnp-arm32v7, ocurrent/opam-staging:debian-13-ocaml-4.12-nnp-arm64, ocurrent/opam-staging:debian-13-ocaml-4.12-nnp-amd64, ocurrent/opam-staging:debian-13-ocaml-4.12-nnp-i386 -> ocaml/opam:debian-ocaml-4.12-nnp
-4.12.1+nnpchecker/amd64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-13-opam-amd64
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.12 --packages=ocaml-variants.4.12.1+options,ocaml-options-only-nnpchecker
-	RUN opam pin add -k version ocaml-variants 4.12.1+options
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-ocurrent/opam-staging:debian-13-ocaml-4.12-nnpchecker-amd64 -> ocaml/opam:debian-13-ocaml-4.12-nnpchecker
-ocurrent/opam-staging:debian-13-ocaml-4.12-nnpchecker-amd64 -> ocaml/opam:debian-ocaml-4.12-nnpchecker
-4.12.1+no-flat-float-array/riscv64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-13-opam-riscv64
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.12 --packages=ocaml-variants.4.12.1+options,ocaml-options-only-no-flat-float-array
-	RUN opam pin add -k version ocaml-variants 4.12.1+options
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.12.1+no-flat-float-array/s390x
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-13-opam-s390x
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.12 --packages=ocaml-variants.4.12.1+options,ocaml-options-only-no-flat-float-array
-	RUN opam pin add -k version ocaml-variants 4.12.1+options
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.12.1+no-flat-float-array/ppc64le
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-13-opam-ppc64le
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.12 --packages=ocaml-variants.4.12.1+options,ocaml-options-only-no-flat-float-array
-	RUN opam pin add -k version ocaml-variants 4.12.1+options
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.12.1+no-flat-float-array/arm32v7
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-13-opam-arm32v7
-	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.12 --packages=ocaml-variants.4.12.1+options,ocaml-options-only-no-flat-float-array
-	RUN opam pin add -k version ocaml-variants 4.12.1+options
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "/usr/bin/linux32", "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.12.1+no-flat-float-array/arm64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-13-opam-arm64
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.12 --packages=ocaml-variants.4.12.1+options,ocaml-options-only-no-flat-float-array
-	RUN opam pin add -k version ocaml-variants 4.12.1+options
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.12.1+no-flat-float-array/amd64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-13-opam-amd64
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.12 --packages=ocaml-variants.4.12.1+options,ocaml-options-only-no-flat-float-array
-	RUN opam pin add -k version ocaml-variants 4.12.1+options
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.12.1+no-flat-float-array/i386
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-13-opam-i386
-	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.12 --packages=ocaml-variants.4.12.1+options,ocaml-options-only-no-flat-float-array
-	RUN opam pin add -k version ocaml-variants 4.12.1+options
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "/usr/bin/linux32", "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-ocurrent/opam-staging:debian-13-ocaml-4.12-no-flat-float-array-riscv64, ocurrent/opam-staging:debian-13-ocaml-4.12-no-flat-float-array-s390x, ocurrent/opam-staging:debian-13-ocaml-4.12-no-flat-float-array-ppc64le, ocurrent/opam-staging:debian-13-ocaml-4.12-no-flat-float-array-arm32v7, ocurrent/opam-staging:debian-13-ocaml-4.12-no-flat-float-array-arm64, ocurrent/opam-staging:debian-13-ocaml-4.12-no-flat-float-array-amd64, ocurrent/opam-staging:debian-13-ocaml-4.12-no-flat-float-array-i386 -> ocaml/opam:debian-13-ocaml-4.12-no-flat-float-array
-ocurrent/opam-staging:debian-13-ocaml-4.12-no-flat-float-array-riscv64, ocurrent/opam-staging:debian-13-ocaml-4.12-no-flat-float-array-s390x, ocurrent/opam-staging:debian-13-ocaml-4.12-no-flat-float-array-ppc64le, ocurrent/opam-staging:debian-13-ocaml-4.12-no-flat-float-array-arm32v7, ocurrent/opam-staging:debian-13-ocaml-4.12-no-flat-float-array-arm64, ocurrent/opam-staging:debian-13-ocaml-4.12-no-flat-float-array-amd64, ocurrent/opam-staging:debian-13-ocaml-4.12-no-flat-float-array-i386 -> ocaml/opam:debian-ocaml-4.12-no-flat-float-array
-4.13.1/riscv64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-13-opam-riscv64
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.13 --packages=ocaml-base-compiler.4.13.1
-	RUN opam pin add -k version ocaml-base-compiler 4.13.1
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.13.1/s390x
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-13-opam-s390x
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.13 --packages=ocaml-base-compiler.4.13.1
-	RUN opam pin add -k version ocaml-base-compiler 4.13.1
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.13.1/ppc64le
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-13-opam-ppc64le
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.13 --packages=ocaml-base-compiler.4.13.1
-	RUN opam pin add -k version ocaml-base-compiler 4.13.1
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.13.1/arm32v7
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-13-opam-arm32v7
-	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.13 --packages=ocaml-base-compiler.4.13.1
-	RUN opam pin add -k version ocaml-base-compiler 4.13.1
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "/usr/bin/linux32", "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.13.1/arm64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-13-opam-arm64
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.13 --packages=ocaml-base-compiler.4.13.1
-	RUN opam pin add -k version ocaml-base-compiler 4.13.1
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.13.1/amd64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-13-opam-amd64
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.13 --packages=ocaml-base-compiler.4.13.1
-	RUN opam pin add -k version ocaml-base-compiler 4.13.1
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.13.1/i386
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-13-opam-i386
-	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.13 --packages=ocaml-base-compiler.4.13.1
-	RUN opam pin add -k version ocaml-base-compiler 4.13.1
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "/usr/bin/linux32", "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-ocurrent/opam-staging:debian-13-ocaml-4.13-riscv64, ocurrent/opam-staging:debian-13-ocaml-4.13-s390x, ocurrent/opam-staging:debian-13-ocaml-4.13-ppc64le, ocurrent/opam-staging:debian-13-ocaml-4.13-arm32v7, ocurrent/opam-staging:debian-13-ocaml-4.13-arm64, ocurrent/opam-staging:debian-13-ocaml-4.13-amd64, ocurrent/opam-staging:debian-13-ocaml-4.13-i386 -> ocaml/opam:debian-13-ocaml-4.13
-ocurrent/opam-staging:debian-13-ocaml-4.13-riscv64, ocurrent/opam-staging:debian-13-ocaml-4.13-s390x, ocurrent/opam-staging:debian-13-ocaml-4.13-ppc64le, ocurrent/opam-staging:debian-13-ocaml-4.13-arm32v7, ocurrent/opam-staging:debian-13-ocaml-4.13-arm64, ocurrent/opam-staging:debian-13-ocaml-4.13-amd64, ocurrent/opam-staging:debian-13-ocaml-4.13-i386 -> ocaml/opam:debian-ocaml-4.13
-4.13.1+afl/riscv64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-13-opam-riscv64
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.13 --packages=ocaml-variants.4.13.1+options,ocaml-options-only-afl
-	RUN opam pin add -k version ocaml-variants 4.13.1+options
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.13.1+afl/s390x
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-13-opam-s390x
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.13 --packages=ocaml-variants.4.13.1+options,ocaml-options-only-afl
-	RUN opam pin add -k version ocaml-variants 4.13.1+options
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.13.1+afl/ppc64le
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-13-opam-ppc64le
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.13 --packages=ocaml-variants.4.13.1+options,ocaml-options-only-afl
-	RUN opam pin add -k version ocaml-variants 4.13.1+options
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.13.1+afl/arm32v7
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-13-opam-arm32v7
-	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.13 --packages=ocaml-variants.4.13.1+options,ocaml-options-only-afl
-	RUN opam pin add -k version ocaml-variants 4.13.1+options
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "/usr/bin/linux32", "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.13.1+afl/arm64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-13-opam-arm64
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.13 --packages=ocaml-variants.4.13.1+options,ocaml-options-only-afl
-	RUN opam pin add -k version ocaml-variants 4.13.1+options
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.13.1+afl/amd64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-13-opam-amd64
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.13 --packages=ocaml-variants.4.13.1+options,ocaml-options-only-afl
-	RUN opam pin add -k version ocaml-variants 4.13.1+options
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.13.1+afl/i386
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-13-opam-i386
-	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.13 --packages=ocaml-variants.4.13.1+options,ocaml-options-only-afl
-	RUN opam pin add -k version ocaml-variants 4.13.1+options
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "/usr/bin/linux32", "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-ocurrent/opam-staging:debian-13-ocaml-4.13-afl-riscv64, ocurrent/opam-staging:debian-13-ocaml-4.13-afl-s390x, ocurrent/opam-staging:debian-13-ocaml-4.13-afl-ppc64le, ocurrent/opam-staging:debian-13-ocaml-4.13-afl-arm32v7, ocurrent/opam-staging:debian-13-ocaml-4.13-afl-arm64, ocurrent/opam-staging:debian-13-ocaml-4.13-afl-amd64, ocurrent/opam-staging:debian-13-ocaml-4.13-afl-i386 -> ocaml/opam:debian-13-ocaml-4.13-afl
-ocurrent/opam-staging:debian-13-ocaml-4.13-afl-riscv64, ocurrent/opam-staging:debian-13-ocaml-4.13-afl-s390x, ocurrent/opam-staging:debian-13-ocaml-4.13-afl-ppc64le, ocurrent/opam-staging:debian-13-ocaml-4.13-afl-arm32v7, ocurrent/opam-staging:debian-13-ocaml-4.13-afl-arm64, ocurrent/opam-staging:debian-13-ocaml-4.13-afl-amd64, ocurrent/opam-staging:debian-13-ocaml-4.13-afl-i386 -> ocaml/opam:debian-ocaml-4.13-afl
-4.13.1+flambda/riscv64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-13-opam-riscv64
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.13 --packages=ocaml-variants.4.13.1+options,ocaml-options-only-flambda
-	RUN opam pin add -k version ocaml-variants 4.13.1+options
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.13.1+flambda/s390x
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-13-opam-s390x
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.13 --packages=ocaml-variants.4.13.1+options,ocaml-options-only-flambda
-	RUN opam pin add -k version ocaml-variants 4.13.1+options
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.13.1+flambda/ppc64le
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-13-opam-ppc64le
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.13 --packages=ocaml-variants.4.13.1+options,ocaml-options-only-flambda
-	RUN opam pin add -k version ocaml-variants 4.13.1+options
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.13.1+flambda/arm32v7
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-13-opam-arm32v7
-	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.13 --packages=ocaml-variants.4.13.1+options,ocaml-options-only-flambda
-	RUN opam pin add -k version ocaml-variants 4.13.1+options
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "/usr/bin/linux32", "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.13.1+flambda/arm64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-13-opam-arm64
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.13 --packages=ocaml-variants.4.13.1+options,ocaml-options-only-flambda
-	RUN opam pin add -k version ocaml-variants 4.13.1+options
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.13.1+flambda/amd64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-13-opam-amd64
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.13 --packages=ocaml-variants.4.13.1+options,ocaml-options-only-flambda
-	RUN opam pin add -k version ocaml-variants 4.13.1+options
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.13.1+flambda/i386
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-13-opam-i386
-	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.13 --packages=ocaml-variants.4.13.1+options,ocaml-options-only-flambda
-	RUN opam pin add -k version ocaml-variants 4.13.1+options
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "/usr/bin/linux32", "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-ocurrent/opam-staging:debian-13-ocaml-4.13-flambda-riscv64, ocurrent/opam-staging:debian-13-ocaml-4.13-flambda-s390x, ocurrent/opam-staging:debian-13-ocaml-4.13-flambda-ppc64le, ocurrent/opam-staging:debian-13-ocaml-4.13-flambda-arm32v7, ocurrent/opam-staging:debian-13-ocaml-4.13-flambda-arm64, ocurrent/opam-staging:debian-13-ocaml-4.13-flambda-amd64, ocurrent/opam-staging:debian-13-ocaml-4.13-flambda-i386 -> ocaml/opam:debian-13-ocaml-4.13-flambda
-ocurrent/opam-staging:debian-13-ocaml-4.13-flambda-riscv64, ocurrent/opam-staging:debian-13-ocaml-4.13-flambda-s390x, ocurrent/opam-staging:debian-13-ocaml-4.13-flambda-ppc64le, ocurrent/opam-staging:debian-13-ocaml-4.13-flambda-arm32v7, ocurrent/opam-staging:debian-13-ocaml-4.13-flambda-arm64, ocurrent/opam-staging:debian-13-ocaml-4.13-flambda-amd64, ocurrent/opam-staging:debian-13-ocaml-4.13-flambda-i386 -> ocaml/opam:debian-ocaml-4.13-flambda
-4.13.1+flambda+fp/amd64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-13-opam-amd64
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.13 --packages=ocaml-variants.4.13.1+options,ocaml-options-only-flambda-fp
-	RUN opam pin add -k version ocaml-variants 4.13.1+options
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-ocurrent/opam-staging:debian-13-ocaml-4.13-flambda-fp-amd64 -> ocaml/opam:debian-13-ocaml-4.13-flambda-fp
-ocurrent/opam-staging:debian-13-ocaml-4.13-flambda-fp-amd64 -> ocaml/opam:debian-ocaml-4.13-flambda-fp
-4.13.1+fp/amd64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-13-opam-amd64
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.13 --packages=ocaml-variants.4.13.1+options,ocaml-options-only-fp
-	RUN opam pin add -k version ocaml-variants 4.13.1+options
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-ocurrent/opam-staging:debian-13-ocaml-4.13-fp-amd64 -> ocaml/opam:debian-13-ocaml-4.13-fp
-ocurrent/opam-staging:debian-13-ocaml-4.13-fp-amd64 -> ocaml/opam:debian-ocaml-4.13-fp
-4.13.1+nnp/riscv64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-13-opam-riscv64
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.13 --packages=ocaml-variants.4.13.1+options,ocaml-options-only-nnp
-	RUN opam pin add -k version ocaml-variants 4.13.1+options
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.13.1+nnp/s390x
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-13-opam-s390x
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.13 --packages=ocaml-variants.4.13.1+options,ocaml-options-only-nnp
-	RUN opam pin add -k version ocaml-variants 4.13.1+options
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.13.1+nnp/ppc64le
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-13-opam-ppc64le
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.13 --packages=ocaml-variants.4.13.1+options,ocaml-options-only-nnp
-	RUN opam pin add -k version ocaml-variants 4.13.1+options
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.13.1+nnp/arm32v7
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-13-opam-arm32v7
-	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.13 --packages=ocaml-variants.4.13.1+options,ocaml-options-only-nnp
-	RUN opam pin add -k version ocaml-variants 4.13.1+options
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "/usr/bin/linux32", "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.13.1+nnp/arm64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-13-opam-arm64
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.13 --packages=ocaml-variants.4.13.1+options,ocaml-options-only-nnp
-	RUN opam pin add -k version ocaml-variants 4.13.1+options
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.13.1+nnp/amd64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-13-opam-amd64
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.13 --packages=ocaml-variants.4.13.1+options,ocaml-options-only-nnp
-	RUN opam pin add -k version ocaml-variants 4.13.1+options
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.13.1+nnp/i386
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-13-opam-i386
-	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.13 --packages=ocaml-variants.4.13.1+options,ocaml-options-only-nnp
-	RUN opam pin add -k version ocaml-variants 4.13.1+options
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "/usr/bin/linux32", "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-ocurrent/opam-staging:debian-13-ocaml-4.13-nnp-riscv64, ocurrent/opam-staging:debian-13-ocaml-4.13-nnp-s390x, ocurrent/opam-staging:debian-13-ocaml-4.13-nnp-ppc64le, ocurrent/opam-staging:debian-13-ocaml-4.13-nnp-arm32v7, ocurrent/opam-staging:debian-13-ocaml-4.13-nnp-arm64, ocurrent/opam-staging:debian-13-ocaml-4.13-nnp-amd64, ocurrent/opam-staging:debian-13-ocaml-4.13-nnp-i386 -> ocaml/opam:debian-13-ocaml-4.13-nnp
-ocurrent/opam-staging:debian-13-ocaml-4.13-nnp-riscv64, ocurrent/opam-staging:debian-13-ocaml-4.13-nnp-s390x, ocurrent/opam-staging:debian-13-ocaml-4.13-nnp-ppc64le, ocurrent/opam-staging:debian-13-ocaml-4.13-nnp-arm32v7, ocurrent/opam-staging:debian-13-ocaml-4.13-nnp-arm64, ocurrent/opam-staging:debian-13-ocaml-4.13-nnp-amd64, ocurrent/opam-staging:debian-13-ocaml-4.13-nnp-i386 -> ocaml/opam:debian-ocaml-4.13-nnp
-4.13.1+nnpchecker/amd64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-13-opam-amd64
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.13 --packages=ocaml-variants.4.13.1+options,ocaml-options-only-nnpchecker
-	RUN opam pin add -k version ocaml-variants 4.13.1+options
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-ocurrent/opam-staging:debian-13-ocaml-4.13-nnpchecker-amd64 -> ocaml/opam:debian-13-ocaml-4.13-nnpchecker
-ocurrent/opam-staging:debian-13-ocaml-4.13-nnpchecker-amd64 -> ocaml/opam:debian-ocaml-4.13-nnpchecker
-4.13.1+no-flat-float-array/riscv64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-13-opam-riscv64
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.13 --packages=ocaml-variants.4.13.1+options,ocaml-options-only-no-flat-float-array
-	RUN opam pin add -k version ocaml-variants 4.13.1+options
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.13.1+no-flat-float-array/s390x
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-13-opam-s390x
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.13 --packages=ocaml-variants.4.13.1+options,ocaml-options-only-no-flat-float-array
-	RUN opam pin add -k version ocaml-variants 4.13.1+options
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.13.1+no-flat-float-array/ppc64le
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-13-opam-ppc64le
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.13 --packages=ocaml-variants.4.13.1+options,ocaml-options-only-no-flat-float-array
-	RUN opam pin add -k version ocaml-variants 4.13.1+options
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.13.1+no-flat-float-array/arm32v7
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-13-opam-arm32v7
-	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.13 --packages=ocaml-variants.4.13.1+options,ocaml-options-only-no-flat-float-array
-	RUN opam pin add -k version ocaml-variants 4.13.1+options
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "/usr/bin/linux32", "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.13.1+no-flat-float-array/arm64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-13-opam-arm64
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.13 --packages=ocaml-variants.4.13.1+options,ocaml-options-only-no-flat-float-array
-	RUN opam pin add -k version ocaml-variants 4.13.1+options
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.13.1+no-flat-float-array/amd64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-13-opam-amd64
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.13 --packages=ocaml-variants.4.13.1+options,ocaml-options-only-no-flat-float-array
-	RUN opam pin add -k version ocaml-variants 4.13.1+options
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.13.1+no-flat-float-array/i386
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-13-opam-i386
-	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.13 --packages=ocaml-variants.4.13.1+options,ocaml-options-only-no-flat-float-array
-	RUN opam pin add -k version ocaml-variants 4.13.1+options
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "/usr/bin/linux32", "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-ocurrent/opam-staging:debian-13-ocaml-4.13-no-flat-float-array-riscv64, ocurrent/opam-staging:debian-13-ocaml-4.13-no-flat-float-array-s390x, ocurrent/opam-staging:debian-13-ocaml-4.13-no-flat-float-array-ppc64le, ocurrent/opam-staging:debian-13-ocaml-4.13-no-flat-float-array-arm32v7, ocurrent/opam-staging:debian-13-ocaml-4.13-no-flat-float-array-arm64, ocurrent/opam-staging:debian-13-ocaml-4.13-no-flat-float-array-amd64, ocurrent/opam-staging:debian-13-ocaml-4.13-no-flat-float-array-i386 -> ocaml/opam:debian-13-ocaml-4.13-no-flat-float-array
-ocurrent/opam-staging:debian-13-ocaml-4.13-no-flat-float-array-riscv64, ocurrent/opam-staging:debian-13-ocaml-4.13-no-flat-float-array-s390x, ocurrent/opam-staging:debian-13-ocaml-4.13-no-flat-float-array-ppc64le, ocurrent/opam-staging:debian-13-ocaml-4.13-no-flat-float-array-arm32v7, ocurrent/opam-staging:debian-13-ocaml-4.13-no-flat-float-array-arm64, ocurrent/opam-staging:debian-13-ocaml-4.13-no-flat-float-array-amd64, ocurrent/opam-staging:debian-13-ocaml-4.13-no-flat-float-array-i386 -> ocaml/opam:debian-ocaml-4.13-no-flat-float-array
 4.14.3/riscv64
 	# syntax=docker/dockerfile:1
 
@@ -8063,552 +5065,6 @@ ocurrent/opam-staging:debian-13-ocaml-4.14-nnpchecker-amd64 -> ocaml/opam:debian
 
 ocurrent/opam-staging:debian-13-ocaml-4.14-no-flat-float-array-riscv64, ocurrent/opam-staging:debian-13-ocaml-4.14-no-flat-float-array-s390x, ocurrent/opam-staging:debian-13-ocaml-4.14-no-flat-float-array-ppc64le, ocurrent/opam-staging:debian-13-ocaml-4.14-no-flat-float-array-arm32v7, ocurrent/opam-staging:debian-13-ocaml-4.14-no-flat-float-array-arm64, ocurrent/opam-staging:debian-13-ocaml-4.14-no-flat-float-array-amd64, ocurrent/opam-staging:debian-13-ocaml-4.14-no-flat-float-array-i386 -> ocaml/opam:debian-13-ocaml-4.14-no-flat-float-array
 ocurrent/opam-staging:debian-13-ocaml-4.14-no-flat-float-array-riscv64, ocurrent/opam-staging:debian-13-ocaml-4.14-no-flat-float-array-s390x, ocurrent/opam-staging:debian-13-ocaml-4.14-no-flat-float-array-ppc64le, ocurrent/opam-staging:debian-13-ocaml-4.14-no-flat-float-array-arm32v7, ocurrent/opam-staging:debian-13-ocaml-4.14-no-flat-float-array-arm64, ocurrent/opam-staging:debian-13-ocaml-4.14-no-flat-float-array-amd64, ocurrent/opam-staging:debian-13-ocaml-4.14-no-flat-float-array-i386 -> ocaml/opam:debian-ocaml-4.14-no-flat-float-array
-5.0.0/riscv64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-13-opam-riscv64
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 5.0 --packages=ocaml-base-compiler.5.0.0
-	RUN opam pin add -k version ocaml-base-compiler 5.0.0
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-5.0.0/s390x
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-13-opam-s390x
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 5.0 --packages=ocaml-base-compiler.5.0.0
-	RUN opam pin add -k version ocaml-base-compiler 5.0.0
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-5.0.0/ppc64le
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-13-opam-ppc64le
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 5.0 --packages=ocaml-base-compiler.5.0.0
-	RUN opam pin add -k version ocaml-base-compiler 5.0.0
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-5.0.0/arm32v7
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-13-opam-arm32v7
-	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 5.0 --packages=ocaml-base-compiler.5.0.0
-	RUN opam pin add -k version ocaml-base-compiler 5.0.0
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "/usr/bin/linux32", "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-5.0.0/arm64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-13-opam-arm64
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 5.0 --packages=ocaml-base-compiler.5.0.0
-	RUN opam pin add -k version ocaml-base-compiler 5.0.0
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-5.0.0/amd64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-13-opam-amd64
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 5.0 --packages=ocaml-base-compiler.5.0.0
-	RUN opam pin add -k version ocaml-base-compiler 5.0.0
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-5.0.0/i386
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-13-opam-i386
-	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 5.0 --packages=ocaml-base-compiler.5.0.0
-	RUN opam pin add -k version ocaml-base-compiler 5.0.0
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "/usr/bin/linux32", "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-ocurrent/opam-staging:debian-13-ocaml-5.0-riscv64, ocurrent/opam-staging:debian-13-ocaml-5.0-s390x, ocurrent/opam-staging:debian-13-ocaml-5.0-ppc64le, ocurrent/opam-staging:debian-13-ocaml-5.0-arm32v7, ocurrent/opam-staging:debian-13-ocaml-5.0-arm64, ocurrent/opam-staging:debian-13-ocaml-5.0-amd64, ocurrent/opam-staging:debian-13-ocaml-5.0-i386 -> ocaml/opam:debian-13-ocaml-5.0
-ocurrent/opam-staging:debian-13-ocaml-5.0-riscv64, ocurrent/opam-staging:debian-13-ocaml-5.0-s390x, ocurrent/opam-staging:debian-13-ocaml-5.0-ppc64le, ocurrent/opam-staging:debian-13-ocaml-5.0-arm32v7, ocurrent/opam-staging:debian-13-ocaml-5.0-arm64, ocurrent/opam-staging:debian-13-ocaml-5.0-amd64, ocurrent/opam-staging:debian-13-ocaml-5.0-i386 -> ocaml/opam:debian-ocaml-5.0
-5.0.0+afl/arm64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-13-opam-arm64
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 5.0 --packages=ocaml-variants.5.0.0+options,ocaml-options-only-afl
-	RUN opam pin add -k version ocaml-variants 5.0.0+options
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-5.0.0+afl/amd64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-13-opam-amd64
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 5.0 --packages=ocaml-variants.5.0.0+options,ocaml-options-only-afl
-	RUN opam pin add -k version ocaml-variants 5.0.0+options
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-ocurrent/opam-staging:debian-13-ocaml-5.0-afl-arm64, ocurrent/opam-staging:debian-13-ocaml-5.0-afl-amd64 -> ocaml/opam:debian-13-ocaml-5.0-afl
-ocurrent/opam-staging:debian-13-ocaml-5.0-afl-arm64, ocurrent/opam-staging:debian-13-ocaml-5.0-afl-amd64 -> ocaml/opam:debian-ocaml-5.0-afl
-5.0.0+flambda/arm64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-13-opam-arm64
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 5.0 --packages=ocaml-variants.5.0.0+options,ocaml-options-only-flambda
-	RUN opam pin add -k version ocaml-variants 5.0.0+options
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-5.0.0+flambda/amd64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-13-opam-amd64
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 5.0 --packages=ocaml-variants.5.0.0+options,ocaml-options-only-flambda
-	RUN opam pin add -k version ocaml-variants 5.0.0+options
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-ocurrent/opam-staging:debian-13-ocaml-5.0-flambda-arm64, ocurrent/opam-staging:debian-13-ocaml-5.0-flambda-amd64 -> ocaml/opam:debian-13-ocaml-5.0-flambda
-ocurrent/opam-staging:debian-13-ocaml-5.0-flambda-arm64, ocurrent/opam-staging:debian-13-ocaml-5.0-flambda-amd64 -> ocaml/opam:debian-ocaml-5.0-flambda
-5.0.0+no-flat-float-array/riscv64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-13-opam-riscv64
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 5.0 --packages=ocaml-variants.5.0.0+options,ocaml-options-only-no-flat-float-array
-	RUN opam pin add -k version ocaml-variants 5.0.0+options
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-5.0.0+no-flat-float-array/s390x
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-13-opam-s390x
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 5.0 --packages=ocaml-variants.5.0.0+options,ocaml-options-only-no-flat-float-array
-	RUN opam pin add -k version ocaml-variants 5.0.0+options
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-5.0.0+no-flat-float-array/ppc64le
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-13-opam-ppc64le
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 5.0 --packages=ocaml-variants.5.0.0+options,ocaml-options-only-no-flat-float-array
-	RUN opam pin add -k version ocaml-variants 5.0.0+options
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-5.0.0+no-flat-float-array/arm32v7
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-13-opam-arm32v7
-	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 5.0 --packages=ocaml-variants.5.0.0+options,ocaml-options-only-no-flat-float-array
-	RUN opam pin add -k version ocaml-variants 5.0.0+options
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "/usr/bin/linux32", "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-5.0.0+no-flat-float-array/arm64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-13-opam-arm64
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 5.0 --packages=ocaml-variants.5.0.0+options,ocaml-options-only-no-flat-float-array
-	RUN opam pin add -k version ocaml-variants 5.0.0+options
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-5.0.0+no-flat-float-array/amd64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-13-opam-amd64
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 5.0 --packages=ocaml-variants.5.0.0+options,ocaml-options-only-no-flat-float-array
-	RUN opam pin add -k version ocaml-variants 5.0.0+options
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-5.0.0+no-flat-float-array/i386
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-13-opam-i386
-	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 5.0 --packages=ocaml-variants.5.0.0+options,ocaml-options-only-no-flat-float-array
-	RUN opam pin add -k version ocaml-variants 5.0.0+options
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "/usr/bin/linux32", "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-ocurrent/opam-staging:debian-13-ocaml-5.0-no-flat-float-array-riscv64, ocurrent/opam-staging:debian-13-ocaml-5.0-no-flat-float-array-s390x, ocurrent/opam-staging:debian-13-ocaml-5.0-no-flat-float-array-ppc64le, ocurrent/opam-staging:debian-13-ocaml-5.0-no-flat-float-array-arm32v7, ocurrent/opam-staging:debian-13-ocaml-5.0-no-flat-float-array-arm64, ocurrent/opam-staging:debian-13-ocaml-5.0-no-flat-float-array-amd64, ocurrent/opam-staging:debian-13-ocaml-5.0-no-flat-float-array-i386 -> ocaml/opam:debian-13-ocaml-5.0-no-flat-float-array
-ocurrent/opam-staging:debian-13-ocaml-5.0-no-flat-float-array-riscv64, ocurrent/opam-staging:debian-13-ocaml-5.0-no-flat-float-array-s390x, ocurrent/opam-staging:debian-13-ocaml-5.0-no-flat-float-array-ppc64le, ocurrent/opam-staging:debian-13-ocaml-5.0-no-flat-float-array-arm32v7, ocurrent/opam-staging:debian-13-ocaml-5.0-no-flat-float-array-arm64, ocurrent/opam-staging:debian-13-ocaml-5.0-no-flat-float-array-amd64, ocurrent/opam-staging:debian-13-ocaml-5.0-no-flat-float-array-i386 -> ocaml/opam:debian-ocaml-5.0-no-flat-float-array
-5.1.1/riscv64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-13-opam-riscv64
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	USER root
-	RUN apt-get -y update
-	RUN DEBIAN_FRONTEND=noninteractive apt-get -y upgrade
-	RUN DEBIAN_FRONTEND=noninteractive apt-get -y install libzstd-dev
-	USER opam
-	RUN opam switch create 5.1 --packages=ocaml-base-compiler.5.1.1
-	RUN opam pin add -k version ocaml-base-compiler 5.1.1
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-5.1.1/s390x
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-13-opam-s390x
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	USER root
-	RUN apt-get -y update
-	RUN DEBIAN_FRONTEND=noninteractive apt-get -y upgrade
-	RUN DEBIAN_FRONTEND=noninteractive apt-get -y install libzstd-dev
-	USER opam
-	RUN opam switch create 5.1 --packages=ocaml-base-compiler.5.1.1
-	RUN opam pin add -k version ocaml-base-compiler 5.1.1
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-5.1.1/ppc64le
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-13-opam-ppc64le
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	USER root
-	RUN apt-get -y update
-	RUN DEBIAN_FRONTEND=noninteractive apt-get -y upgrade
-	RUN DEBIAN_FRONTEND=noninteractive apt-get -y install libzstd-dev
-	USER opam
-	RUN opam switch create 5.1 --packages=ocaml-base-compiler.5.1.1
-	RUN opam pin add -k version ocaml-base-compiler 5.1.1
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-5.1.1/arm32v7
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-13-opam-arm32v7
-	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	USER root
-	RUN apt-get -y update
-	RUN DEBIAN_FRONTEND=noninteractive apt-get -y upgrade
-	RUN DEBIAN_FRONTEND=noninteractive apt-get -y install libzstd-dev
-	USER opam
-	RUN opam switch create 5.1 --packages=ocaml-base-compiler.5.1.1
-	RUN opam pin add -k version ocaml-base-compiler 5.1.1
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "/usr/bin/linux32", "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-5.1.1/arm64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-13-opam-arm64
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	USER root
-	RUN apt-get -y update
-	RUN DEBIAN_FRONTEND=noninteractive apt-get -y upgrade
-	RUN DEBIAN_FRONTEND=noninteractive apt-get -y install libzstd-dev
-	USER opam
-	RUN opam switch create 5.1 --packages=ocaml-base-compiler.5.1.1
-	RUN opam pin add -k version ocaml-base-compiler 5.1.1
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-5.1.1/amd64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-13-opam-amd64
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	USER root
-	RUN apt-get -y update
-	RUN DEBIAN_FRONTEND=noninteractive apt-get -y upgrade
-	RUN DEBIAN_FRONTEND=noninteractive apt-get -y install libzstd-dev
-	USER opam
-	RUN opam switch create 5.1 --packages=ocaml-base-compiler.5.1.1
-	RUN opam pin add -k version ocaml-base-compiler 5.1.1
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-5.1.1/i386
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-13-opam-i386
-	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	USER root
-	RUN apt-get -y update
-	RUN DEBIAN_FRONTEND=noninteractive apt-get -y upgrade
-	RUN DEBIAN_FRONTEND=noninteractive apt-get -y install libzstd-dev
-	USER opam
-	RUN opam switch create 5.1 --packages=ocaml-base-compiler.5.1.1
-	RUN opam pin add -k version ocaml-base-compiler 5.1.1
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "/usr/bin/linux32", "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-ocurrent/opam-staging:debian-13-ocaml-5.1-riscv64, ocurrent/opam-staging:debian-13-ocaml-5.1-s390x, ocurrent/opam-staging:debian-13-ocaml-5.1-ppc64le, ocurrent/opam-staging:debian-13-ocaml-5.1-arm32v7, ocurrent/opam-staging:debian-13-ocaml-5.1-arm64, ocurrent/opam-staging:debian-13-ocaml-5.1-amd64, ocurrent/opam-staging:debian-13-ocaml-5.1-i386 -> ocaml/opam:debian-13-ocaml-5.1
-ocurrent/opam-staging:debian-13-ocaml-5.1-riscv64, ocurrent/opam-staging:debian-13-ocaml-5.1-s390x, ocurrent/opam-staging:debian-13-ocaml-5.1-ppc64le, ocurrent/opam-staging:debian-13-ocaml-5.1-arm32v7, ocurrent/opam-staging:debian-13-ocaml-5.1-arm64, ocurrent/opam-staging:debian-13-ocaml-5.1-amd64, ocurrent/opam-staging:debian-13-ocaml-5.1-i386 -> ocaml/opam:debian-ocaml-5.1
-5.1.1+afl/arm64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-13-opam-arm64
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	USER root
-	RUN apt-get -y update
-	RUN DEBIAN_FRONTEND=noninteractive apt-get -y upgrade
-	RUN DEBIAN_FRONTEND=noninteractive apt-get -y install libzstd-dev
-	USER opam
-	RUN opam switch create 5.1 --packages=ocaml-variants.5.1.1+options,ocaml-options-only-afl
-	RUN opam pin add -k version ocaml-variants 5.1.1+options
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-5.1.1+afl/amd64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-13-opam-amd64
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	USER root
-	RUN apt-get -y update
-	RUN DEBIAN_FRONTEND=noninteractive apt-get -y upgrade
-	RUN DEBIAN_FRONTEND=noninteractive apt-get -y install libzstd-dev
-	USER opam
-	RUN opam switch create 5.1 --packages=ocaml-variants.5.1.1+options,ocaml-options-only-afl
-	RUN opam pin add -k version ocaml-variants 5.1.1+options
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-ocurrent/opam-staging:debian-13-ocaml-5.1-afl-arm64, ocurrent/opam-staging:debian-13-ocaml-5.1-afl-amd64 -> ocaml/opam:debian-13-ocaml-5.1-afl
-ocurrent/opam-staging:debian-13-ocaml-5.1-afl-arm64, ocurrent/opam-staging:debian-13-ocaml-5.1-afl-amd64 -> ocaml/opam:debian-ocaml-5.1-afl
-5.1.1+flambda/arm64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-13-opam-arm64
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	USER root
-	RUN apt-get -y update
-	RUN DEBIAN_FRONTEND=noninteractive apt-get -y upgrade
-	RUN DEBIAN_FRONTEND=noninteractive apt-get -y install libzstd-dev
-	USER opam
-	RUN opam switch create 5.1 --packages=ocaml-variants.5.1.1+options,ocaml-options-only-flambda
-	RUN opam pin add -k version ocaml-variants 5.1.1+options
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-5.1.1+flambda/amd64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-13-opam-amd64
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	USER root
-	RUN apt-get -y update
-	RUN DEBIAN_FRONTEND=noninteractive apt-get -y upgrade
-	RUN DEBIAN_FRONTEND=noninteractive apt-get -y install libzstd-dev
-	USER opam
-	RUN opam switch create 5.1 --packages=ocaml-variants.5.1.1+options,ocaml-options-only-flambda
-	RUN opam pin add -k version ocaml-variants 5.1.1+options
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-ocurrent/opam-staging:debian-13-ocaml-5.1-flambda-arm64, ocurrent/opam-staging:debian-13-ocaml-5.1-flambda-amd64 -> ocaml/opam:debian-13-ocaml-5.1-flambda
-ocurrent/opam-staging:debian-13-ocaml-5.1-flambda-arm64, ocurrent/opam-staging:debian-13-ocaml-5.1-flambda-amd64 -> ocaml/opam:debian-ocaml-5.1-flambda
-5.1.1+no-flat-float-array/riscv64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-13-opam-riscv64
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	USER root
-	RUN apt-get -y update
-	RUN DEBIAN_FRONTEND=noninteractive apt-get -y upgrade
-	RUN DEBIAN_FRONTEND=noninteractive apt-get -y install libzstd-dev
-	USER opam
-	RUN opam switch create 5.1 --packages=ocaml-variants.5.1.1+options,ocaml-options-only-no-flat-float-array
-	RUN opam pin add -k version ocaml-variants 5.1.1+options
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-5.1.1+no-flat-float-array/s390x
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-13-opam-s390x
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	USER root
-	RUN apt-get -y update
-	RUN DEBIAN_FRONTEND=noninteractive apt-get -y upgrade
-	RUN DEBIAN_FRONTEND=noninteractive apt-get -y install libzstd-dev
-	USER opam
-	RUN opam switch create 5.1 --packages=ocaml-variants.5.1.1+options,ocaml-options-only-no-flat-float-array
-	RUN opam pin add -k version ocaml-variants 5.1.1+options
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-5.1.1+no-flat-float-array/ppc64le
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-13-opam-ppc64le
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	USER root
-	RUN apt-get -y update
-	RUN DEBIAN_FRONTEND=noninteractive apt-get -y upgrade
-	RUN DEBIAN_FRONTEND=noninteractive apt-get -y install libzstd-dev
-	USER opam
-	RUN opam switch create 5.1 --packages=ocaml-variants.5.1.1+options,ocaml-options-only-no-flat-float-array
-	RUN opam pin add -k version ocaml-variants 5.1.1+options
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-5.1.1+no-flat-float-array/arm32v7
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-13-opam-arm32v7
-	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	USER root
-	RUN apt-get -y update
-	RUN DEBIAN_FRONTEND=noninteractive apt-get -y upgrade
-	RUN DEBIAN_FRONTEND=noninteractive apt-get -y install libzstd-dev
-	USER opam
-	RUN opam switch create 5.1 --packages=ocaml-variants.5.1.1+options,ocaml-options-only-no-flat-float-array
-	RUN opam pin add -k version ocaml-variants 5.1.1+options
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "/usr/bin/linux32", "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-5.1.1+no-flat-float-array/arm64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-13-opam-arm64
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	USER root
-	RUN apt-get -y update
-	RUN DEBIAN_FRONTEND=noninteractive apt-get -y upgrade
-	RUN DEBIAN_FRONTEND=noninteractive apt-get -y install libzstd-dev
-	USER opam
-	RUN opam switch create 5.1 --packages=ocaml-variants.5.1.1+options,ocaml-options-only-no-flat-float-array
-	RUN opam pin add -k version ocaml-variants 5.1.1+options
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-5.1.1+no-flat-float-array/amd64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-13-opam-amd64
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	USER root
-	RUN apt-get -y update
-	RUN DEBIAN_FRONTEND=noninteractive apt-get -y upgrade
-	RUN DEBIAN_FRONTEND=noninteractive apt-get -y install libzstd-dev
-	USER opam
-	RUN opam switch create 5.1 --packages=ocaml-variants.5.1.1+options,ocaml-options-only-no-flat-float-array
-	RUN opam pin add -k version ocaml-variants 5.1.1+options
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-5.1.1+no-flat-float-array/i386
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-13-opam-i386
-	SHELL [ "/usr/bin/linux32", "/bin/sh", "-c" ]
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	USER root
-	RUN apt-get -y update
-	RUN DEBIAN_FRONTEND=noninteractive apt-get -y upgrade
-	RUN DEBIAN_FRONTEND=noninteractive apt-get -y install libzstd-dev
-	USER opam
-	RUN opam switch create 5.1 --packages=ocaml-variants.5.1.1+options,ocaml-options-only-no-flat-float-array
-	RUN opam pin add -k version ocaml-variants 5.1.1+options
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "/usr/bin/linux32", "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-ocurrent/opam-staging:debian-13-ocaml-5.1-no-flat-float-array-riscv64, ocurrent/opam-staging:debian-13-ocaml-5.1-no-flat-float-array-s390x, ocurrent/opam-staging:debian-13-ocaml-5.1-no-flat-float-array-ppc64le, ocurrent/opam-staging:debian-13-ocaml-5.1-no-flat-float-array-arm32v7, ocurrent/opam-staging:debian-13-ocaml-5.1-no-flat-float-array-arm64, ocurrent/opam-staging:debian-13-ocaml-5.1-no-flat-float-array-amd64, ocurrent/opam-staging:debian-13-ocaml-5.1-no-flat-float-array-i386 -> ocaml/opam:debian-13-ocaml-5.1-no-flat-float-array
-ocurrent/opam-staging:debian-13-ocaml-5.1-no-flat-float-array-riscv64, ocurrent/opam-staging:debian-13-ocaml-5.1-no-flat-float-array-s390x, ocurrent/opam-staging:debian-13-ocaml-5.1-no-flat-float-array-ppc64le, ocurrent/opam-staging:debian-13-ocaml-5.1-no-flat-float-array-arm32v7, ocurrent/opam-staging:debian-13-ocaml-5.1-no-flat-float-array-arm64, ocurrent/opam-staging:debian-13-ocaml-5.1-no-flat-float-array-amd64, ocurrent/opam-staging:debian-13-ocaml-5.1-no-flat-float-array-i386 -> ocaml/opam:debian-ocaml-5.1-no-flat-float-array
 5.2.1/riscv64
 	# syntax=docker/dockerfile:1
 
@@ -10689,34 +7145,6 @@ ocurrent/opam-staging:debian-testing-opam-amd64 -> ocaml/opam:debian-testing-opa
 	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
 
 ocurrent/opam-staging:debian-testing-ocaml-4.08-amd64 -> ocaml/opam:debian-testing-ocaml-4.08
-4.09.1/amd64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-testing-opam-amd64
-	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.09 --packages=ocaml-base-compiler.4.09.1
-	RUN opam pin add -k version ocaml-base-compiler 4.09.1
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-ocurrent/opam-staging:debian-testing-ocaml-4.09-amd64 -> ocaml/opam:debian-testing-ocaml-4.09
-4.10.2/amd64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-testing-opam-amd64
-	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.10 --packages=ocaml-base-compiler.4.10.2
-	RUN opam pin add -k version ocaml-base-compiler 4.10.2
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-ocurrent/opam-staging:debian-testing-ocaml-4.10-amd64 -> ocaml/opam:debian-testing-ocaml-4.10
 4.11.2/amd64
 	# syntax=docker/dockerfile:1
 
@@ -10731,34 +7159,6 @@ ocurrent/opam-staging:debian-testing-ocaml-4.10-amd64 -> ocaml/opam:debian-testi
 	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
 
 ocurrent/opam-staging:debian-testing-ocaml-4.11-amd64 -> ocaml/opam:debian-testing-ocaml-4.11
-4.12.1/amd64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-testing-opam-amd64
-	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.12 --packages=ocaml-base-compiler.4.12.1
-	RUN opam pin add -k version ocaml-base-compiler 4.12.1
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-ocurrent/opam-staging:debian-testing-ocaml-4.12-amd64 -> ocaml/opam:debian-testing-ocaml-4.12
-4.13.1/amd64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-testing-opam-amd64
-	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.13 --packages=ocaml-base-compiler.4.13.1
-	RUN opam pin add -k version ocaml-base-compiler 4.13.1
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-ocurrent/opam-staging:debian-testing-ocaml-4.13-amd64 -> ocaml/opam:debian-testing-ocaml-4.13
 4.14.3/amd64
 	# syntax=docker/dockerfile:1
 
@@ -10773,38 +7173,6 @@ ocurrent/opam-staging:debian-testing-ocaml-4.13-amd64 -> ocaml/opam:debian-testi
 	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
 
 ocurrent/opam-staging:debian-testing-ocaml-4.14-amd64 -> ocaml/opam:debian-testing-ocaml-4.14
-5.0.0/amd64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-testing-opam-amd64
-	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 5.0 --packages=ocaml-base-compiler.5.0.0
-	RUN opam pin add -k version ocaml-base-compiler 5.0.0
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-ocurrent/opam-staging:debian-testing-ocaml-5.0-amd64 -> ocaml/opam:debian-testing-ocaml-5.0
-5.1.1/amd64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-testing-opam-amd64
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	USER root
-	RUN apt-get -y update
-	RUN DEBIAN_FRONTEND=noninteractive apt-get -y upgrade
-	RUN DEBIAN_FRONTEND=noninteractive apt-get -y install libzstd-dev
-	USER opam
-	RUN opam switch create 5.1 --packages=ocaml-base-compiler.5.1.1
-	RUN opam pin add -k version ocaml-base-compiler 5.1.1
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-ocurrent/opam-staging:debian-testing-ocaml-5.1-amd64 -> ocaml/opam:debian-testing-ocaml-5.1
 5.2.1/amd64
 	# syntax=docker/dockerfile:1
 
@@ -11018,34 +7386,6 @@ ocurrent/opam-staging:debian-unstable-opam-amd64 -> ocaml/opam:debian-unstable-o
 	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
 
 ocurrent/opam-staging:debian-unstable-ocaml-4.08-amd64 -> ocaml/opam:debian-unstable-ocaml-4.08
-4.09.1/amd64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-unstable-opam-amd64
-	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.09 --packages=ocaml-base-compiler.4.09.1
-	RUN opam pin add -k version ocaml-base-compiler 4.09.1
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-ocurrent/opam-staging:debian-unstable-ocaml-4.09-amd64 -> ocaml/opam:debian-unstable-ocaml-4.09
-4.10.2/amd64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-unstable-opam-amd64
-	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.10 --packages=ocaml-base-compiler.4.10.2
-	RUN opam pin add -k version ocaml-base-compiler 4.10.2
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-ocurrent/opam-staging:debian-unstable-ocaml-4.10-amd64 -> ocaml/opam:debian-unstable-ocaml-4.10
 4.11.2/amd64
 	# syntax=docker/dockerfile:1
 
@@ -11060,34 +7400,6 @@ ocurrent/opam-staging:debian-unstable-ocaml-4.10-amd64 -> ocaml/opam:debian-unst
 	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
 
 ocurrent/opam-staging:debian-unstable-ocaml-4.11-amd64 -> ocaml/opam:debian-unstable-ocaml-4.11
-4.12.1/amd64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-unstable-opam-amd64
-	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.12 --packages=ocaml-base-compiler.4.12.1
-	RUN opam pin add -k version ocaml-base-compiler 4.12.1
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-ocurrent/opam-staging:debian-unstable-ocaml-4.12-amd64 -> ocaml/opam:debian-unstable-ocaml-4.12
-4.13.1/amd64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-unstable-opam-amd64
-	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.13 --packages=ocaml-base-compiler.4.13.1
-	RUN opam pin add -k version ocaml-base-compiler 4.13.1
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-ocurrent/opam-staging:debian-unstable-ocaml-4.13-amd64 -> ocaml/opam:debian-unstable-ocaml-4.13
 4.14.3/amd64
 	# syntax=docker/dockerfile:1
 
@@ -11102,38 +7414,6 @@ ocurrent/opam-staging:debian-unstable-ocaml-4.13-amd64 -> ocaml/opam:debian-unst
 	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
 
 ocurrent/opam-staging:debian-unstable-ocaml-4.14-amd64 -> ocaml/opam:debian-unstable-ocaml-4.14
-5.0.0/amd64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-unstable-opam-amd64
-	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 5.0 --packages=ocaml-base-compiler.5.0.0
-	RUN opam pin add -k version ocaml-base-compiler 5.0.0
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-ocurrent/opam-staging:debian-unstable-ocaml-5.0-amd64 -> ocaml/opam:debian-unstable-ocaml-5.0
-5.1.1/amd64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:debian-unstable-opam-amd64
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	USER root
-	RUN apt-get -y update
-	RUN DEBIAN_FRONTEND=noninteractive apt-get -y upgrade
-	RUN DEBIAN_FRONTEND=noninteractive apt-get -y install libzstd-dev
-	USER opam
-	RUN opam switch create 5.1 --packages=ocaml-base-compiler.5.1.1
-	RUN opam pin add -k version ocaml-base-compiler 5.1.1
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-ocurrent/opam-staging:debian-unstable-ocaml-5.1-amd64 -> ocaml/opam:debian-unstable-ocaml-5.1
 5.2.1/amd64
 	# syntax=docker/dockerfile:1
 
@@ -11441,60 +7721,6 @@ ocurrent/opam-staging:fedora-42-opam-arm64, ocurrent/opam-staging:fedora-42-opam
 	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
 
 ocurrent/opam-staging:fedora-42-ocaml-4.08-arm64, ocurrent/opam-staging:fedora-42-ocaml-4.08-amd64 -> ocaml/opam:fedora-42-ocaml-4.08
-4.09.1/arm64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:fedora-42-opam-arm64
-	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.09 --packages=ocaml-base-compiler.4.09.1
-	RUN opam pin add -k version ocaml-base-compiler 4.09.1
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.09.1/amd64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:fedora-42-opam-amd64
-	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.09 --packages=ocaml-base-compiler.4.09.1
-	RUN opam pin add -k version ocaml-base-compiler 4.09.1
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-ocurrent/opam-staging:fedora-42-ocaml-4.09-arm64, ocurrent/opam-staging:fedora-42-ocaml-4.09-amd64 -> ocaml/opam:fedora-42-ocaml-4.09
-4.10.2/arm64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:fedora-42-opam-arm64
-	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.10 --packages=ocaml-base-compiler.4.10.2
-	RUN opam pin add -k version ocaml-base-compiler 4.10.2
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.10.2/amd64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:fedora-42-opam-amd64
-	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.10 --packages=ocaml-base-compiler.4.10.2
-	RUN opam pin add -k version ocaml-base-compiler 4.10.2
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-ocurrent/opam-staging:fedora-42-ocaml-4.10-arm64, ocurrent/opam-staging:fedora-42-ocaml-4.10-amd64 -> ocaml/opam:fedora-42-ocaml-4.10
 4.11.2/arm64
 	# syntax=docker/dockerfile:1
 
@@ -11522,60 +7748,6 @@ ocurrent/opam-staging:fedora-42-ocaml-4.10-arm64, ocurrent/opam-staging:fedora-4
 	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
 
 ocurrent/opam-staging:fedora-42-ocaml-4.11-arm64, ocurrent/opam-staging:fedora-42-ocaml-4.11-amd64 -> ocaml/opam:fedora-42-ocaml-4.11
-4.12.1/arm64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:fedora-42-opam-arm64
-	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.12 --packages=ocaml-base-compiler.4.12.1
-	RUN opam pin add -k version ocaml-base-compiler 4.12.1
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.12.1/amd64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:fedora-42-opam-amd64
-	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.12 --packages=ocaml-base-compiler.4.12.1
-	RUN opam pin add -k version ocaml-base-compiler 4.12.1
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-ocurrent/opam-staging:fedora-42-ocaml-4.12-arm64, ocurrent/opam-staging:fedora-42-ocaml-4.12-amd64 -> ocaml/opam:fedora-42-ocaml-4.12
-4.13.1/arm64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:fedora-42-opam-arm64
-	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.13 --packages=ocaml-base-compiler.4.13.1
-	RUN opam pin add -k version ocaml-base-compiler 4.13.1
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.13.1/amd64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:fedora-42-opam-amd64
-	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.13 --packages=ocaml-base-compiler.4.13.1
-	RUN opam pin add -k version ocaml-base-compiler 4.13.1
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-ocurrent/opam-staging:fedora-42-ocaml-4.13-arm64, ocurrent/opam-staging:fedora-42-ocaml-4.13-amd64 -> ocaml/opam:fedora-42-ocaml-4.13
 4.14.3/arm64
 	# syntax=docker/dockerfile:1
 
@@ -11603,64 +7775,6 @@ ocurrent/opam-staging:fedora-42-ocaml-4.13-arm64, ocurrent/opam-staging:fedora-4
 	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
 
 ocurrent/opam-staging:fedora-42-ocaml-4.14-arm64, ocurrent/opam-staging:fedora-42-ocaml-4.14-amd64 -> ocaml/opam:fedora-42-ocaml-4.14
-5.0.0/arm64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:fedora-42-opam-arm64
-	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 5.0 --packages=ocaml-base-compiler.5.0.0
-	RUN opam pin add -k version ocaml-base-compiler 5.0.0
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-5.0.0/amd64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:fedora-42-opam-amd64
-	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 5.0 --packages=ocaml-base-compiler.5.0.0
-	RUN opam pin add -k version ocaml-base-compiler 5.0.0
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-ocurrent/opam-staging:fedora-42-ocaml-5.0-arm64, ocurrent/opam-staging:fedora-42-ocaml-5.0-amd64 -> ocaml/opam:fedora-42-ocaml-5.0
-5.1.1/arm64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:fedora-42-opam-arm64
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	USER root
-	RUN yum install -y zstd && yum clean packages
-	USER opam
-	RUN opam switch create 5.1 --packages=ocaml-base-compiler.5.1.1
-	RUN opam pin add -k version ocaml-base-compiler 5.1.1
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-5.1.1/amd64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:fedora-42-opam-amd64
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	USER root
-	RUN yum install -y zstd && yum clean packages
-	USER opam
-	RUN opam switch create 5.1 --packages=ocaml-base-compiler.5.1.1
-	RUN opam pin add -k version ocaml-base-compiler 5.1.1
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-ocurrent/opam-staging:fedora-42-ocaml-5.1-arm64, ocurrent/opam-staging:fedora-42-ocaml-5.1-amd64 -> ocaml/opam:fedora-42-ocaml-5.1
 5.2.1/arm64
 	# syntax=docker/dockerfile:1
 
@@ -12050,62 +8164,6 @@ ocurrent/opam-staging:fedora-43-opam-arm64, ocurrent/opam-staging:fedora-43-opam
 
 ocurrent/opam-staging:fedora-43-ocaml-4.08-arm64, ocurrent/opam-staging:fedora-43-ocaml-4.08-amd64 -> ocaml/opam:fedora-43-ocaml-4.08
 ocurrent/opam-staging:fedora-43-ocaml-4.08-arm64, ocurrent/opam-staging:fedora-43-ocaml-4.08-amd64 -> ocaml/opam:fedora-ocaml-4.08
-4.09.1/arm64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:fedora-43-opam-arm64
-	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.09 --packages=ocaml-base-compiler.4.09.1
-	RUN opam pin add -k version ocaml-base-compiler 4.09.1
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.09.1/amd64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:fedora-43-opam-amd64
-	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.09 --packages=ocaml-base-compiler.4.09.1
-	RUN opam pin add -k version ocaml-base-compiler 4.09.1
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-ocurrent/opam-staging:fedora-43-ocaml-4.09-arm64, ocurrent/opam-staging:fedora-43-ocaml-4.09-amd64 -> ocaml/opam:fedora-43-ocaml-4.09
-ocurrent/opam-staging:fedora-43-ocaml-4.09-arm64, ocurrent/opam-staging:fedora-43-ocaml-4.09-amd64 -> ocaml/opam:fedora-ocaml-4.09
-4.10.2/arm64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:fedora-43-opam-arm64
-	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.10 --packages=ocaml-base-compiler.4.10.2
-	RUN opam pin add -k version ocaml-base-compiler 4.10.2
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.10.2/amd64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:fedora-43-opam-amd64
-	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.10 --packages=ocaml-base-compiler.4.10.2
-	RUN opam pin add -k version ocaml-base-compiler 4.10.2
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-ocurrent/opam-staging:fedora-43-ocaml-4.10-arm64, ocurrent/opam-staging:fedora-43-ocaml-4.10-amd64 -> ocaml/opam:fedora-43-ocaml-4.10
-ocurrent/opam-staging:fedora-43-ocaml-4.10-arm64, ocurrent/opam-staging:fedora-43-ocaml-4.10-amd64 -> ocaml/opam:fedora-ocaml-4.10
 4.11.2/arm64
 	# syntax=docker/dockerfile:1
 
@@ -12134,62 +8192,6 @@ ocurrent/opam-staging:fedora-43-ocaml-4.10-arm64, ocurrent/opam-staging:fedora-4
 
 ocurrent/opam-staging:fedora-43-ocaml-4.11-arm64, ocurrent/opam-staging:fedora-43-ocaml-4.11-amd64 -> ocaml/opam:fedora-43-ocaml-4.11
 ocurrent/opam-staging:fedora-43-ocaml-4.11-arm64, ocurrent/opam-staging:fedora-43-ocaml-4.11-amd64 -> ocaml/opam:fedora-ocaml-4.11
-4.12.1/arm64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:fedora-43-opam-arm64
-	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.12 --packages=ocaml-base-compiler.4.12.1
-	RUN opam pin add -k version ocaml-base-compiler 4.12.1
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.12.1/amd64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:fedora-43-opam-amd64
-	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.12 --packages=ocaml-base-compiler.4.12.1
-	RUN opam pin add -k version ocaml-base-compiler 4.12.1
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-ocurrent/opam-staging:fedora-43-ocaml-4.12-arm64, ocurrent/opam-staging:fedora-43-ocaml-4.12-amd64 -> ocaml/opam:fedora-43-ocaml-4.12
-ocurrent/opam-staging:fedora-43-ocaml-4.12-arm64, ocurrent/opam-staging:fedora-43-ocaml-4.12-amd64 -> ocaml/opam:fedora-ocaml-4.12
-4.13.1/arm64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:fedora-43-opam-arm64
-	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.13 --packages=ocaml-base-compiler.4.13.1
-	RUN opam pin add -k version ocaml-base-compiler 4.13.1
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.13.1/amd64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:fedora-43-opam-amd64
-	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.13 --packages=ocaml-base-compiler.4.13.1
-	RUN opam pin add -k version ocaml-base-compiler 4.13.1
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-ocurrent/opam-staging:fedora-43-ocaml-4.13-arm64, ocurrent/opam-staging:fedora-43-ocaml-4.13-amd64 -> ocaml/opam:fedora-43-ocaml-4.13
-ocurrent/opam-staging:fedora-43-ocaml-4.13-arm64, ocurrent/opam-staging:fedora-43-ocaml-4.13-amd64 -> ocaml/opam:fedora-ocaml-4.13
 4.14.3/arm64
 	# syntax=docker/dockerfile:1
 
@@ -12218,66 +8220,6 @@ ocurrent/opam-staging:fedora-43-ocaml-4.13-arm64, ocurrent/opam-staging:fedora-4
 
 ocurrent/opam-staging:fedora-43-ocaml-4.14-arm64, ocurrent/opam-staging:fedora-43-ocaml-4.14-amd64 -> ocaml/opam:fedora-43-ocaml-4.14
 ocurrent/opam-staging:fedora-43-ocaml-4.14-arm64, ocurrent/opam-staging:fedora-43-ocaml-4.14-amd64 -> ocaml/opam:fedora-ocaml-4.14
-5.0.0/arm64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:fedora-43-opam-arm64
-	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 5.0 --packages=ocaml-base-compiler.5.0.0
-	RUN opam pin add -k version ocaml-base-compiler 5.0.0
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-5.0.0/amd64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:fedora-43-opam-amd64
-	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 5.0 --packages=ocaml-base-compiler.5.0.0
-	RUN opam pin add -k version ocaml-base-compiler 5.0.0
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-ocurrent/opam-staging:fedora-43-ocaml-5.0-arm64, ocurrent/opam-staging:fedora-43-ocaml-5.0-amd64 -> ocaml/opam:fedora-43-ocaml-5.0
-ocurrent/opam-staging:fedora-43-ocaml-5.0-arm64, ocurrent/opam-staging:fedora-43-ocaml-5.0-amd64 -> ocaml/opam:fedora-ocaml-5.0
-5.1.1/arm64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:fedora-43-opam-arm64
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	USER root
-	RUN yum install -y zstd && yum clean packages
-	USER opam
-	RUN opam switch create 5.1 --packages=ocaml-base-compiler.5.1.1
-	RUN opam pin add -k version ocaml-base-compiler 5.1.1
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-5.1.1/amd64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:fedora-43-opam-amd64
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	USER root
-	RUN yum install -y zstd && yum clean packages
-	USER opam
-	RUN opam switch create 5.1 --packages=ocaml-base-compiler.5.1.1
-	RUN opam pin add -k version ocaml-base-compiler 5.1.1
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-ocurrent/opam-staging:fedora-43-ocaml-5.1-arm64, ocurrent/opam-staging:fedora-43-ocaml-5.1-amd64 -> ocaml/opam:fedora-43-ocaml-5.1
-ocurrent/opam-staging:fedora-43-ocaml-5.1-arm64, ocurrent/opam-staging:fedora-43-ocaml-5.1-amd64 -> ocaml/opam:fedora-ocaml-5.1
 5.2.1/arm64
 	# syntax=docker/dockerfile:1
 
@@ -12577,34 +8519,6 @@ ocurrent/opam-staging:oraclelinux-10-opam-amd64 -> ocaml/opam:oraclelinux-10-opa
 
 ocurrent/opam-staging:oraclelinux-10-ocaml-4.08-amd64 -> ocaml/opam:oraclelinux-10-ocaml-4.08
 ocurrent/opam-staging:oraclelinux-10-ocaml-4.08-amd64 -> ocaml/opam:oraclelinux-ocaml-4.08
-4.09.1/amd64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:oraclelinux-10-opam-amd64
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.09 --packages=ocaml-base-compiler.4.09.1
-	RUN opam pin add -k version ocaml-base-compiler 4.09.1
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-ocurrent/opam-staging:oraclelinux-10-ocaml-4.09-amd64 -> ocaml/opam:oraclelinux-10-ocaml-4.09
-ocurrent/opam-staging:oraclelinux-10-ocaml-4.09-amd64 -> ocaml/opam:oraclelinux-ocaml-4.09
-4.10.2/amd64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:oraclelinux-10-opam-amd64
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.10 --packages=ocaml-base-compiler.4.10.2
-	RUN opam pin add -k version ocaml-base-compiler 4.10.2
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-ocurrent/opam-staging:oraclelinux-10-ocaml-4.10-amd64 -> ocaml/opam:oraclelinux-10-ocaml-4.10
-ocurrent/opam-staging:oraclelinux-10-ocaml-4.10-amd64 -> ocaml/opam:oraclelinux-ocaml-4.10
 4.11.2/amd64
 	# syntax=docker/dockerfile:1
 
@@ -12619,34 +8533,6 @@ ocurrent/opam-staging:oraclelinux-10-ocaml-4.10-amd64 -> ocaml/opam:oraclelinux-
 
 ocurrent/opam-staging:oraclelinux-10-ocaml-4.11-amd64 -> ocaml/opam:oraclelinux-10-ocaml-4.11
 ocurrent/opam-staging:oraclelinux-10-ocaml-4.11-amd64 -> ocaml/opam:oraclelinux-ocaml-4.11
-4.12.1/amd64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:oraclelinux-10-opam-amd64
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.12 --packages=ocaml-base-compiler.4.12.1
-	RUN opam pin add -k version ocaml-base-compiler 4.12.1
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-ocurrent/opam-staging:oraclelinux-10-ocaml-4.12-amd64 -> ocaml/opam:oraclelinux-10-ocaml-4.12
-ocurrent/opam-staging:oraclelinux-10-ocaml-4.12-amd64 -> ocaml/opam:oraclelinux-ocaml-4.12
-4.13.1/amd64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:oraclelinux-10-opam-amd64
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.13 --packages=ocaml-base-compiler.4.13.1
-	RUN opam pin add -k version ocaml-base-compiler 4.13.1
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-ocurrent/opam-staging:oraclelinux-10-ocaml-4.13-amd64 -> ocaml/opam:oraclelinux-10-ocaml-4.13
-ocurrent/opam-staging:oraclelinux-10-ocaml-4.13-amd64 -> ocaml/opam:oraclelinux-ocaml-4.13
 4.14.3/amd64
 	# syntax=docker/dockerfile:1
 
@@ -12661,37 +8547,6 @@ ocurrent/opam-staging:oraclelinux-10-ocaml-4.13-amd64 -> ocaml/opam:oraclelinux-
 
 ocurrent/opam-staging:oraclelinux-10-ocaml-4.14-amd64 -> ocaml/opam:oraclelinux-10-ocaml-4.14
 ocurrent/opam-staging:oraclelinux-10-ocaml-4.14-amd64 -> ocaml/opam:oraclelinux-ocaml-4.14
-5.0.0/amd64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:oraclelinux-10-opam-amd64
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 5.0 --packages=ocaml-base-compiler.5.0.0
-	RUN opam pin add -k version ocaml-base-compiler 5.0.0
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-ocurrent/opam-staging:oraclelinux-10-ocaml-5.0-amd64 -> ocaml/opam:oraclelinux-10-ocaml-5.0
-ocurrent/opam-staging:oraclelinux-10-ocaml-5.0-amd64 -> ocaml/opam:oraclelinux-ocaml-5.0
-5.1.1/amd64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:oraclelinux-10-opam-amd64
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	USER root
-	RUN yum install -y zstd && yum clean packages
-	USER opam
-	RUN opam switch create 5.1 --packages=ocaml-base-compiler.5.1.1
-	RUN opam pin add -k version ocaml-base-compiler 5.1.1
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-ocurrent/opam-staging:oraclelinux-10-ocaml-5.1-amd64 -> ocaml/opam:oraclelinux-10-ocaml-5.1
-ocurrent/opam-staging:oraclelinux-10-ocaml-5.1-amd64 -> ocaml/opam:oraclelinux-ocaml-5.1
 5.2.1/amd64
 	# syntax=docker/dockerfile:1
 
@@ -12992,60 +8847,6 @@ ocurrent/opam-staging:opensuse-15.6-opam-arm64, ocurrent/opam-staging:opensuse-1
 	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
 
 ocurrent/opam-staging:opensuse-15.6-ocaml-4.08-arm64, ocurrent/opam-staging:opensuse-15.6-ocaml-4.08-amd64 -> ocaml/opam:opensuse-15.6-ocaml-4.08
-4.09.1/arm64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:opensuse-15.6-opam-arm64
-	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.09 --packages=ocaml-base-compiler.4.09.1
-	RUN opam pin add -k version ocaml-base-compiler 4.09.1
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.09.1/amd64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:opensuse-15.6-opam-amd64
-	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.09 --packages=ocaml-base-compiler.4.09.1
-	RUN opam pin add -k version ocaml-base-compiler 4.09.1
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-ocurrent/opam-staging:opensuse-15.6-ocaml-4.09-arm64, ocurrent/opam-staging:opensuse-15.6-ocaml-4.09-amd64 -> ocaml/opam:opensuse-15.6-ocaml-4.09
-4.10.2/arm64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:opensuse-15.6-opam-arm64
-	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.10 --packages=ocaml-base-compiler.4.10.2
-	RUN opam pin add -k version ocaml-base-compiler 4.10.2
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.10.2/amd64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:opensuse-15.6-opam-amd64
-	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.10 --packages=ocaml-base-compiler.4.10.2
-	RUN opam pin add -k version ocaml-base-compiler 4.10.2
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-ocurrent/opam-staging:opensuse-15.6-ocaml-4.10-arm64, ocurrent/opam-staging:opensuse-15.6-ocaml-4.10-amd64 -> ocaml/opam:opensuse-15.6-ocaml-4.10
 4.11.2/arm64
 	# syntax=docker/dockerfile:1
 
@@ -13073,60 +8874,6 @@ ocurrent/opam-staging:opensuse-15.6-ocaml-4.10-arm64, ocurrent/opam-staging:open
 	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
 
 ocurrent/opam-staging:opensuse-15.6-ocaml-4.11-arm64, ocurrent/opam-staging:opensuse-15.6-ocaml-4.11-amd64 -> ocaml/opam:opensuse-15.6-ocaml-4.11
-4.12.1/arm64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:opensuse-15.6-opam-arm64
-	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.12 --packages=ocaml-base-compiler.4.12.1
-	RUN opam pin add -k version ocaml-base-compiler 4.12.1
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.12.1/amd64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:opensuse-15.6-opam-amd64
-	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.12 --packages=ocaml-base-compiler.4.12.1
-	RUN opam pin add -k version ocaml-base-compiler 4.12.1
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-ocurrent/opam-staging:opensuse-15.6-ocaml-4.12-arm64, ocurrent/opam-staging:opensuse-15.6-ocaml-4.12-amd64 -> ocaml/opam:opensuse-15.6-ocaml-4.12
-4.13.1/arm64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:opensuse-15.6-opam-arm64
-	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.13 --packages=ocaml-base-compiler.4.13.1
-	RUN opam pin add -k version ocaml-base-compiler 4.13.1
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.13.1/amd64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:opensuse-15.6-opam-amd64
-	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.13 --packages=ocaml-base-compiler.4.13.1
-	RUN opam pin add -k version ocaml-base-compiler 4.13.1
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-ocurrent/opam-staging:opensuse-15.6-ocaml-4.13-arm64, ocurrent/opam-staging:opensuse-15.6-ocaml-4.13-amd64 -> ocaml/opam:opensuse-15.6-ocaml-4.13
 4.14.3/arm64
 	# syntax=docker/dockerfile:1
 
@@ -13154,68 +8901,6 @@ ocurrent/opam-staging:opensuse-15.6-ocaml-4.13-arm64, ocurrent/opam-staging:open
 	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
 
 ocurrent/opam-staging:opensuse-15.6-ocaml-4.14-arm64, ocurrent/opam-staging:opensuse-15.6-ocaml-4.14-amd64 -> ocaml/opam:opensuse-15.6-ocaml-4.14
-5.0.0/arm64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:opensuse-15.6-opam-arm64
-	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 5.0 --packages=ocaml-base-compiler.5.0.0
-	RUN opam pin add -k version ocaml-base-compiler 5.0.0
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-5.0.0/amd64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:opensuse-15.6-opam-amd64
-	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 5.0 --packages=ocaml-base-compiler.5.0.0
-	RUN opam pin add -k version ocaml-base-compiler 5.0.0
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-ocurrent/opam-staging:opensuse-15.6-ocaml-5.0-arm64, ocurrent/opam-staging:opensuse-15.6-ocaml-5.0-amd64 -> ocaml/opam:opensuse-15.6-ocaml-5.0
-5.1.1/arm64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:opensuse-15.6-opam-arm64
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	USER root
-	RUN zypper repos repo-openh264 && zypper removerepo repo-openh264 || true
-	RUN zypper update -y
-	RUN zypper install --force-resolution -y zstd
-	USER opam
-	RUN opam switch create 5.1 --packages=ocaml-base-compiler.5.1.1
-	RUN opam pin add -k version ocaml-base-compiler 5.1.1
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-5.1.1/amd64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:opensuse-15.6-opam-amd64
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	USER root
-	RUN zypper repos repo-openh264 && zypper removerepo repo-openh264 || true
-	RUN zypper update -y
-	RUN zypper install --force-resolution -y zstd
-	USER opam
-	RUN opam switch create 5.1 --packages=ocaml-base-compiler.5.1.1
-	RUN opam pin add -k version ocaml-base-compiler 5.1.1
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-ocurrent/opam-staging:opensuse-15.6-ocaml-5.1-arm64, ocurrent/opam-staging:opensuse-15.6-ocaml-5.1-amd64 -> ocaml/opam:opensuse-15.6-ocaml-5.1
 5.2.1/arm64
 	# syntax=docker/dockerfile:1
 
@@ -13627,62 +9312,6 @@ ocurrent/opam-staging:opensuse-16.0-opam-arm64, ocurrent/opam-staging:opensuse-1
 
 ocurrent/opam-staging:opensuse-16.0-ocaml-4.08-arm64, ocurrent/opam-staging:opensuse-16.0-ocaml-4.08-amd64 -> ocaml/opam:opensuse-16.0-ocaml-4.08
 ocurrent/opam-staging:opensuse-16.0-ocaml-4.08-arm64, ocurrent/opam-staging:opensuse-16.0-ocaml-4.08-amd64 -> ocaml/opam:opensuse-ocaml-4.08
-4.09.1/arm64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:opensuse-16.0-opam-arm64
-	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.09 --packages=ocaml-base-compiler.4.09.1
-	RUN opam pin add -k version ocaml-base-compiler 4.09.1
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.09.1/amd64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:opensuse-16.0-opam-amd64
-	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.09 --packages=ocaml-base-compiler.4.09.1
-	RUN opam pin add -k version ocaml-base-compiler 4.09.1
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-ocurrent/opam-staging:opensuse-16.0-ocaml-4.09-arm64, ocurrent/opam-staging:opensuse-16.0-ocaml-4.09-amd64 -> ocaml/opam:opensuse-16.0-ocaml-4.09
-ocurrent/opam-staging:opensuse-16.0-ocaml-4.09-arm64, ocurrent/opam-staging:opensuse-16.0-ocaml-4.09-amd64 -> ocaml/opam:opensuse-ocaml-4.09
-4.10.2/arm64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:opensuse-16.0-opam-arm64
-	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.10 --packages=ocaml-base-compiler.4.10.2
-	RUN opam pin add -k version ocaml-base-compiler 4.10.2
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.10.2/amd64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:opensuse-16.0-opam-amd64
-	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.10 --packages=ocaml-base-compiler.4.10.2
-	RUN opam pin add -k version ocaml-base-compiler 4.10.2
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-ocurrent/opam-staging:opensuse-16.0-ocaml-4.10-arm64, ocurrent/opam-staging:opensuse-16.0-ocaml-4.10-amd64 -> ocaml/opam:opensuse-16.0-ocaml-4.10
-ocurrent/opam-staging:opensuse-16.0-ocaml-4.10-arm64, ocurrent/opam-staging:opensuse-16.0-ocaml-4.10-amd64 -> ocaml/opam:opensuse-ocaml-4.10
 4.11.2/arm64
 	# syntax=docker/dockerfile:1
 
@@ -13711,62 +9340,6 @@ ocurrent/opam-staging:opensuse-16.0-ocaml-4.10-arm64, ocurrent/opam-staging:open
 
 ocurrent/opam-staging:opensuse-16.0-ocaml-4.11-arm64, ocurrent/opam-staging:opensuse-16.0-ocaml-4.11-amd64 -> ocaml/opam:opensuse-16.0-ocaml-4.11
 ocurrent/opam-staging:opensuse-16.0-ocaml-4.11-arm64, ocurrent/opam-staging:opensuse-16.0-ocaml-4.11-amd64 -> ocaml/opam:opensuse-ocaml-4.11
-4.12.1/arm64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:opensuse-16.0-opam-arm64
-	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.12 --packages=ocaml-base-compiler.4.12.1
-	RUN opam pin add -k version ocaml-base-compiler 4.12.1
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.12.1/amd64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:opensuse-16.0-opam-amd64
-	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.12 --packages=ocaml-base-compiler.4.12.1
-	RUN opam pin add -k version ocaml-base-compiler 4.12.1
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-ocurrent/opam-staging:opensuse-16.0-ocaml-4.12-arm64, ocurrent/opam-staging:opensuse-16.0-ocaml-4.12-amd64 -> ocaml/opam:opensuse-16.0-ocaml-4.12
-ocurrent/opam-staging:opensuse-16.0-ocaml-4.12-arm64, ocurrent/opam-staging:opensuse-16.0-ocaml-4.12-amd64 -> ocaml/opam:opensuse-ocaml-4.12
-4.13.1/arm64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:opensuse-16.0-opam-arm64
-	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.13 --packages=ocaml-base-compiler.4.13.1
-	RUN opam pin add -k version ocaml-base-compiler 4.13.1
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.13.1/amd64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:opensuse-16.0-opam-amd64
-	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.13 --packages=ocaml-base-compiler.4.13.1
-	RUN opam pin add -k version ocaml-base-compiler 4.13.1
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-ocurrent/opam-staging:opensuse-16.0-ocaml-4.13-arm64, ocurrent/opam-staging:opensuse-16.0-ocaml-4.13-amd64 -> ocaml/opam:opensuse-16.0-ocaml-4.13
-ocurrent/opam-staging:opensuse-16.0-ocaml-4.13-arm64, ocurrent/opam-staging:opensuse-16.0-ocaml-4.13-amd64 -> ocaml/opam:opensuse-ocaml-4.13
 4.14.3/arm64
 	# syntax=docker/dockerfile:1
 
@@ -13795,70 +9368,6 @@ ocurrent/opam-staging:opensuse-16.0-ocaml-4.13-arm64, ocurrent/opam-staging:open
 
 ocurrent/opam-staging:opensuse-16.0-ocaml-4.14-arm64, ocurrent/opam-staging:opensuse-16.0-ocaml-4.14-amd64 -> ocaml/opam:opensuse-16.0-ocaml-4.14
 ocurrent/opam-staging:opensuse-16.0-ocaml-4.14-arm64, ocurrent/opam-staging:opensuse-16.0-ocaml-4.14-amd64 -> ocaml/opam:opensuse-ocaml-4.14
-5.0.0/arm64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:opensuse-16.0-opam-arm64
-	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 5.0 --packages=ocaml-base-compiler.5.0.0
-	RUN opam pin add -k version ocaml-base-compiler 5.0.0
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-5.0.0/amd64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:opensuse-16.0-opam-amd64
-	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 5.0 --packages=ocaml-base-compiler.5.0.0
-	RUN opam pin add -k version ocaml-base-compiler 5.0.0
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-ocurrent/opam-staging:opensuse-16.0-ocaml-5.0-arm64, ocurrent/opam-staging:opensuse-16.0-ocaml-5.0-amd64 -> ocaml/opam:opensuse-16.0-ocaml-5.0
-ocurrent/opam-staging:opensuse-16.0-ocaml-5.0-arm64, ocurrent/opam-staging:opensuse-16.0-ocaml-5.0-amd64 -> ocaml/opam:opensuse-ocaml-5.0
-5.1.1/arm64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:opensuse-16.0-opam-arm64
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	USER root
-	RUN zypper repos repo-openh264 && zypper removerepo repo-openh264 || true
-	RUN zypper update -y
-	RUN zypper install --force-resolution -y zstd
-	USER opam
-	RUN opam switch create 5.1 --packages=ocaml-base-compiler.5.1.1
-	RUN opam pin add -k version ocaml-base-compiler 5.1.1
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-5.1.1/amd64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:opensuse-16.0-opam-amd64
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	USER root
-	RUN zypper repos repo-openh264 && zypper removerepo repo-openh264 || true
-	RUN zypper update -y
-	RUN zypper install --force-resolution -y zstd
-	USER opam
-	RUN opam switch create 5.1 --packages=ocaml-base-compiler.5.1.1
-	RUN opam pin add -k version ocaml-base-compiler 5.1.1
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-ocurrent/opam-staging:opensuse-16.0-ocaml-5.1-arm64, ocurrent/opam-staging:opensuse-16.0-ocaml-5.1-amd64 -> ocaml/opam:opensuse-16.0-ocaml-5.1
-ocurrent/opam-staging:opensuse-16.0-ocaml-5.1-arm64, ocurrent/opam-staging:opensuse-16.0-ocaml-5.1-amd64 -> ocaml/opam:opensuse-ocaml-5.1
 5.2.1/arm64
 	# syntax=docker/dockerfile:1
 
@@ -14181,34 +9690,6 @@ ocurrent/opam-staging:opensuse-tumbleweed-opam-amd64 -> ocaml/opam:opensuse-tumb
 	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
 
 ocurrent/opam-staging:opensuse-tumbleweed-ocaml-4.08-amd64 -> ocaml/opam:opensuse-tumbleweed-ocaml-4.08
-4.09.1/amd64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:opensuse-tumbleweed-opam-amd64
-	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.09 --packages=ocaml-base-compiler.4.09.1
-	RUN opam pin add -k version ocaml-base-compiler 4.09.1
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-ocurrent/opam-staging:opensuse-tumbleweed-ocaml-4.09-amd64 -> ocaml/opam:opensuse-tumbleweed-ocaml-4.09
-4.10.2/amd64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:opensuse-tumbleweed-opam-amd64
-	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.10 --packages=ocaml-base-compiler.4.10.2
-	RUN opam pin add -k version ocaml-base-compiler 4.10.2
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-ocurrent/opam-staging:opensuse-tumbleweed-ocaml-4.10-amd64 -> ocaml/opam:opensuse-tumbleweed-ocaml-4.10
 4.11.2/amd64
 	# syntax=docker/dockerfile:1
 
@@ -14223,34 +9704,6 @@ ocurrent/opam-staging:opensuse-tumbleweed-ocaml-4.10-amd64 -> ocaml/opam:opensus
 	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
 
 ocurrent/opam-staging:opensuse-tumbleweed-ocaml-4.11-amd64 -> ocaml/opam:opensuse-tumbleweed-ocaml-4.11
-4.12.1/amd64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:opensuse-tumbleweed-opam-amd64
-	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.12 --packages=ocaml-base-compiler.4.12.1
-	RUN opam pin add -k version ocaml-base-compiler 4.12.1
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-ocurrent/opam-staging:opensuse-tumbleweed-ocaml-4.12-amd64 -> ocaml/opam:opensuse-tumbleweed-ocaml-4.12
-4.13.1/amd64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:opensuse-tumbleweed-opam-amd64
-	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.13 --packages=ocaml-base-compiler.4.13.1
-	RUN opam pin add -k version ocaml-base-compiler 4.13.1
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-ocurrent/opam-staging:opensuse-tumbleweed-ocaml-4.13-amd64 -> ocaml/opam:opensuse-tumbleweed-ocaml-4.13
 4.14.3/amd64
 	# syntax=docker/dockerfile:1
 
@@ -14265,38 +9718,6 @@ ocurrent/opam-staging:opensuse-tumbleweed-ocaml-4.13-amd64 -> ocaml/opam:opensus
 	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
 
 ocurrent/opam-staging:opensuse-tumbleweed-ocaml-4.14-amd64 -> ocaml/opam:opensuse-tumbleweed-ocaml-4.14
-5.0.0/amd64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:opensuse-tumbleweed-opam-amd64
-	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 5.0 --packages=ocaml-base-compiler.5.0.0
-	RUN opam pin add -k version ocaml-base-compiler 5.0.0
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-ocurrent/opam-staging:opensuse-tumbleweed-ocaml-5.0-amd64 -> ocaml/opam:opensuse-tumbleweed-ocaml-5.0
-5.1.1/amd64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:opensuse-tumbleweed-opam-amd64
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	USER root
-	RUN zypper repos repo-openh264 && zypper removerepo repo-openh264 || true
-	RUN zypper update -y
-	RUN zypper install --force-resolution -y zstd
-	USER opam
-	RUN opam switch create 5.1 --packages=ocaml-base-compiler.5.1.1
-	RUN opam pin add -k version ocaml-base-compiler 5.1.1
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-ocurrent/opam-staging:opensuse-tumbleweed-ocaml-5.1-amd64 -> ocaml/opam:opensuse-tumbleweed-ocaml-5.1
 5.2.1/amd64
 	# syntax=docker/dockerfile:1
 
@@ -14885,104 +10306,6 @@ ocurrent/opam-staging:ubuntu-22.04-opam-s390x, ocurrent/opam-staging:ubuntu-22.0
 	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
 
 ocurrent/opam-staging:ubuntu-22.04-ocaml-4.08-s390x, ocurrent/opam-staging:ubuntu-22.04-ocaml-4.08-ppc64le, ocurrent/opam-staging:ubuntu-22.04-ocaml-4.08-arm64, ocurrent/opam-staging:ubuntu-22.04-ocaml-4.08-amd64 -> ocaml/opam:ubuntu-22.04-ocaml-4.08
-4.09.1/s390x
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:ubuntu-22.04-opam-s390x
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.09 --packages=ocaml-base-compiler.4.09.1
-	RUN opam pin add -k version ocaml-base-compiler 4.09.1
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.09.1/ppc64le
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:ubuntu-22.04-opam-ppc64le
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.09 --packages=ocaml-base-compiler.4.09.1
-	RUN opam pin add -k version ocaml-base-compiler 4.09.1
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.09.1/arm64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:ubuntu-22.04-opam-arm64
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.09 --packages=ocaml-base-compiler.4.09.1
-	RUN opam pin add -k version ocaml-base-compiler 4.09.1
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.09.1/amd64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:ubuntu-22.04-opam-amd64
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.09 --packages=ocaml-base-compiler.4.09.1
-	RUN opam pin add -k version ocaml-base-compiler 4.09.1
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-ocurrent/opam-staging:ubuntu-22.04-ocaml-4.09-s390x, ocurrent/opam-staging:ubuntu-22.04-ocaml-4.09-ppc64le, ocurrent/opam-staging:ubuntu-22.04-ocaml-4.09-arm64, ocurrent/opam-staging:ubuntu-22.04-ocaml-4.09-amd64 -> ocaml/opam:ubuntu-22.04-ocaml-4.09
-4.10.2/s390x
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:ubuntu-22.04-opam-s390x
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.10 --packages=ocaml-base-compiler.4.10.2
-	RUN opam pin add -k version ocaml-base-compiler 4.10.2
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.10.2/ppc64le
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:ubuntu-22.04-opam-ppc64le
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.10 --packages=ocaml-base-compiler.4.10.2
-	RUN opam pin add -k version ocaml-base-compiler 4.10.2
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.10.2/arm64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:ubuntu-22.04-opam-arm64
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.10 --packages=ocaml-base-compiler.4.10.2
-	RUN opam pin add -k version ocaml-base-compiler 4.10.2
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.10.2/amd64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:ubuntu-22.04-opam-amd64
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.10 --packages=ocaml-base-compiler.4.10.2
-	RUN opam pin add -k version ocaml-base-compiler 4.10.2
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-ocurrent/opam-staging:ubuntu-22.04-ocaml-4.10-s390x, ocurrent/opam-staging:ubuntu-22.04-ocaml-4.10-ppc64le, ocurrent/opam-staging:ubuntu-22.04-ocaml-4.10-arm64, ocurrent/opam-staging:ubuntu-22.04-ocaml-4.10-amd64 -> ocaml/opam:ubuntu-22.04-ocaml-4.10
 4.11.2/s390x
 	# syntax=docker/dockerfile:1
 
@@ -15044,128 +10367,6 @@ ocurrent/opam-staging:ubuntu-22.04-ocaml-4.10-s390x, ocurrent/opam-staging:ubunt
 	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
 
 ocurrent/opam-staging:ubuntu-22.04-ocaml-4.11-s390x, ocurrent/opam-staging:ubuntu-22.04-ocaml-4.11-ppc64le, ocurrent/opam-staging:ubuntu-22.04-ocaml-4.11-arm64, ocurrent/opam-staging:ubuntu-22.04-ocaml-4.11-amd64, ocurrent/opam-staging:ubuntu-22.04-ocaml-4.11-riscv64 -> ocaml/opam:ubuntu-22.04-ocaml-4.11
-4.12.1/s390x
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:ubuntu-22.04-opam-s390x
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.12 --packages=ocaml-base-compiler.4.12.1
-	RUN opam pin add -k version ocaml-base-compiler 4.12.1
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.12.1/ppc64le
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:ubuntu-22.04-opam-ppc64le
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.12 --packages=ocaml-base-compiler.4.12.1
-	RUN opam pin add -k version ocaml-base-compiler 4.12.1
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.12.1/arm64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:ubuntu-22.04-opam-arm64
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.12 --packages=ocaml-base-compiler.4.12.1
-	RUN opam pin add -k version ocaml-base-compiler 4.12.1
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.12.1/amd64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:ubuntu-22.04-opam-amd64
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.12 --packages=ocaml-base-compiler.4.12.1
-	RUN opam pin add -k version ocaml-base-compiler 4.12.1
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.12.1/riscv64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:ubuntu-22.04-opam-riscv64
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.12 --packages=ocaml-base-compiler.4.12.1
-	RUN opam pin add -k version ocaml-base-compiler 4.12.1
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-ocurrent/opam-staging:ubuntu-22.04-ocaml-4.12-s390x, ocurrent/opam-staging:ubuntu-22.04-ocaml-4.12-ppc64le, ocurrent/opam-staging:ubuntu-22.04-ocaml-4.12-arm64, ocurrent/opam-staging:ubuntu-22.04-ocaml-4.12-amd64, ocurrent/opam-staging:ubuntu-22.04-ocaml-4.12-riscv64 -> ocaml/opam:ubuntu-22.04-ocaml-4.12
-4.13.1/s390x
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:ubuntu-22.04-opam-s390x
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.13 --packages=ocaml-base-compiler.4.13.1
-	RUN opam pin add -k version ocaml-base-compiler 4.13.1
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.13.1/ppc64le
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:ubuntu-22.04-opam-ppc64le
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.13 --packages=ocaml-base-compiler.4.13.1
-	RUN opam pin add -k version ocaml-base-compiler 4.13.1
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.13.1/arm64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:ubuntu-22.04-opam-arm64
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.13 --packages=ocaml-base-compiler.4.13.1
-	RUN opam pin add -k version ocaml-base-compiler 4.13.1
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.13.1/amd64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:ubuntu-22.04-opam-amd64
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.13 --packages=ocaml-base-compiler.4.13.1
-	RUN opam pin add -k version ocaml-base-compiler 4.13.1
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.13.1/riscv64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:ubuntu-22.04-opam-riscv64
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.13 --packages=ocaml-base-compiler.4.13.1
-	RUN opam pin add -k version ocaml-base-compiler 4.13.1
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-ocurrent/opam-staging:ubuntu-22.04-ocaml-4.13-s390x, ocurrent/opam-staging:ubuntu-22.04-ocaml-4.13-ppc64le, ocurrent/opam-staging:ubuntu-22.04-ocaml-4.13-arm64, ocurrent/opam-staging:ubuntu-22.04-ocaml-4.13-amd64, ocurrent/opam-staging:ubuntu-22.04-ocaml-4.13-riscv64 -> ocaml/opam:ubuntu-22.04-ocaml-4.13
 4.14.3/s390x
 	# syntax=docker/dockerfile:1
 
@@ -15227,153 +10428,6 @@ ocurrent/opam-staging:ubuntu-22.04-ocaml-4.13-s390x, ocurrent/opam-staging:ubunt
 	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
 
 ocurrent/opam-staging:ubuntu-22.04-ocaml-4.14-s390x, ocurrent/opam-staging:ubuntu-22.04-ocaml-4.14-ppc64le, ocurrent/opam-staging:ubuntu-22.04-ocaml-4.14-arm64, ocurrent/opam-staging:ubuntu-22.04-ocaml-4.14-amd64, ocurrent/opam-staging:ubuntu-22.04-ocaml-4.14-riscv64 -> ocaml/opam:ubuntu-22.04-ocaml-4.14
-5.0.0/s390x
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:ubuntu-22.04-opam-s390x
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 5.0 --packages=ocaml-base-compiler.5.0.0
-	RUN opam pin add -k version ocaml-base-compiler 5.0.0
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-5.0.0/ppc64le
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:ubuntu-22.04-opam-ppc64le
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 5.0 --packages=ocaml-base-compiler.5.0.0
-	RUN opam pin add -k version ocaml-base-compiler 5.0.0
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-5.0.0/arm64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:ubuntu-22.04-opam-arm64
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 5.0 --packages=ocaml-base-compiler.5.0.0
-	RUN opam pin add -k version ocaml-base-compiler 5.0.0
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-5.0.0/amd64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:ubuntu-22.04-opam-amd64
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 5.0 --packages=ocaml-base-compiler.5.0.0
-	RUN opam pin add -k version ocaml-base-compiler 5.0.0
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-5.0.0/riscv64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:ubuntu-22.04-opam-riscv64
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 5.0 --packages=ocaml-base-compiler.5.0.0
-	RUN opam pin add -k version ocaml-base-compiler 5.0.0
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-ocurrent/opam-staging:ubuntu-22.04-ocaml-5.0-s390x, ocurrent/opam-staging:ubuntu-22.04-ocaml-5.0-ppc64le, ocurrent/opam-staging:ubuntu-22.04-ocaml-5.0-arm64, ocurrent/opam-staging:ubuntu-22.04-ocaml-5.0-amd64, ocurrent/opam-staging:ubuntu-22.04-ocaml-5.0-riscv64 -> ocaml/opam:ubuntu-22.04-ocaml-5.0
-5.1.1/s390x
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:ubuntu-22.04-opam-s390x
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	USER root
-	RUN apt-get -y update
-	RUN DEBIAN_FRONTEND=noninteractive apt-get -y upgrade
-	RUN DEBIAN_FRONTEND=noninteractive apt-get -y install libzstd-dev
-	USER opam
-	RUN opam switch create 5.1 --packages=ocaml-base-compiler.5.1.1
-	RUN opam pin add -k version ocaml-base-compiler 5.1.1
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-5.1.1/ppc64le
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:ubuntu-22.04-opam-ppc64le
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	USER root
-	RUN apt-get -y update
-	RUN DEBIAN_FRONTEND=noninteractive apt-get -y upgrade
-	RUN DEBIAN_FRONTEND=noninteractive apt-get -y install libzstd-dev
-	USER opam
-	RUN opam switch create 5.1 --packages=ocaml-base-compiler.5.1.1
-	RUN opam pin add -k version ocaml-base-compiler 5.1.1
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-5.1.1/arm64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:ubuntu-22.04-opam-arm64
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	USER root
-	RUN apt-get -y update
-	RUN DEBIAN_FRONTEND=noninteractive apt-get -y upgrade
-	RUN DEBIAN_FRONTEND=noninteractive apt-get -y install libzstd-dev
-	USER opam
-	RUN opam switch create 5.1 --packages=ocaml-base-compiler.5.1.1
-	RUN opam pin add -k version ocaml-base-compiler 5.1.1
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-5.1.1/amd64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:ubuntu-22.04-opam-amd64
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	USER root
-	RUN apt-get -y update
-	RUN DEBIAN_FRONTEND=noninteractive apt-get -y upgrade
-	RUN DEBIAN_FRONTEND=noninteractive apt-get -y install libzstd-dev
-	USER opam
-	RUN opam switch create 5.1 --packages=ocaml-base-compiler.5.1.1
-	RUN opam pin add -k version ocaml-base-compiler 5.1.1
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-5.1.1/riscv64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:ubuntu-22.04-opam-riscv64
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	USER root
-	RUN apt-get -y update
-	RUN DEBIAN_FRONTEND=noninteractive apt-get -y upgrade
-	RUN DEBIAN_FRONTEND=noninteractive apt-get -y install libzstd-dev
-	USER opam
-	RUN opam switch create 5.1 --packages=ocaml-base-compiler.5.1.1
-	RUN opam pin add -k version ocaml-base-compiler 5.1.1
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-ocurrent/opam-staging:ubuntu-22.04-ocaml-5.1-s390x, ocurrent/opam-staging:ubuntu-22.04-ocaml-5.1-ppc64le, ocurrent/opam-staging:ubuntu-22.04-ocaml-5.1-arm64, ocurrent/opam-staging:ubuntu-22.04-ocaml-5.1-amd64, ocurrent/opam-staging:ubuntu-22.04-ocaml-5.1-riscv64 -> ocaml/opam:ubuntu-22.04-ocaml-5.1
 5.2.1/s390x
 	# syntax=docker/dockerfile:1
 
@@ -16382,107 +11436,6 @@ ocurrent/opam-staging:ubuntu-24.04-opam-s390x, ocurrent/opam-staging:ubuntu-24.0
 	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
 
 ocurrent/opam-staging:ubuntu-24.04-ocaml-4.08-s390x, ocurrent/opam-staging:ubuntu-24.04-ocaml-4.08-ppc64le, ocurrent/opam-staging:ubuntu-24.04-ocaml-4.08-arm64, ocurrent/opam-staging:ubuntu-24.04-ocaml-4.08-amd64 -> ocaml/opam:ubuntu-24.04-ocaml-4.08
-ocurrent/opam-staging:ubuntu-24.04-ocaml-4.08-s390x, ocurrent/opam-staging:ubuntu-24.04-ocaml-4.08-ppc64le, ocurrent/opam-staging:ubuntu-24.04-ocaml-4.08-arm64, ocurrent/opam-staging:ubuntu-24.04-ocaml-4.08-amd64 -> ocaml/opam:ubuntu-lts-ocaml-4.08
-4.09.1/s390x
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:ubuntu-24.04-opam-s390x
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.09 --packages=ocaml-base-compiler.4.09.1
-	RUN opam pin add -k version ocaml-base-compiler 4.09.1
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.09.1/ppc64le
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:ubuntu-24.04-opam-ppc64le
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.09 --packages=ocaml-base-compiler.4.09.1
-	RUN opam pin add -k version ocaml-base-compiler 4.09.1
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.09.1/arm64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:ubuntu-24.04-opam-arm64
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.09 --packages=ocaml-base-compiler.4.09.1
-	RUN opam pin add -k version ocaml-base-compiler 4.09.1
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.09.1/amd64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:ubuntu-24.04-opam-amd64
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.09 --packages=ocaml-base-compiler.4.09.1
-	RUN opam pin add -k version ocaml-base-compiler 4.09.1
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-ocurrent/opam-staging:ubuntu-24.04-ocaml-4.09-s390x, ocurrent/opam-staging:ubuntu-24.04-ocaml-4.09-ppc64le, ocurrent/opam-staging:ubuntu-24.04-ocaml-4.09-arm64, ocurrent/opam-staging:ubuntu-24.04-ocaml-4.09-amd64 -> ocaml/opam:ubuntu-24.04-ocaml-4.09
-ocurrent/opam-staging:ubuntu-24.04-ocaml-4.09-s390x, ocurrent/opam-staging:ubuntu-24.04-ocaml-4.09-ppc64le, ocurrent/opam-staging:ubuntu-24.04-ocaml-4.09-arm64, ocurrent/opam-staging:ubuntu-24.04-ocaml-4.09-amd64 -> ocaml/opam:ubuntu-lts-ocaml-4.09
-4.10.2/s390x
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:ubuntu-24.04-opam-s390x
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.10 --packages=ocaml-base-compiler.4.10.2
-	RUN opam pin add -k version ocaml-base-compiler 4.10.2
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.10.2/ppc64le
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:ubuntu-24.04-opam-ppc64le
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.10 --packages=ocaml-base-compiler.4.10.2
-	RUN opam pin add -k version ocaml-base-compiler 4.10.2
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.10.2/arm64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:ubuntu-24.04-opam-arm64
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.10 --packages=ocaml-base-compiler.4.10.2
-	RUN opam pin add -k version ocaml-base-compiler 4.10.2
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.10.2/amd64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:ubuntu-24.04-opam-amd64
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.10 --packages=ocaml-base-compiler.4.10.2
-	RUN opam pin add -k version ocaml-base-compiler 4.10.2
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-ocurrent/opam-staging:ubuntu-24.04-ocaml-4.10-s390x, ocurrent/opam-staging:ubuntu-24.04-ocaml-4.10-ppc64le, ocurrent/opam-staging:ubuntu-24.04-ocaml-4.10-arm64, ocurrent/opam-staging:ubuntu-24.04-ocaml-4.10-amd64 -> ocaml/opam:ubuntu-24.04-ocaml-4.10
-ocurrent/opam-staging:ubuntu-24.04-ocaml-4.10-s390x, ocurrent/opam-staging:ubuntu-24.04-ocaml-4.10-ppc64le, ocurrent/opam-staging:ubuntu-24.04-ocaml-4.10-arm64, ocurrent/opam-staging:ubuntu-24.04-ocaml-4.10-amd64 -> ocaml/opam:ubuntu-lts-ocaml-4.10
 4.11.2/s390x
 	# syntax=docker/dockerfile:1
 
@@ -16544,131 +11497,6 @@ ocurrent/opam-staging:ubuntu-24.04-ocaml-4.10-s390x, ocurrent/opam-staging:ubunt
 	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
 
 ocurrent/opam-staging:ubuntu-24.04-ocaml-4.11-s390x, ocurrent/opam-staging:ubuntu-24.04-ocaml-4.11-ppc64le, ocurrent/opam-staging:ubuntu-24.04-ocaml-4.11-arm64, ocurrent/opam-staging:ubuntu-24.04-ocaml-4.11-amd64, ocurrent/opam-staging:ubuntu-24.04-ocaml-4.11-riscv64 -> ocaml/opam:ubuntu-24.04-ocaml-4.11
-ocurrent/opam-staging:ubuntu-24.04-ocaml-4.11-s390x, ocurrent/opam-staging:ubuntu-24.04-ocaml-4.11-ppc64le, ocurrent/opam-staging:ubuntu-24.04-ocaml-4.11-arm64, ocurrent/opam-staging:ubuntu-24.04-ocaml-4.11-amd64, ocurrent/opam-staging:ubuntu-24.04-ocaml-4.11-riscv64 -> ocaml/opam:ubuntu-lts-ocaml-4.11
-4.12.1/s390x
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:ubuntu-24.04-opam-s390x
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.12 --packages=ocaml-base-compiler.4.12.1
-	RUN opam pin add -k version ocaml-base-compiler 4.12.1
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.12.1/ppc64le
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:ubuntu-24.04-opam-ppc64le
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.12 --packages=ocaml-base-compiler.4.12.1
-	RUN opam pin add -k version ocaml-base-compiler 4.12.1
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.12.1/arm64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:ubuntu-24.04-opam-arm64
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.12 --packages=ocaml-base-compiler.4.12.1
-	RUN opam pin add -k version ocaml-base-compiler 4.12.1
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.12.1/amd64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:ubuntu-24.04-opam-amd64
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.12 --packages=ocaml-base-compiler.4.12.1
-	RUN opam pin add -k version ocaml-base-compiler 4.12.1
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.12.1/riscv64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:ubuntu-24.04-opam-riscv64
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.12 --packages=ocaml-base-compiler.4.12.1
-	RUN opam pin add -k version ocaml-base-compiler 4.12.1
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-ocurrent/opam-staging:ubuntu-24.04-ocaml-4.12-s390x, ocurrent/opam-staging:ubuntu-24.04-ocaml-4.12-ppc64le, ocurrent/opam-staging:ubuntu-24.04-ocaml-4.12-arm64, ocurrent/opam-staging:ubuntu-24.04-ocaml-4.12-amd64, ocurrent/opam-staging:ubuntu-24.04-ocaml-4.12-riscv64 -> ocaml/opam:ubuntu-24.04-ocaml-4.12
-ocurrent/opam-staging:ubuntu-24.04-ocaml-4.12-s390x, ocurrent/opam-staging:ubuntu-24.04-ocaml-4.12-ppc64le, ocurrent/opam-staging:ubuntu-24.04-ocaml-4.12-arm64, ocurrent/opam-staging:ubuntu-24.04-ocaml-4.12-amd64, ocurrent/opam-staging:ubuntu-24.04-ocaml-4.12-riscv64 -> ocaml/opam:ubuntu-lts-ocaml-4.12
-4.13.1/s390x
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:ubuntu-24.04-opam-s390x
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.13 --packages=ocaml-base-compiler.4.13.1
-	RUN opam pin add -k version ocaml-base-compiler 4.13.1
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.13.1/ppc64le
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:ubuntu-24.04-opam-ppc64le
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.13 --packages=ocaml-base-compiler.4.13.1
-	RUN opam pin add -k version ocaml-base-compiler 4.13.1
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.13.1/arm64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:ubuntu-24.04-opam-arm64
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.13 --packages=ocaml-base-compiler.4.13.1
-	RUN opam pin add -k version ocaml-base-compiler 4.13.1
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.13.1/amd64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:ubuntu-24.04-opam-amd64
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.13 --packages=ocaml-base-compiler.4.13.1
-	RUN opam pin add -k version ocaml-base-compiler 4.13.1
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.13.1/riscv64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:ubuntu-24.04-opam-riscv64
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.13 --packages=ocaml-base-compiler.4.13.1
-	RUN opam pin add -k version ocaml-base-compiler 4.13.1
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-ocurrent/opam-staging:ubuntu-24.04-ocaml-4.13-s390x, ocurrent/opam-staging:ubuntu-24.04-ocaml-4.13-ppc64le, ocurrent/opam-staging:ubuntu-24.04-ocaml-4.13-arm64, ocurrent/opam-staging:ubuntu-24.04-ocaml-4.13-amd64, ocurrent/opam-staging:ubuntu-24.04-ocaml-4.13-riscv64 -> ocaml/opam:ubuntu-24.04-ocaml-4.13
-ocurrent/opam-staging:ubuntu-24.04-ocaml-4.13-s390x, ocurrent/opam-staging:ubuntu-24.04-ocaml-4.13-ppc64le, ocurrent/opam-staging:ubuntu-24.04-ocaml-4.13-arm64, ocurrent/opam-staging:ubuntu-24.04-ocaml-4.13-amd64, ocurrent/opam-staging:ubuntu-24.04-ocaml-4.13-riscv64 -> ocaml/opam:ubuntu-lts-ocaml-4.13
 4.14.3/s390x
 	# syntax=docker/dockerfile:1
 
@@ -16730,156 +11558,6 @@ ocurrent/opam-staging:ubuntu-24.04-ocaml-4.13-s390x, ocurrent/opam-staging:ubunt
 	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
 
 ocurrent/opam-staging:ubuntu-24.04-ocaml-4.14-s390x, ocurrent/opam-staging:ubuntu-24.04-ocaml-4.14-ppc64le, ocurrent/opam-staging:ubuntu-24.04-ocaml-4.14-arm64, ocurrent/opam-staging:ubuntu-24.04-ocaml-4.14-amd64, ocurrent/opam-staging:ubuntu-24.04-ocaml-4.14-riscv64 -> ocaml/opam:ubuntu-24.04-ocaml-4.14
-ocurrent/opam-staging:ubuntu-24.04-ocaml-4.14-s390x, ocurrent/opam-staging:ubuntu-24.04-ocaml-4.14-ppc64le, ocurrent/opam-staging:ubuntu-24.04-ocaml-4.14-arm64, ocurrent/opam-staging:ubuntu-24.04-ocaml-4.14-amd64, ocurrent/opam-staging:ubuntu-24.04-ocaml-4.14-riscv64 -> ocaml/opam:ubuntu-lts-ocaml-4.14
-5.0.0/s390x
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:ubuntu-24.04-opam-s390x
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 5.0 --packages=ocaml-base-compiler.5.0.0
-	RUN opam pin add -k version ocaml-base-compiler 5.0.0
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-5.0.0/ppc64le
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:ubuntu-24.04-opam-ppc64le
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 5.0 --packages=ocaml-base-compiler.5.0.0
-	RUN opam pin add -k version ocaml-base-compiler 5.0.0
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-5.0.0/arm64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:ubuntu-24.04-opam-arm64
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 5.0 --packages=ocaml-base-compiler.5.0.0
-	RUN opam pin add -k version ocaml-base-compiler 5.0.0
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-5.0.0/amd64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:ubuntu-24.04-opam-amd64
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 5.0 --packages=ocaml-base-compiler.5.0.0
-	RUN opam pin add -k version ocaml-base-compiler 5.0.0
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-5.0.0/riscv64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:ubuntu-24.04-opam-riscv64
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 5.0 --packages=ocaml-base-compiler.5.0.0
-	RUN opam pin add -k version ocaml-base-compiler 5.0.0
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-ocurrent/opam-staging:ubuntu-24.04-ocaml-5.0-s390x, ocurrent/opam-staging:ubuntu-24.04-ocaml-5.0-ppc64le, ocurrent/opam-staging:ubuntu-24.04-ocaml-5.0-arm64, ocurrent/opam-staging:ubuntu-24.04-ocaml-5.0-amd64, ocurrent/opam-staging:ubuntu-24.04-ocaml-5.0-riscv64 -> ocaml/opam:ubuntu-24.04-ocaml-5.0
-ocurrent/opam-staging:ubuntu-24.04-ocaml-5.0-s390x, ocurrent/opam-staging:ubuntu-24.04-ocaml-5.0-ppc64le, ocurrent/opam-staging:ubuntu-24.04-ocaml-5.0-arm64, ocurrent/opam-staging:ubuntu-24.04-ocaml-5.0-amd64, ocurrent/opam-staging:ubuntu-24.04-ocaml-5.0-riscv64 -> ocaml/opam:ubuntu-lts-ocaml-5.0
-5.1.1/s390x
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:ubuntu-24.04-opam-s390x
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	USER root
-	RUN apt-get -y update
-	RUN DEBIAN_FRONTEND=noninteractive apt-get -y upgrade
-	RUN DEBIAN_FRONTEND=noninteractive apt-get -y install libzstd-dev
-	USER opam
-	RUN opam switch create 5.1 --packages=ocaml-base-compiler.5.1.1
-	RUN opam pin add -k version ocaml-base-compiler 5.1.1
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-5.1.1/ppc64le
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:ubuntu-24.04-opam-ppc64le
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	USER root
-	RUN apt-get -y update
-	RUN DEBIAN_FRONTEND=noninteractive apt-get -y upgrade
-	RUN DEBIAN_FRONTEND=noninteractive apt-get -y install libzstd-dev
-	USER opam
-	RUN opam switch create 5.1 --packages=ocaml-base-compiler.5.1.1
-	RUN opam pin add -k version ocaml-base-compiler 5.1.1
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-5.1.1/arm64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:ubuntu-24.04-opam-arm64
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	USER root
-	RUN apt-get -y update
-	RUN DEBIAN_FRONTEND=noninteractive apt-get -y upgrade
-	RUN DEBIAN_FRONTEND=noninteractive apt-get -y install libzstd-dev
-	USER opam
-	RUN opam switch create 5.1 --packages=ocaml-base-compiler.5.1.1
-	RUN opam pin add -k version ocaml-base-compiler 5.1.1
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-5.1.1/amd64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:ubuntu-24.04-opam-amd64
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	USER root
-	RUN apt-get -y update
-	RUN DEBIAN_FRONTEND=noninteractive apt-get -y upgrade
-	RUN DEBIAN_FRONTEND=noninteractive apt-get -y install libzstd-dev
-	USER opam
-	RUN opam switch create 5.1 --packages=ocaml-base-compiler.5.1.1
-	RUN opam pin add -k version ocaml-base-compiler 5.1.1
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-5.1.1/riscv64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:ubuntu-24.04-opam-riscv64
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	USER root
-	RUN apt-get -y update
-	RUN DEBIAN_FRONTEND=noninteractive apt-get -y upgrade
-	RUN DEBIAN_FRONTEND=noninteractive apt-get -y install libzstd-dev
-	USER opam
-	RUN opam switch create 5.1 --packages=ocaml-base-compiler.5.1.1
-	RUN opam pin add -k version ocaml-base-compiler 5.1.1
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-ocurrent/opam-staging:ubuntu-24.04-ocaml-5.1-s390x, ocurrent/opam-staging:ubuntu-24.04-ocaml-5.1-ppc64le, ocurrent/opam-staging:ubuntu-24.04-ocaml-5.1-arm64, ocurrent/opam-staging:ubuntu-24.04-ocaml-5.1-amd64, ocurrent/opam-staging:ubuntu-24.04-ocaml-5.1-riscv64 -> ocaml/opam:ubuntu-24.04-ocaml-5.1
-ocurrent/opam-staging:ubuntu-24.04-ocaml-5.1-s390x, ocurrent/opam-staging:ubuntu-24.04-ocaml-5.1-ppc64le, ocurrent/opam-staging:ubuntu-24.04-ocaml-5.1-arm64, ocurrent/opam-staging:ubuntu-24.04-ocaml-5.1-amd64, ocurrent/opam-staging:ubuntu-24.04-ocaml-5.1-riscv64 -> ocaml/opam:ubuntu-lts-ocaml-5.1
 5.2.1/s390x
 	# syntax=docker/dockerfile:1
 
@@ -16966,7 +11644,6 @@ ocurrent/opam-staging:ubuntu-24.04-ocaml-5.1-s390x, ocurrent/opam-staging:ubuntu
 	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
 
 ocurrent/opam-staging:ubuntu-24.04-ocaml-5.2-s390x, ocurrent/opam-staging:ubuntu-24.04-ocaml-5.2-ppc64le, ocurrent/opam-staging:ubuntu-24.04-ocaml-5.2-arm64, ocurrent/opam-staging:ubuntu-24.04-ocaml-5.2-amd64, ocurrent/opam-staging:ubuntu-24.04-ocaml-5.2-riscv64 -> ocaml/opam:ubuntu-24.04-ocaml-5.2
-ocurrent/opam-staging:ubuntu-24.04-ocaml-5.2-s390x, ocurrent/opam-staging:ubuntu-24.04-ocaml-5.2-ppc64le, ocurrent/opam-staging:ubuntu-24.04-ocaml-5.2-arm64, ocurrent/opam-staging:ubuntu-24.04-ocaml-5.2-amd64, ocurrent/opam-staging:ubuntu-24.04-ocaml-5.2-riscv64 -> ocaml/opam:ubuntu-lts-ocaml-5.2
 5.3.0/s390x
 	# syntax=docker/dockerfile:1
 
@@ -17053,7 +11730,6 @@ ocurrent/opam-staging:ubuntu-24.04-ocaml-5.2-s390x, ocurrent/opam-staging:ubuntu
 	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
 
 ocurrent/opam-staging:ubuntu-24.04-ocaml-5.3-s390x, ocurrent/opam-staging:ubuntu-24.04-ocaml-5.3-ppc64le, ocurrent/opam-staging:ubuntu-24.04-ocaml-5.3-arm64, ocurrent/opam-staging:ubuntu-24.04-ocaml-5.3-amd64, ocurrent/opam-staging:ubuntu-24.04-ocaml-5.3-riscv64 -> ocaml/opam:ubuntu-24.04-ocaml-5.3
-ocurrent/opam-staging:ubuntu-24.04-ocaml-5.3-s390x, ocurrent/opam-staging:ubuntu-24.04-ocaml-5.3-ppc64le, ocurrent/opam-staging:ubuntu-24.04-ocaml-5.3-arm64, ocurrent/opam-staging:ubuntu-24.04-ocaml-5.3-amd64, ocurrent/opam-staging:ubuntu-24.04-ocaml-5.3-riscv64 -> ocaml/opam:ubuntu-lts-ocaml-5.3
 5.4.1/s390x
 	# syntax=docker/dockerfile:1
 
@@ -17139,10 +11815,8 @@ ocurrent/opam-staging:ubuntu-24.04-ocaml-5.3-s390x, ocurrent/opam-staging:ubuntu
 	CMD bash
 	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
 
-ocurrent/opam-staging:ubuntu-24.04-ocaml-5.4-s390x, ocurrent/opam-staging:ubuntu-24.04-ocaml-5.4-ppc64le, ocurrent/opam-staging:ubuntu-24.04-ocaml-5.4-arm64, ocurrent/opam-staging:ubuntu-24.04-ocaml-5.4-amd64, ocurrent/opam-staging:ubuntu-24.04-ocaml-5.4-riscv64 -> ocaml/opam:ubuntu-lts
 ocurrent/opam-staging:ubuntu-24.04-ocaml-5.4-s390x, ocurrent/opam-staging:ubuntu-24.04-ocaml-5.4-ppc64le, ocurrent/opam-staging:ubuntu-24.04-ocaml-5.4-arm64, ocurrent/opam-staging:ubuntu-24.04-ocaml-5.4-amd64, ocurrent/opam-staging:ubuntu-24.04-ocaml-5.4-riscv64 -> ocaml/opam:ubuntu-24.04
 ocurrent/opam-staging:ubuntu-24.04-ocaml-5.4-s390x, ocurrent/opam-staging:ubuntu-24.04-ocaml-5.4-ppc64le, ocurrent/opam-staging:ubuntu-24.04-ocaml-5.4-arm64, ocurrent/opam-staging:ubuntu-24.04-ocaml-5.4-amd64, ocurrent/opam-staging:ubuntu-24.04-ocaml-5.4-riscv64 -> ocaml/opam:ubuntu-24.04-ocaml-5.4
-ocurrent/opam-staging:ubuntu-24.04-ocaml-5.4-s390x, ocurrent/opam-staging:ubuntu-24.04-ocaml-5.4-ppc64le, ocurrent/opam-staging:ubuntu-24.04-ocaml-5.4-arm64, ocurrent/opam-staging:ubuntu-24.04-ocaml-5.4-amd64, ocurrent/opam-staging:ubuntu-24.04-ocaml-5.4-riscv64 -> ocaml/opam:ubuntu-lts-ocaml-5.4
 5.5.0~beta1/s390x
 	# syntax=docker/dockerfile:1
 
@@ -17234,7 +11908,6 @@ ocurrent/opam-staging:ubuntu-24.04-ocaml-5.4-s390x, ocurrent/opam-staging:ubuntu
 	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
 
 ocurrent/opam-staging:ubuntu-24.04-ocaml-5.5-beta1-s390x, ocurrent/opam-staging:ubuntu-24.04-ocaml-5.5-beta1-ppc64le, ocurrent/opam-staging:ubuntu-24.04-ocaml-5.5-beta1-arm64, ocurrent/opam-staging:ubuntu-24.04-ocaml-5.5-beta1-amd64, ocurrent/opam-staging:ubuntu-24.04-ocaml-5.5-beta1-riscv64 -> ocaml/opam:ubuntu-24.04-ocaml-5.5-beta1
-ocurrent/opam-staging:ubuntu-24.04-ocaml-5.5-beta1-s390x, ocurrent/opam-staging:ubuntu-24.04-ocaml-5.5-beta1-ppc64le, ocurrent/opam-staging:ubuntu-24.04-ocaml-5.5-beta1-arm64, ocurrent/opam-staging:ubuntu-24.04-ocaml-5.5-beta1-amd64, ocurrent/opam-staging:ubuntu-24.04-ocaml-5.5-beta1-riscv64 -> ocaml/opam:ubuntu-lts-ocaml-5.5-beta1
 5.5.0/s390x
 	# syntax=docker/dockerfile:1
 
@@ -17326,7 +11999,6 @@ ocurrent/opam-staging:ubuntu-24.04-ocaml-5.5-beta1-s390x, ocurrent/opam-staging:
 	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
 
 ocurrent/opam-staging:ubuntu-24.04-ocaml-5.5-s390x, ocurrent/opam-staging:ubuntu-24.04-ocaml-5.5-ppc64le, ocurrent/opam-staging:ubuntu-24.04-ocaml-5.5-arm64, ocurrent/opam-staging:ubuntu-24.04-ocaml-5.5-amd64, ocurrent/opam-staging:ubuntu-24.04-ocaml-5.5-riscv64 -> ocaml/opam:ubuntu-24.04-ocaml-5.5
-ocurrent/opam-staging:ubuntu-24.04-ocaml-5.5-s390x, ocurrent/opam-staging:ubuntu-24.04-ocaml-5.5-ppc64le, ocurrent/opam-staging:ubuntu-24.04-ocaml-5.5-arm64, ocurrent/opam-staging:ubuntu-24.04-ocaml-5.5-amd64, ocurrent/opam-staging:ubuntu-24.04-ocaml-5.5-riscv64 -> ocaml/opam:ubuntu-lts-ocaml-5.5
 5.6.0/s390x
 	# syntax=docker/dockerfile:1
 
@@ -17418,7 +12090,6 @@ ocurrent/opam-staging:ubuntu-24.04-ocaml-5.5-s390x, ocurrent/opam-staging:ubuntu
 	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
 
 ocurrent/opam-staging:ubuntu-24.04-ocaml-5.6-s390x, ocurrent/opam-staging:ubuntu-24.04-ocaml-5.6-ppc64le, ocurrent/opam-staging:ubuntu-24.04-ocaml-5.6-arm64, ocurrent/opam-staging:ubuntu-24.04-ocaml-5.6-amd64, ocurrent/opam-staging:ubuntu-24.04-ocaml-5.6-riscv64 -> ocaml/opam:ubuntu-24.04-ocaml-5.6
-ocurrent/opam-staging:ubuntu-24.04-ocaml-5.6-s390x, ocurrent/opam-staging:ubuntu-24.04-ocaml-5.6-ppc64le, ocurrent/opam-staging:ubuntu-24.04-ocaml-5.6-arm64, ocurrent/opam-staging:ubuntu-24.04-ocaml-5.6-amd64, ocurrent/opam-staging:ubuntu-24.04-ocaml-5.6-riscv64 -> ocaml/opam:ubuntu-lts-ocaml-5.6
 ubuntu-25.04
 ubuntu-25.04/s390x
 	# syntax=docker/dockerfile:1
@@ -17899,112 +12570,6 @@ ocurrent/opam-staging:ubuntu-25.04-opam-s390x, ocurrent/opam-staging:ubuntu-25.0
 	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
 
 ocurrent/opam-staging:ubuntu-25.04-ocaml-4.08-s390x, ocurrent/opam-staging:ubuntu-25.04-ocaml-4.08-ppc64le, ocurrent/opam-staging:ubuntu-25.04-ocaml-4.08-arm64, ocurrent/opam-staging:ubuntu-25.04-ocaml-4.08-amd64 -> ocaml/opam:ubuntu-25.04-ocaml-4.08
-4.09.1/s390x
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:ubuntu-25.04-opam-s390x
-	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.09 --packages=ocaml-base-compiler.4.09.1
-	RUN opam pin add -k version ocaml-base-compiler 4.09.1
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.09.1/ppc64le
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:ubuntu-25.04-opam-ppc64le
-	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.09 --packages=ocaml-base-compiler.4.09.1
-	RUN opam pin add -k version ocaml-base-compiler 4.09.1
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.09.1/arm64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:ubuntu-25.04-opam-arm64
-	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.09 --packages=ocaml-base-compiler.4.09.1
-	RUN opam pin add -k version ocaml-base-compiler 4.09.1
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.09.1/amd64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:ubuntu-25.04-opam-amd64
-	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.09 --packages=ocaml-base-compiler.4.09.1
-	RUN opam pin add -k version ocaml-base-compiler 4.09.1
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-ocurrent/opam-staging:ubuntu-25.04-ocaml-4.09-s390x, ocurrent/opam-staging:ubuntu-25.04-ocaml-4.09-ppc64le, ocurrent/opam-staging:ubuntu-25.04-ocaml-4.09-arm64, ocurrent/opam-staging:ubuntu-25.04-ocaml-4.09-amd64 -> ocaml/opam:ubuntu-25.04-ocaml-4.09
-4.10.2/s390x
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:ubuntu-25.04-opam-s390x
-	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.10 --packages=ocaml-base-compiler.4.10.2
-	RUN opam pin add -k version ocaml-base-compiler 4.10.2
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.10.2/ppc64le
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:ubuntu-25.04-opam-ppc64le
-	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.10 --packages=ocaml-base-compiler.4.10.2
-	RUN opam pin add -k version ocaml-base-compiler 4.10.2
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.10.2/arm64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:ubuntu-25.04-opam-arm64
-	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.10 --packages=ocaml-base-compiler.4.10.2
-	RUN opam pin add -k version ocaml-base-compiler 4.10.2
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.10.2/amd64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:ubuntu-25.04-opam-amd64
-	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.10 --packages=ocaml-base-compiler.4.10.2
-	RUN opam pin add -k version ocaml-base-compiler 4.10.2
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-ocurrent/opam-staging:ubuntu-25.04-ocaml-4.10-s390x, ocurrent/opam-staging:ubuntu-25.04-ocaml-4.10-ppc64le, ocurrent/opam-staging:ubuntu-25.04-ocaml-4.10-arm64, ocurrent/opam-staging:ubuntu-25.04-ocaml-4.10-amd64 -> ocaml/opam:ubuntu-25.04-ocaml-4.10
 4.11.2/s390x
 	# syntax=docker/dockerfile:1
 
@@ -18071,138 +12636,6 @@ ocurrent/opam-staging:ubuntu-25.04-ocaml-4.10-s390x, ocurrent/opam-staging:ubunt
 	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
 
 ocurrent/opam-staging:ubuntu-25.04-ocaml-4.11-s390x, ocurrent/opam-staging:ubuntu-25.04-ocaml-4.11-ppc64le, ocurrent/opam-staging:ubuntu-25.04-ocaml-4.11-arm64, ocurrent/opam-staging:ubuntu-25.04-ocaml-4.11-amd64, ocurrent/opam-staging:ubuntu-25.04-ocaml-4.11-riscv64 -> ocaml/opam:ubuntu-25.04-ocaml-4.11
-4.12.1/s390x
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:ubuntu-25.04-opam-s390x
-	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.12 --packages=ocaml-base-compiler.4.12.1
-	RUN opam pin add -k version ocaml-base-compiler 4.12.1
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.12.1/ppc64le
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:ubuntu-25.04-opam-ppc64le
-	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.12 --packages=ocaml-base-compiler.4.12.1
-	RUN opam pin add -k version ocaml-base-compiler 4.12.1
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.12.1/arm64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:ubuntu-25.04-opam-arm64
-	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.12 --packages=ocaml-base-compiler.4.12.1
-	RUN opam pin add -k version ocaml-base-compiler 4.12.1
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.12.1/amd64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:ubuntu-25.04-opam-amd64
-	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.12 --packages=ocaml-base-compiler.4.12.1
-	RUN opam pin add -k version ocaml-base-compiler 4.12.1
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.12.1/riscv64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:ubuntu-25.04-opam-riscv64
-	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.12 --packages=ocaml-base-compiler.4.12.1
-	RUN opam pin add -k version ocaml-base-compiler 4.12.1
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-ocurrent/opam-staging:ubuntu-25.04-ocaml-4.12-s390x, ocurrent/opam-staging:ubuntu-25.04-ocaml-4.12-ppc64le, ocurrent/opam-staging:ubuntu-25.04-ocaml-4.12-arm64, ocurrent/opam-staging:ubuntu-25.04-ocaml-4.12-amd64, ocurrent/opam-staging:ubuntu-25.04-ocaml-4.12-riscv64 -> ocaml/opam:ubuntu-25.04-ocaml-4.12
-4.13.1/s390x
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:ubuntu-25.04-opam-s390x
-	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.13 --packages=ocaml-base-compiler.4.13.1
-	RUN opam pin add -k version ocaml-base-compiler 4.13.1
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.13.1/ppc64le
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:ubuntu-25.04-opam-ppc64le
-	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.13 --packages=ocaml-base-compiler.4.13.1
-	RUN opam pin add -k version ocaml-base-compiler 4.13.1
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.13.1/arm64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:ubuntu-25.04-opam-arm64
-	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.13 --packages=ocaml-base-compiler.4.13.1
-	RUN opam pin add -k version ocaml-base-compiler 4.13.1
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.13.1/amd64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:ubuntu-25.04-opam-amd64
-	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.13 --packages=ocaml-base-compiler.4.13.1
-	RUN opam pin add -k version ocaml-base-compiler 4.13.1
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.13.1/riscv64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:ubuntu-25.04-opam-riscv64
-	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.13 --packages=ocaml-base-compiler.4.13.1
-	RUN opam pin add -k version ocaml-base-compiler 4.13.1
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-ocurrent/opam-staging:ubuntu-25.04-ocaml-4.13-s390x, ocurrent/opam-staging:ubuntu-25.04-ocaml-4.13-ppc64le, ocurrent/opam-staging:ubuntu-25.04-ocaml-4.13-arm64, ocurrent/opam-staging:ubuntu-25.04-ocaml-4.13-amd64, ocurrent/opam-staging:ubuntu-25.04-ocaml-4.13-riscv64 -> ocaml/opam:ubuntu-25.04-ocaml-4.13
 4.14.3/s390x
 	# syntax=docker/dockerfile:1
 
@@ -18269,158 +12702,6 @@ ocurrent/opam-staging:ubuntu-25.04-ocaml-4.13-s390x, ocurrent/opam-staging:ubunt
 	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
 
 ocurrent/opam-staging:ubuntu-25.04-ocaml-4.14-s390x, ocurrent/opam-staging:ubuntu-25.04-ocaml-4.14-ppc64le, ocurrent/opam-staging:ubuntu-25.04-ocaml-4.14-arm64, ocurrent/opam-staging:ubuntu-25.04-ocaml-4.14-amd64, ocurrent/opam-staging:ubuntu-25.04-ocaml-4.14-riscv64 -> ocaml/opam:ubuntu-25.04-ocaml-4.14
-5.0.0/s390x
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:ubuntu-25.04-opam-s390x
-	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 5.0 --packages=ocaml-base-compiler.5.0.0
-	RUN opam pin add -k version ocaml-base-compiler 5.0.0
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-5.0.0/ppc64le
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:ubuntu-25.04-opam-ppc64le
-	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 5.0 --packages=ocaml-base-compiler.5.0.0
-	RUN opam pin add -k version ocaml-base-compiler 5.0.0
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-5.0.0/arm64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:ubuntu-25.04-opam-arm64
-	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 5.0 --packages=ocaml-base-compiler.5.0.0
-	RUN opam pin add -k version ocaml-base-compiler 5.0.0
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-5.0.0/amd64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:ubuntu-25.04-opam-amd64
-	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 5.0 --packages=ocaml-base-compiler.5.0.0
-	RUN opam pin add -k version ocaml-base-compiler 5.0.0
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-5.0.0/riscv64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:ubuntu-25.04-opam-riscv64
-	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 5.0 --packages=ocaml-base-compiler.5.0.0
-	RUN opam pin add -k version ocaml-base-compiler 5.0.0
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-ocurrent/opam-staging:ubuntu-25.04-ocaml-5.0-s390x, ocurrent/opam-staging:ubuntu-25.04-ocaml-5.0-ppc64le, ocurrent/opam-staging:ubuntu-25.04-ocaml-5.0-arm64, ocurrent/opam-staging:ubuntu-25.04-ocaml-5.0-amd64, ocurrent/opam-staging:ubuntu-25.04-ocaml-5.0-riscv64 -> ocaml/opam:ubuntu-25.04-ocaml-5.0
-5.1.1/s390x
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:ubuntu-25.04-opam-s390x
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	USER root
-	RUN apt-get -y update
-	RUN DEBIAN_FRONTEND=noninteractive apt-get -y upgrade
-	RUN DEBIAN_FRONTEND=noninteractive apt-get -y install libzstd-dev
-	USER opam
-	RUN opam switch create 5.1 --packages=ocaml-base-compiler.5.1.1
-	RUN opam pin add -k version ocaml-base-compiler 5.1.1
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-5.1.1/ppc64le
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:ubuntu-25.04-opam-ppc64le
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	USER root
-	RUN apt-get -y update
-	RUN DEBIAN_FRONTEND=noninteractive apt-get -y upgrade
-	RUN DEBIAN_FRONTEND=noninteractive apt-get -y install libzstd-dev
-	USER opam
-	RUN opam switch create 5.1 --packages=ocaml-base-compiler.5.1.1
-	RUN opam pin add -k version ocaml-base-compiler 5.1.1
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-5.1.1/arm64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:ubuntu-25.04-opam-arm64
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	USER root
-	RUN apt-get -y update
-	RUN DEBIAN_FRONTEND=noninteractive apt-get -y upgrade
-	RUN DEBIAN_FRONTEND=noninteractive apt-get -y install libzstd-dev
-	USER opam
-	RUN opam switch create 5.1 --packages=ocaml-base-compiler.5.1.1
-	RUN opam pin add -k version ocaml-base-compiler 5.1.1
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-5.1.1/amd64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:ubuntu-25.04-opam-amd64
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	USER root
-	RUN apt-get -y update
-	RUN DEBIAN_FRONTEND=noninteractive apt-get -y upgrade
-	RUN DEBIAN_FRONTEND=noninteractive apt-get -y install libzstd-dev
-	USER opam
-	RUN opam switch create 5.1 --packages=ocaml-base-compiler.5.1.1
-	RUN opam pin add -k version ocaml-base-compiler 5.1.1
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-5.1.1/riscv64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:ubuntu-25.04-opam-riscv64
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	USER root
-	RUN apt-get -y update
-	RUN DEBIAN_FRONTEND=noninteractive apt-get -y upgrade
-	RUN DEBIAN_FRONTEND=noninteractive apt-get -y install libzstd-dev
-	USER opam
-	RUN opam switch create 5.1 --packages=ocaml-base-compiler.5.1.1
-	RUN opam pin add -k version ocaml-base-compiler 5.1.1
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-ocurrent/opam-staging:ubuntu-25.04-ocaml-5.1-s390x, ocurrent/opam-staging:ubuntu-25.04-ocaml-5.1-ppc64le, ocurrent/opam-staging:ubuntu-25.04-ocaml-5.1-arm64, ocurrent/opam-staging:ubuntu-25.04-ocaml-5.1-amd64, ocurrent/opam-staging:ubuntu-25.04-ocaml-5.1-riscv64 -> ocaml/opam:ubuntu-25.04-ocaml-5.1
 5.2.1/s390x
 	# syntax=docker/dockerfile:1
 
@@ -18982,7 +13263,7 @@ ubuntu-25.10/s390x
 	RUN apt-get -y update
 	RUN DEBIAN_FRONTEND=noninteractive apt-get -y upgrade
 	RUN DEBIAN_FRONTEND=noninteractive apt-get -y install build-essential curl git rsync sudo unzip nano libcap-dev libx11-dev bubblewrap
-	RUN apt-get remove coreutils-from-uutils --allow-remove-essential -y
+	RUN apt-get install -y --allow-remove-essential coreutils-from-gnu coreutils-from-uutils-
 	COPY --from=0 [ "/usr/local/bin/opam-2.0", "/usr/bin/opam-2.0" ]
 	RUN ln /usr/bin/opam-2.0 /usr/bin/opam
 	COPY --from=0 [ "/usr/local/bin/opam-2.1", "/usr/bin/opam-2.1" ]
@@ -19068,7 +13349,7 @@ ubuntu-25.10/ppc64le
 	RUN apt-get -y update
 	RUN DEBIAN_FRONTEND=noninteractive apt-get -y upgrade
 	RUN DEBIAN_FRONTEND=noninteractive apt-get -y install build-essential curl git rsync sudo unzip nano libcap-dev libx11-dev bubblewrap
-	RUN apt-get remove coreutils-from-uutils --allow-remove-essential -y
+	RUN apt-get install -y --allow-remove-essential coreutils-from-gnu coreutils-from-uutils-
 	COPY --from=0 [ "/usr/local/bin/opam-2.0", "/usr/bin/opam-2.0" ]
 	RUN ln /usr/bin/opam-2.0 /usr/bin/opam
 	COPY --from=0 [ "/usr/local/bin/opam-2.1", "/usr/bin/opam-2.1" ]
@@ -19154,7 +13435,7 @@ ubuntu-25.10/arm64
 	RUN apt-get -y update
 	RUN DEBIAN_FRONTEND=noninteractive apt-get -y upgrade
 	RUN DEBIAN_FRONTEND=noninteractive apt-get -y install build-essential curl git rsync sudo unzip nano libcap-dev libx11-dev bubblewrap
-	RUN apt-get remove coreutils-from-uutils --allow-remove-essential -y
+	RUN apt-get install -y --allow-remove-essential coreutils-from-gnu coreutils-from-uutils-
 	COPY --from=0 [ "/usr/local/bin/opam-2.0", "/usr/bin/opam-2.0" ]
 	RUN ln /usr/bin/opam-2.0 /usr/bin/opam
 	COPY --from=0 [ "/usr/local/bin/opam-2.1", "/usr/bin/opam-2.1" ]
@@ -19240,7 +13521,7 @@ ubuntu-25.10/amd64
 	RUN apt-get -y update
 	RUN DEBIAN_FRONTEND=noninteractive apt-get -y upgrade
 	RUN DEBIAN_FRONTEND=noninteractive apt-get -y install build-essential curl git rsync sudo unzip nano libcap-dev libx11-dev bubblewrap
-	RUN apt-get remove coreutils-from-uutils --allow-remove-essential -y
+	RUN apt-get install -y --allow-remove-essential coreutils-from-gnu coreutils-from-uutils-
 	COPY --from=0 [ "/usr/local/bin/opam-2.0", "/usr/bin/opam-2.0" ]
 	RUN ln /usr/bin/opam-2.0 /usr/bin/opam
 	COPY --from=0 [ "/usr/local/bin/opam-2.1", "/usr/bin/opam-2.1" ]
@@ -19352,115 +13633,6 @@ ocurrent/opam-staging:ubuntu-25.10-opam-s390x, ocurrent/opam-staging:ubuntu-25.1
 	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
 
 ocurrent/opam-staging:ubuntu-25.10-ocaml-4.08-s390x, ocurrent/opam-staging:ubuntu-25.10-ocaml-4.08-ppc64le, ocurrent/opam-staging:ubuntu-25.10-ocaml-4.08-arm64, ocurrent/opam-staging:ubuntu-25.10-ocaml-4.08-amd64 -> ocaml/opam:ubuntu-25.10-ocaml-4.08
-ocurrent/opam-staging:ubuntu-25.10-ocaml-4.08-s390x, ocurrent/opam-staging:ubuntu-25.10-ocaml-4.08-ppc64le, ocurrent/opam-staging:ubuntu-25.10-ocaml-4.08-arm64, ocurrent/opam-staging:ubuntu-25.10-ocaml-4.08-amd64 -> ocaml/opam:ubuntu-ocaml-4.08
-4.09.1/s390x
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:ubuntu-25.10-opam-s390x
-	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.09 --packages=ocaml-base-compiler.4.09.1
-	RUN opam pin add -k version ocaml-base-compiler 4.09.1
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.09.1/ppc64le
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:ubuntu-25.10-opam-ppc64le
-	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.09 --packages=ocaml-base-compiler.4.09.1
-	RUN opam pin add -k version ocaml-base-compiler 4.09.1
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.09.1/arm64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:ubuntu-25.10-opam-arm64
-	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.09 --packages=ocaml-base-compiler.4.09.1
-	RUN opam pin add -k version ocaml-base-compiler 4.09.1
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.09.1/amd64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:ubuntu-25.10-opam-amd64
-	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.09 --packages=ocaml-base-compiler.4.09.1
-	RUN opam pin add -k version ocaml-base-compiler 4.09.1
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-ocurrent/opam-staging:ubuntu-25.10-ocaml-4.09-s390x, ocurrent/opam-staging:ubuntu-25.10-ocaml-4.09-ppc64le, ocurrent/opam-staging:ubuntu-25.10-ocaml-4.09-arm64, ocurrent/opam-staging:ubuntu-25.10-ocaml-4.09-amd64 -> ocaml/opam:ubuntu-25.10-ocaml-4.09
-ocurrent/opam-staging:ubuntu-25.10-ocaml-4.09-s390x, ocurrent/opam-staging:ubuntu-25.10-ocaml-4.09-ppc64le, ocurrent/opam-staging:ubuntu-25.10-ocaml-4.09-arm64, ocurrent/opam-staging:ubuntu-25.10-ocaml-4.09-amd64 -> ocaml/opam:ubuntu-ocaml-4.09
-4.10.2/s390x
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:ubuntu-25.10-opam-s390x
-	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.10 --packages=ocaml-base-compiler.4.10.2
-	RUN opam pin add -k version ocaml-base-compiler 4.10.2
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.10.2/ppc64le
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:ubuntu-25.10-opam-ppc64le
-	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.10 --packages=ocaml-base-compiler.4.10.2
-	RUN opam pin add -k version ocaml-base-compiler 4.10.2
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.10.2/arm64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:ubuntu-25.10-opam-arm64
-	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.10 --packages=ocaml-base-compiler.4.10.2
-	RUN opam pin add -k version ocaml-base-compiler 4.10.2
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.10.2/amd64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:ubuntu-25.10-opam-amd64
-	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.10 --packages=ocaml-base-compiler.4.10.2
-	RUN opam pin add -k version ocaml-base-compiler 4.10.2
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-ocurrent/opam-staging:ubuntu-25.10-ocaml-4.10-s390x, ocurrent/opam-staging:ubuntu-25.10-ocaml-4.10-ppc64le, ocurrent/opam-staging:ubuntu-25.10-ocaml-4.10-arm64, ocurrent/opam-staging:ubuntu-25.10-ocaml-4.10-amd64 -> ocaml/opam:ubuntu-25.10-ocaml-4.10
-ocurrent/opam-staging:ubuntu-25.10-ocaml-4.10-s390x, ocurrent/opam-staging:ubuntu-25.10-ocaml-4.10-ppc64le, ocurrent/opam-staging:ubuntu-25.10-ocaml-4.10-arm64, ocurrent/opam-staging:ubuntu-25.10-ocaml-4.10-amd64 -> ocaml/opam:ubuntu-ocaml-4.10
 4.11.2/s390x
 	# syntax=docker/dockerfile:1
 
@@ -19514,115 +13686,6 @@ ocurrent/opam-staging:ubuntu-25.10-ocaml-4.10-s390x, ocurrent/opam-staging:ubunt
 	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
 
 ocurrent/opam-staging:ubuntu-25.10-ocaml-4.11-s390x, ocurrent/opam-staging:ubuntu-25.10-ocaml-4.11-ppc64le, ocurrent/opam-staging:ubuntu-25.10-ocaml-4.11-arm64, ocurrent/opam-staging:ubuntu-25.10-ocaml-4.11-amd64 -> ocaml/opam:ubuntu-25.10-ocaml-4.11
-ocurrent/opam-staging:ubuntu-25.10-ocaml-4.11-s390x, ocurrent/opam-staging:ubuntu-25.10-ocaml-4.11-ppc64le, ocurrent/opam-staging:ubuntu-25.10-ocaml-4.11-arm64, ocurrent/opam-staging:ubuntu-25.10-ocaml-4.11-amd64 -> ocaml/opam:ubuntu-ocaml-4.11
-4.12.1/s390x
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:ubuntu-25.10-opam-s390x
-	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.12 --packages=ocaml-base-compiler.4.12.1
-	RUN opam pin add -k version ocaml-base-compiler 4.12.1
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.12.1/ppc64le
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:ubuntu-25.10-opam-ppc64le
-	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.12 --packages=ocaml-base-compiler.4.12.1
-	RUN opam pin add -k version ocaml-base-compiler 4.12.1
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.12.1/arm64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:ubuntu-25.10-opam-arm64
-	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.12 --packages=ocaml-base-compiler.4.12.1
-	RUN opam pin add -k version ocaml-base-compiler 4.12.1
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.12.1/amd64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:ubuntu-25.10-opam-amd64
-	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.12 --packages=ocaml-base-compiler.4.12.1
-	RUN opam pin add -k version ocaml-base-compiler 4.12.1
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-ocurrent/opam-staging:ubuntu-25.10-ocaml-4.12-s390x, ocurrent/opam-staging:ubuntu-25.10-ocaml-4.12-ppc64le, ocurrent/opam-staging:ubuntu-25.10-ocaml-4.12-arm64, ocurrent/opam-staging:ubuntu-25.10-ocaml-4.12-amd64 -> ocaml/opam:ubuntu-25.10-ocaml-4.12
-ocurrent/opam-staging:ubuntu-25.10-ocaml-4.12-s390x, ocurrent/opam-staging:ubuntu-25.10-ocaml-4.12-ppc64le, ocurrent/opam-staging:ubuntu-25.10-ocaml-4.12-arm64, ocurrent/opam-staging:ubuntu-25.10-ocaml-4.12-amd64 -> ocaml/opam:ubuntu-ocaml-4.12
-4.13.1/s390x
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:ubuntu-25.10-opam-s390x
-	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.13 --packages=ocaml-base-compiler.4.13.1
-	RUN opam pin add -k version ocaml-base-compiler 4.13.1
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.13.1/ppc64le
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:ubuntu-25.10-opam-ppc64le
-	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.13 --packages=ocaml-base-compiler.4.13.1
-	RUN opam pin add -k version ocaml-base-compiler 4.13.1
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.13.1/arm64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:ubuntu-25.10-opam-arm64
-	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.13 --packages=ocaml-base-compiler.4.13.1
-	RUN opam pin add -k version ocaml-base-compiler 4.13.1
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.13.1/amd64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:ubuntu-25.10-opam-amd64
-	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.13 --packages=ocaml-base-compiler.4.13.1
-	RUN opam pin add -k version ocaml-base-compiler 4.13.1
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-ocurrent/opam-staging:ubuntu-25.10-ocaml-4.13-s390x, ocurrent/opam-staging:ubuntu-25.10-ocaml-4.13-ppc64le, ocurrent/opam-staging:ubuntu-25.10-ocaml-4.13-arm64, ocurrent/opam-staging:ubuntu-25.10-ocaml-4.13-amd64 -> ocaml/opam:ubuntu-25.10-ocaml-4.13
-ocurrent/opam-staging:ubuntu-25.10-ocaml-4.13-s390x, ocurrent/opam-staging:ubuntu-25.10-ocaml-4.13-ppc64le, ocurrent/opam-staging:ubuntu-25.10-ocaml-4.13-arm64, ocurrent/opam-staging:ubuntu-25.10-ocaml-4.13-amd64 -> ocaml/opam:ubuntu-ocaml-4.13
 4.14.3/s390x
 	# syntax=docker/dockerfile:1
 
@@ -19676,131 +13739,6 @@ ocurrent/opam-staging:ubuntu-25.10-ocaml-4.13-s390x, ocurrent/opam-staging:ubunt
 	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
 
 ocurrent/opam-staging:ubuntu-25.10-ocaml-4.14-s390x, ocurrent/opam-staging:ubuntu-25.10-ocaml-4.14-ppc64le, ocurrent/opam-staging:ubuntu-25.10-ocaml-4.14-arm64, ocurrent/opam-staging:ubuntu-25.10-ocaml-4.14-amd64 -> ocaml/opam:ubuntu-25.10-ocaml-4.14
-ocurrent/opam-staging:ubuntu-25.10-ocaml-4.14-s390x, ocurrent/opam-staging:ubuntu-25.10-ocaml-4.14-ppc64le, ocurrent/opam-staging:ubuntu-25.10-ocaml-4.14-arm64, ocurrent/opam-staging:ubuntu-25.10-ocaml-4.14-amd64 -> ocaml/opam:ubuntu-ocaml-4.14
-5.0.0/s390x
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:ubuntu-25.10-opam-s390x
-	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 5.0 --packages=ocaml-base-compiler.5.0.0
-	RUN opam pin add -k version ocaml-base-compiler 5.0.0
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-5.0.0/ppc64le
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:ubuntu-25.10-opam-ppc64le
-	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 5.0 --packages=ocaml-base-compiler.5.0.0
-	RUN opam pin add -k version ocaml-base-compiler 5.0.0
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-5.0.0/arm64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:ubuntu-25.10-opam-arm64
-	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 5.0 --packages=ocaml-base-compiler.5.0.0
-	RUN opam pin add -k version ocaml-base-compiler 5.0.0
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-5.0.0/amd64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:ubuntu-25.10-opam-amd64
-	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 5.0 --packages=ocaml-base-compiler.5.0.0
-	RUN opam pin add -k version ocaml-base-compiler 5.0.0
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-ocurrent/opam-staging:ubuntu-25.10-ocaml-5.0-s390x, ocurrent/opam-staging:ubuntu-25.10-ocaml-5.0-ppc64le, ocurrent/opam-staging:ubuntu-25.10-ocaml-5.0-arm64, ocurrent/opam-staging:ubuntu-25.10-ocaml-5.0-amd64 -> ocaml/opam:ubuntu-25.10-ocaml-5.0
-ocurrent/opam-staging:ubuntu-25.10-ocaml-5.0-s390x, ocurrent/opam-staging:ubuntu-25.10-ocaml-5.0-ppc64le, ocurrent/opam-staging:ubuntu-25.10-ocaml-5.0-arm64, ocurrent/opam-staging:ubuntu-25.10-ocaml-5.0-amd64 -> ocaml/opam:ubuntu-ocaml-5.0
-5.1.1/s390x
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:ubuntu-25.10-opam-s390x
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	USER root
-	RUN apt-get -y update
-	RUN DEBIAN_FRONTEND=noninteractive apt-get -y upgrade
-	RUN DEBIAN_FRONTEND=noninteractive apt-get -y install libzstd-dev
-	USER opam
-	RUN opam switch create 5.1 --packages=ocaml-base-compiler.5.1.1
-	RUN opam pin add -k version ocaml-base-compiler 5.1.1
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-5.1.1/ppc64le
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:ubuntu-25.10-opam-ppc64le
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	USER root
-	RUN apt-get -y update
-	RUN DEBIAN_FRONTEND=noninteractive apt-get -y upgrade
-	RUN DEBIAN_FRONTEND=noninteractive apt-get -y install libzstd-dev
-	USER opam
-	RUN opam switch create 5.1 --packages=ocaml-base-compiler.5.1.1
-	RUN opam pin add -k version ocaml-base-compiler 5.1.1
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-5.1.1/arm64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:ubuntu-25.10-opam-arm64
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	USER root
-	RUN apt-get -y update
-	RUN DEBIAN_FRONTEND=noninteractive apt-get -y upgrade
-	RUN DEBIAN_FRONTEND=noninteractive apt-get -y install libzstd-dev
-	USER opam
-	RUN opam switch create 5.1 --packages=ocaml-base-compiler.5.1.1
-	RUN opam pin add -k version ocaml-base-compiler 5.1.1
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-5.1.1/amd64
-	# syntax=docker/dockerfile:1
-
-	FROM ocurrent/opam-staging:ubuntu-25.10-opam-amd64
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	USER root
-	RUN apt-get -y update
-	RUN DEBIAN_FRONTEND=noninteractive apt-get -y upgrade
-	RUN DEBIAN_FRONTEND=noninteractive apt-get -y install libzstd-dev
-	USER opam
-	RUN opam switch create 5.1 --packages=ocaml-base-compiler.5.1.1
-	RUN opam pin add -k version ocaml-base-compiler 5.1.1
-	RUN opam install -y opam-depext
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD bash
-	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-ocurrent/opam-staging:ubuntu-25.10-ocaml-5.1-s390x, ocurrent/opam-staging:ubuntu-25.10-ocaml-5.1-ppc64le, ocurrent/opam-staging:ubuntu-25.10-ocaml-5.1-arm64, ocurrent/opam-staging:ubuntu-25.10-ocaml-5.1-amd64 -> ocaml/opam:ubuntu-25.10-ocaml-5.1
-ocurrent/opam-staging:ubuntu-25.10-ocaml-5.1-s390x, ocurrent/opam-staging:ubuntu-25.10-ocaml-5.1-ppc64le, ocurrent/opam-staging:ubuntu-25.10-ocaml-5.1-arm64, ocurrent/opam-staging:ubuntu-25.10-ocaml-5.1-amd64 -> ocaml/opam:ubuntu-ocaml-5.1
 5.2.1/s390x
 	# syntax=docker/dockerfile:1
 
@@ -19870,7 +13808,6 @@ ocurrent/opam-staging:ubuntu-25.10-ocaml-5.1-s390x, ocurrent/opam-staging:ubuntu
 	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
 
 ocurrent/opam-staging:ubuntu-25.10-ocaml-5.2-s390x, ocurrent/opam-staging:ubuntu-25.10-ocaml-5.2-ppc64le, ocurrent/opam-staging:ubuntu-25.10-ocaml-5.2-arm64, ocurrent/opam-staging:ubuntu-25.10-ocaml-5.2-amd64 -> ocaml/opam:ubuntu-25.10-ocaml-5.2
-ocurrent/opam-staging:ubuntu-25.10-ocaml-5.2-s390x, ocurrent/opam-staging:ubuntu-25.10-ocaml-5.2-ppc64le, ocurrent/opam-staging:ubuntu-25.10-ocaml-5.2-arm64, ocurrent/opam-staging:ubuntu-25.10-ocaml-5.2-amd64 -> ocaml/opam:ubuntu-ocaml-5.2
 5.3.0/s390x
 	# syntax=docker/dockerfile:1
 
@@ -19940,7 +13877,6 @@ ocurrent/opam-staging:ubuntu-25.10-ocaml-5.2-s390x, ocurrent/opam-staging:ubuntu
 	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
 
 ocurrent/opam-staging:ubuntu-25.10-ocaml-5.3-s390x, ocurrent/opam-staging:ubuntu-25.10-ocaml-5.3-ppc64le, ocurrent/opam-staging:ubuntu-25.10-ocaml-5.3-arm64, ocurrent/opam-staging:ubuntu-25.10-ocaml-5.3-amd64 -> ocaml/opam:ubuntu-25.10-ocaml-5.3
-ocurrent/opam-staging:ubuntu-25.10-ocaml-5.3-s390x, ocurrent/opam-staging:ubuntu-25.10-ocaml-5.3-ppc64le, ocurrent/opam-staging:ubuntu-25.10-ocaml-5.3-arm64, ocurrent/opam-staging:ubuntu-25.10-ocaml-5.3-amd64 -> ocaml/opam:ubuntu-ocaml-5.3
 5.4.1/s390x
 	# syntax=docker/dockerfile:1
 
@@ -20009,10 +13945,8 @@ ocurrent/opam-staging:ubuntu-25.10-ocaml-5.3-s390x, ocurrent/opam-staging:ubuntu
 	CMD bash
 	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
 
-ocurrent/opam-staging:ubuntu-25.10-ocaml-5.4-s390x, ocurrent/opam-staging:ubuntu-25.10-ocaml-5.4-ppc64le, ocurrent/opam-staging:ubuntu-25.10-ocaml-5.4-arm64, ocurrent/opam-staging:ubuntu-25.10-ocaml-5.4-amd64 -> ocaml/opam:ubuntu
 ocurrent/opam-staging:ubuntu-25.10-ocaml-5.4-s390x, ocurrent/opam-staging:ubuntu-25.10-ocaml-5.4-ppc64le, ocurrent/opam-staging:ubuntu-25.10-ocaml-5.4-arm64, ocurrent/opam-staging:ubuntu-25.10-ocaml-5.4-amd64 -> ocaml/opam:ubuntu-25.10
 ocurrent/opam-staging:ubuntu-25.10-ocaml-5.4-s390x, ocurrent/opam-staging:ubuntu-25.10-ocaml-5.4-ppc64le, ocurrent/opam-staging:ubuntu-25.10-ocaml-5.4-arm64, ocurrent/opam-staging:ubuntu-25.10-ocaml-5.4-amd64 -> ocaml/opam:ubuntu-25.10-ocaml-5.4
-ocurrent/opam-staging:ubuntu-25.10-ocaml-5.4-s390x, ocurrent/opam-staging:ubuntu-25.10-ocaml-5.4-ppc64le, ocurrent/opam-staging:ubuntu-25.10-ocaml-5.4-arm64, ocurrent/opam-staging:ubuntu-25.10-ocaml-5.4-amd64 -> ocaml/opam:ubuntu-ocaml-5.4
 5.5.0~beta1/s390x
 	# syntax=docker/dockerfile:1
 
@@ -20086,7 +14020,6 @@ ocurrent/opam-staging:ubuntu-25.10-ocaml-5.4-s390x, ocurrent/opam-staging:ubuntu
 	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
 
 ocurrent/opam-staging:ubuntu-25.10-ocaml-5.5-beta1-s390x, ocurrent/opam-staging:ubuntu-25.10-ocaml-5.5-beta1-ppc64le, ocurrent/opam-staging:ubuntu-25.10-ocaml-5.5-beta1-arm64, ocurrent/opam-staging:ubuntu-25.10-ocaml-5.5-beta1-amd64 -> ocaml/opam:ubuntu-25.10-ocaml-5.5-beta1
-ocurrent/opam-staging:ubuntu-25.10-ocaml-5.5-beta1-s390x, ocurrent/opam-staging:ubuntu-25.10-ocaml-5.5-beta1-ppc64le, ocurrent/opam-staging:ubuntu-25.10-ocaml-5.5-beta1-arm64, ocurrent/opam-staging:ubuntu-25.10-ocaml-5.5-beta1-amd64 -> ocaml/opam:ubuntu-ocaml-5.5-beta1
 5.5.0/s390x
 	# syntax=docker/dockerfile:1
 
@@ -20160,7 +14093,6 @@ ocurrent/opam-staging:ubuntu-25.10-ocaml-5.5-beta1-s390x, ocurrent/opam-staging:
 	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
 
 ocurrent/opam-staging:ubuntu-25.10-ocaml-5.5-s390x, ocurrent/opam-staging:ubuntu-25.10-ocaml-5.5-ppc64le, ocurrent/opam-staging:ubuntu-25.10-ocaml-5.5-arm64, ocurrent/opam-staging:ubuntu-25.10-ocaml-5.5-amd64 -> ocaml/opam:ubuntu-25.10-ocaml-5.5
-ocurrent/opam-staging:ubuntu-25.10-ocaml-5.5-s390x, ocurrent/opam-staging:ubuntu-25.10-ocaml-5.5-ppc64le, ocurrent/opam-staging:ubuntu-25.10-ocaml-5.5-arm64, ocurrent/opam-staging:ubuntu-25.10-ocaml-5.5-amd64 -> ocaml/opam:ubuntu-ocaml-5.5
 5.6.0/s390x
 	# syntax=docker/dockerfile:1
 
@@ -20234,7 +14166,946 @@ ocurrent/opam-staging:ubuntu-25.10-ocaml-5.5-s390x, ocurrent/opam-staging:ubuntu
 	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
 
 ocurrent/opam-staging:ubuntu-25.10-ocaml-5.6-s390x, ocurrent/opam-staging:ubuntu-25.10-ocaml-5.6-ppc64le, ocurrent/opam-staging:ubuntu-25.10-ocaml-5.6-arm64, ocurrent/opam-staging:ubuntu-25.10-ocaml-5.6-amd64 -> ocaml/opam:ubuntu-25.10-ocaml-5.6
-ocurrent/opam-staging:ubuntu-25.10-ocaml-5.6-s390x, ocurrent/opam-staging:ubuntu-25.10-ocaml-5.6-ppc64le, ocurrent/opam-staging:ubuntu-25.10-ocaml-5.6-arm64, ocurrent/opam-staging:ubuntu-25.10-ocaml-5.6-amd64 -> ocaml/opam:ubuntu-ocaml-5.6
+ubuntu-26.04
+ubuntu-26.04/s390x
+	# syntax=docker/dockerfile:1
+
+	# Autogenerated by OCaml-Dockerfile scripts
+	FROM ubuntu:resolute
+	LABEL distro_style="apt"
+	RUN apt-get -y update
+	RUN DEBIAN_FRONTEND=noninteractive apt-get -y upgrade
+	RUN DEBIAN_FRONTEND=noninteractive apt-get -y install build-essential curl git libcap-dev sudo
+	RUN git config --global user.email "docker@example.com"
+	RUN git config --global user.name "Docker"
+	RUN git clone https://github.com/ocaml/opam /tmp/opam && cd /tmp/opam && cp -P -R -p . ../opam-sources && git checkout master && env MAKE='make -j' shell/bootstrap-ocaml.sh && make -C src_ext cache-archives
+	RUN cd /tmp/opam-sources && cp -P -R -p . ../opam-build-2.0 && cd ../opam-build-2.0 && git fetch -q && git checkout 2.0 && ln -s ../opam/src_ext/archives src_ext/archives && env PATH="/tmp/opam/bootstrap/ocaml/bin:$PATH" ./configure --enable-cold-check && env PATH="/tmp/opam/bootstrap/ocaml/bin:$PATH" make lib-ext all && mkdir -p /usr/local/bin && cp /tmp/opam-build-2.0/opam /usr/local/bin/opam-2.0 && chmod a+x /usr/local/bin/opam-2.0 && rm -rf /tmp/opam-build-2.0
+	RUN cd /tmp/opam-sources && cp -P -R -p . ../opam-build-2.1 && cd ../opam-build-2.1 && git fetch -q && git checkout 2.1 && ln -s ../opam/src_ext/archives src_ext/archives && env PATH="/tmp/opam/bootstrap/ocaml/bin:$PATH" ./configure --enable-cold-check --with-0install-solver && env PATH="/tmp/opam/bootstrap/ocaml/bin:$PATH" make lib-ext all && mkdir -p /usr/local/bin && cp /tmp/opam-build-2.1/opam /usr/local/bin/opam-2.1 && chmod a+x /usr/local/bin/opam-2.1 && rm -rf /tmp/opam-build-2.1
+	RUN cd /tmp/opam-sources && cp -P -R -p . ../opam-build-2.2 && cd ../opam-build-2.2 && git fetch -q && git checkout 2.2 && ln -s ../opam/src_ext/archives src_ext/archives && env PATH="/tmp/opam/bootstrap/ocaml/bin:$PATH" ./configure --enable-cold-check --with-0install-solver --with-vendored-deps && env PATH="/tmp/opam/bootstrap/ocaml/bin:$PATH" make lib-ext all && mkdir -p /usr/local/bin && cp /tmp/opam-build-2.2/opam /usr/local/bin/opam-2.2 && chmod a+x /usr/local/bin/opam-2.2 && rm -rf /tmp/opam-build-2.2
+	RUN cd /tmp/opam-sources && cp -P -R -p . ../opam-build-2.3 && cd ../opam-build-2.3 && git fetch -q && git checkout 2.3 && ln -s ../opam/src_ext/archives src_ext/archives && env PATH="/tmp/opam/bootstrap/ocaml/bin:$PATH" ./configure --enable-cold-check --with-0install-solver --with-vendored-deps && env PATH="/tmp/opam/bootstrap/ocaml/bin:$PATH" make lib-ext all && mkdir -p /usr/local/bin && cp /tmp/opam-build-2.3/opam /usr/local/bin/opam-2.3 && chmod a+x /usr/local/bin/opam-2.3 && rm -rf /tmp/opam-build-2.3
+	RUN cd /tmp/opam-sources && cp -P -R -p . ../opam-build-2.4 && cd ../opam-build-2.4 && git fetch -q && git checkout 2.4 && ln -s ../opam/src_ext/archives src_ext/archives && env PATH="/tmp/opam/bootstrap/ocaml/bin:$PATH" ./configure --enable-cold-check --with-0install-solver --with-vendored-deps && env PATH="/tmp/opam/bootstrap/ocaml/bin:$PATH" make lib-ext all && mkdir -p /usr/local/bin && cp /tmp/opam-build-2.4/opam /usr/local/bin/opam-2.4 && chmod a+x /usr/local/bin/opam-2.4 && rm -rf /tmp/opam-build-2.4
+	RUN cd /tmp/opam-sources && cp -P -R -p . ../opam-build-2.5 && cd ../opam-build-2.5 && git fetch -q && git checkout 2.5 && ln -s ../opam/src_ext/archives src_ext/archives && env PATH="/tmp/opam/bootstrap/ocaml/bin:$PATH" ./configure --enable-cold-check --with-0install-solver --with-vendored-deps && env PATH="/tmp/opam/bootstrap/ocaml/bin:$PATH" make lib-ext all && mkdir -p /usr/local/bin && cp /tmp/opam-build-2.5/opam /usr/local/bin/opam-2.5 && chmod a+x /usr/local/bin/opam-2.5 && rm -rf /tmp/opam-build-2.5
+	RUN cd /tmp/opam-sources && cp -P -R -p . ../opam-build-master && cd ../opam-build-master && git fetch -q && git checkout master && ln -s ../opam/src_ext/archives src_ext/archives && env PATH="/tmp/opam/bootstrap/ocaml/bin:$PATH" ./configure --enable-cold-check --with-0install-solver --with-vendored-deps && env PATH="/tmp/opam/bootstrap/ocaml/bin:$PATH" make lib-ext all && mkdir -p /usr/local/bin && cp /tmp/opam-build-master/opam /usr/local/bin/opam-master && chmod a+x /usr/local/bin/opam-master && rm -rf /tmp/opam-build-master
+
+	FROM ubuntu:resolute
+	RUN ln -fs /usr/share/zoneinfo/Europe/London /etc/localtime
+	COPY <<-EOF /etc/apt/apt.conf.d/mirror-retry
+		Acquire::Retries "5";
+	EOF
+	RUN apt-get -y update
+	RUN DEBIAN_FRONTEND=noninteractive apt-get -y upgrade
+	RUN DEBIAN_FRONTEND=noninteractive apt-get -y install build-essential curl git rsync sudo unzip nano libcap-dev libx11-dev bubblewrap
+	RUN apt-get install -y --allow-remove-essential coreutils-from-gnu coreutils-from-uutils-
+	COPY --from=0 [ "/usr/local/bin/opam-2.0", "/usr/bin/opam-2.0" ]
+	RUN ln /usr/bin/opam-2.0 /usr/bin/opam
+	COPY --from=0 [ "/usr/local/bin/opam-2.1", "/usr/bin/opam-2.1" ]
+	COPY --from=0 [ "/usr/local/bin/opam-2.2", "/usr/bin/opam-2.2" ]
+	COPY --from=0 [ "/usr/local/bin/opam-2.3", "/usr/bin/opam-2.3" ]
+	COPY --from=0 [ "/usr/local/bin/opam-2.4", "/usr/bin/opam-2.4" ]
+	COPY --from=0 [ "/usr/local/bin/opam-2.5", "/usr/bin/opam-2.5" ]
+	COPY --from=0 [ "/usr/local/bin/opam-master", "/usr/bin/opam-dev" ]
+	RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
+	COPY <<-EOF /etc/sudoers.d/opam
+		opam ALL=(ALL:ALL) NOPASSWD:ALL
+	EOF
+	RUN chmod 440 /etc/sudoers.d/opam
+	RUN chown root:root /etc/sudoers.d/opam
+	RUN if getent passwd 1000; then userdel -r $(id -nu 1000); fi
+	RUN useradd --uid 1000 --create-home --shell /bin/bash opam
+	RUN passwd -l opam
+	RUN chown -R opam:opam /home/opam
+	USER opam
+	ENV HOME="/home/opam"
+	WORKDIR /home/opam
+	RUN mkdir .ssh
+	RUN chmod 700 .ssh
+	COPY --chown=opam <<-EOF /home/opam/.opamrc-nosandbox
+		wrap-build-commands: []
+		wrap-install-commands: []
+		wrap-remove-commands: []
+		required-tools: []
+	EOF
+	COPY --chown=opam <<-EOF /home/opam/opam-sandbox-disable
+		#!/bin/sh
+		cp ~/.opamrc-nosandbox ~/.opamrc
+		echo --- opam sandboxing disabled
+	EOF
+	RUN chmod a+x /home/opam/opam-sandbox-disable
+	RUN sudo mv /home/opam/opam-sandbox-disable /usr/bin/opam-sandbox-disable
+	COPY --chown=opam <<-EOF /home/opam/.opamrc-sandbox
+		wrap-build-commands: ["%{hooks}%/sandbox.sh" "build"]
+		wrap-install-commands: ["%{hooks}%/sandbox.sh" "install"]
+		wrap-remove-commands: ["%{hooks}%/sandbox.sh" "remove"]
+	EOF
+	COPY --chown=opam <<-EOF /home/opam/opam-sandbox-enable
+		#!/bin/sh
+		cp ~/.opamrc-sandbox ~/.opamrc
+		echo --- opam sandboxing enabled
+	EOF
+	RUN chmod a+x /home/opam/opam-sandbox-enable
+	RUN sudo mv /home/opam/opam-sandbox-enable /usr/bin/opam-sandbox-enable
+	RUN git config --global user.email "docker@example.com"
+	RUN git config --global user.name "Docker"
+	COPY --link --chown=opam:opam [ ".", "/home/opam/opam-repository" ]
+	RUN opam-sandbox-disable
+	RUN opam init -k git -a /home/opam/opam-repository --bare
+	RUN echo 'archive-mirrors: "https://opam.ocaml.org/cache"' >> ~/.opam/config
+	RUN rm -rf .opam/repo/default/.git
+	COPY --link [ "Dockerfile", "/Dockerfile.opam" ]
+
+ubuntu-26.04/ppc64le
+	# syntax=docker/dockerfile:1
+
+	# Autogenerated by OCaml-Dockerfile scripts
+	FROM ubuntu:resolute
+	LABEL distro_style="apt"
+	RUN apt-get -y update
+	RUN DEBIAN_FRONTEND=noninteractive apt-get -y upgrade
+	RUN DEBIAN_FRONTEND=noninteractive apt-get -y install build-essential curl git libcap-dev sudo
+	RUN git config --global user.email "docker@example.com"
+	RUN git config --global user.name "Docker"
+	RUN git clone https://github.com/ocaml/opam /tmp/opam && cd /tmp/opam && cp -P -R -p . ../opam-sources && git checkout master && env MAKE='make -j' shell/bootstrap-ocaml.sh && make -C src_ext cache-archives
+	RUN cd /tmp/opam-sources && cp -P -R -p . ../opam-build-2.0 && cd ../opam-build-2.0 && git fetch -q && git checkout 2.0 && ln -s ../opam/src_ext/archives src_ext/archives && env PATH="/tmp/opam/bootstrap/ocaml/bin:$PATH" ./configure --enable-cold-check && env PATH="/tmp/opam/bootstrap/ocaml/bin:$PATH" make lib-ext all && mkdir -p /usr/local/bin && cp /tmp/opam-build-2.0/opam /usr/local/bin/opam-2.0 && chmod a+x /usr/local/bin/opam-2.0 && rm -rf /tmp/opam-build-2.0
+	RUN cd /tmp/opam-sources && cp -P -R -p . ../opam-build-2.1 && cd ../opam-build-2.1 && git fetch -q && git checkout 2.1 && ln -s ../opam/src_ext/archives src_ext/archives && env PATH="/tmp/opam/bootstrap/ocaml/bin:$PATH" ./configure --enable-cold-check --with-0install-solver && env PATH="/tmp/opam/bootstrap/ocaml/bin:$PATH" make lib-ext all && mkdir -p /usr/local/bin && cp /tmp/opam-build-2.1/opam /usr/local/bin/opam-2.1 && chmod a+x /usr/local/bin/opam-2.1 && rm -rf /tmp/opam-build-2.1
+	RUN cd /tmp/opam-sources && cp -P -R -p . ../opam-build-2.2 && cd ../opam-build-2.2 && git fetch -q && git checkout 2.2 && ln -s ../opam/src_ext/archives src_ext/archives && env PATH="/tmp/opam/bootstrap/ocaml/bin:$PATH" ./configure --enable-cold-check --with-0install-solver --with-vendored-deps && env PATH="/tmp/opam/bootstrap/ocaml/bin:$PATH" make lib-ext all && mkdir -p /usr/local/bin && cp /tmp/opam-build-2.2/opam /usr/local/bin/opam-2.2 && chmod a+x /usr/local/bin/opam-2.2 && rm -rf /tmp/opam-build-2.2
+	RUN cd /tmp/opam-sources && cp -P -R -p . ../opam-build-2.3 && cd ../opam-build-2.3 && git fetch -q && git checkout 2.3 && ln -s ../opam/src_ext/archives src_ext/archives && env PATH="/tmp/opam/bootstrap/ocaml/bin:$PATH" ./configure --enable-cold-check --with-0install-solver --with-vendored-deps && env PATH="/tmp/opam/bootstrap/ocaml/bin:$PATH" make lib-ext all && mkdir -p /usr/local/bin && cp /tmp/opam-build-2.3/opam /usr/local/bin/opam-2.3 && chmod a+x /usr/local/bin/opam-2.3 && rm -rf /tmp/opam-build-2.3
+	RUN cd /tmp/opam-sources && cp -P -R -p . ../opam-build-2.4 && cd ../opam-build-2.4 && git fetch -q && git checkout 2.4 && ln -s ../opam/src_ext/archives src_ext/archives && env PATH="/tmp/opam/bootstrap/ocaml/bin:$PATH" ./configure --enable-cold-check --with-0install-solver --with-vendored-deps && env PATH="/tmp/opam/bootstrap/ocaml/bin:$PATH" make lib-ext all && mkdir -p /usr/local/bin && cp /tmp/opam-build-2.4/opam /usr/local/bin/opam-2.4 && chmod a+x /usr/local/bin/opam-2.4 && rm -rf /tmp/opam-build-2.4
+	RUN cd /tmp/opam-sources && cp -P -R -p . ../opam-build-2.5 && cd ../opam-build-2.5 && git fetch -q && git checkout 2.5 && ln -s ../opam/src_ext/archives src_ext/archives && env PATH="/tmp/opam/bootstrap/ocaml/bin:$PATH" ./configure --enable-cold-check --with-0install-solver --with-vendored-deps && env PATH="/tmp/opam/bootstrap/ocaml/bin:$PATH" make lib-ext all && mkdir -p /usr/local/bin && cp /tmp/opam-build-2.5/opam /usr/local/bin/opam-2.5 && chmod a+x /usr/local/bin/opam-2.5 && rm -rf /tmp/opam-build-2.5
+	RUN cd /tmp/opam-sources && cp -P -R -p . ../opam-build-master && cd ../opam-build-master && git fetch -q && git checkout master && ln -s ../opam/src_ext/archives src_ext/archives && env PATH="/tmp/opam/bootstrap/ocaml/bin:$PATH" ./configure --enable-cold-check --with-0install-solver --with-vendored-deps && env PATH="/tmp/opam/bootstrap/ocaml/bin:$PATH" make lib-ext all && mkdir -p /usr/local/bin && cp /tmp/opam-build-master/opam /usr/local/bin/opam-master && chmod a+x /usr/local/bin/opam-master && rm -rf /tmp/opam-build-master
+
+	FROM ubuntu:resolute
+	RUN ln -fs /usr/share/zoneinfo/Europe/London /etc/localtime
+	COPY <<-EOF /etc/apt/apt.conf.d/mirror-retry
+		Acquire::Retries "5";
+	EOF
+	RUN apt-get -y update
+	RUN DEBIAN_FRONTEND=noninteractive apt-get -y upgrade
+	RUN DEBIAN_FRONTEND=noninteractive apt-get -y install build-essential curl git rsync sudo unzip nano libcap-dev libx11-dev bubblewrap
+	RUN apt-get install -y --allow-remove-essential coreutils-from-gnu coreutils-from-uutils-
+	COPY --from=0 [ "/usr/local/bin/opam-2.0", "/usr/bin/opam-2.0" ]
+	RUN ln /usr/bin/opam-2.0 /usr/bin/opam
+	COPY --from=0 [ "/usr/local/bin/opam-2.1", "/usr/bin/opam-2.1" ]
+	COPY --from=0 [ "/usr/local/bin/opam-2.2", "/usr/bin/opam-2.2" ]
+	COPY --from=0 [ "/usr/local/bin/opam-2.3", "/usr/bin/opam-2.3" ]
+	COPY --from=0 [ "/usr/local/bin/opam-2.4", "/usr/bin/opam-2.4" ]
+	COPY --from=0 [ "/usr/local/bin/opam-2.5", "/usr/bin/opam-2.5" ]
+	COPY --from=0 [ "/usr/local/bin/opam-master", "/usr/bin/opam-dev" ]
+	RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
+	COPY <<-EOF /etc/sudoers.d/opam
+		opam ALL=(ALL:ALL) NOPASSWD:ALL
+	EOF
+	RUN chmod 440 /etc/sudoers.d/opam
+	RUN chown root:root /etc/sudoers.d/opam
+	RUN if getent passwd 1000; then userdel -r $(id -nu 1000); fi
+	RUN useradd --uid 1000 --create-home --shell /bin/bash opam
+	RUN passwd -l opam
+	RUN chown -R opam:opam /home/opam
+	USER opam
+	ENV HOME="/home/opam"
+	WORKDIR /home/opam
+	RUN mkdir .ssh
+	RUN chmod 700 .ssh
+	COPY --chown=opam <<-EOF /home/opam/.opamrc-nosandbox
+		wrap-build-commands: []
+		wrap-install-commands: []
+		wrap-remove-commands: []
+		required-tools: []
+	EOF
+	COPY --chown=opam <<-EOF /home/opam/opam-sandbox-disable
+		#!/bin/sh
+		cp ~/.opamrc-nosandbox ~/.opamrc
+		echo --- opam sandboxing disabled
+	EOF
+	RUN chmod a+x /home/opam/opam-sandbox-disable
+	RUN sudo mv /home/opam/opam-sandbox-disable /usr/bin/opam-sandbox-disable
+	COPY --chown=opam <<-EOF /home/opam/.opamrc-sandbox
+		wrap-build-commands: ["%{hooks}%/sandbox.sh" "build"]
+		wrap-install-commands: ["%{hooks}%/sandbox.sh" "install"]
+		wrap-remove-commands: ["%{hooks}%/sandbox.sh" "remove"]
+	EOF
+	COPY --chown=opam <<-EOF /home/opam/opam-sandbox-enable
+		#!/bin/sh
+		cp ~/.opamrc-sandbox ~/.opamrc
+		echo --- opam sandboxing enabled
+	EOF
+	RUN chmod a+x /home/opam/opam-sandbox-enable
+	RUN sudo mv /home/opam/opam-sandbox-enable /usr/bin/opam-sandbox-enable
+	RUN git config --global user.email "docker@example.com"
+	RUN git config --global user.name "Docker"
+	COPY --link --chown=opam:opam [ ".", "/home/opam/opam-repository" ]
+	RUN opam-sandbox-disable
+	RUN opam init -k git -a /home/opam/opam-repository --bare
+	RUN echo 'archive-mirrors: "https://opam.ocaml.org/cache"' >> ~/.opam/config
+	RUN rm -rf .opam/repo/default/.git
+	COPY --link [ "Dockerfile", "/Dockerfile.opam" ]
+
+ubuntu-26.04/arm64
+	# syntax=docker/dockerfile:1
+
+	# Autogenerated by OCaml-Dockerfile scripts
+	FROM ubuntu:resolute
+	LABEL distro_style="apt"
+	RUN apt-get -y update
+	RUN DEBIAN_FRONTEND=noninteractive apt-get -y upgrade
+	RUN DEBIAN_FRONTEND=noninteractive apt-get -y install build-essential curl git libcap-dev sudo
+	RUN git config --global user.email "docker@example.com"
+	RUN git config --global user.name "Docker"
+	RUN git clone https://github.com/ocaml/opam /tmp/opam && cd /tmp/opam && cp -P -R -p . ../opam-sources && git checkout master && env MAKE='make -j' shell/bootstrap-ocaml.sh && make -C src_ext cache-archives
+	RUN cd /tmp/opam-sources && cp -P -R -p . ../opam-build-2.0 && cd ../opam-build-2.0 && git fetch -q && git checkout 2.0 && ln -s ../opam/src_ext/archives src_ext/archives && env PATH="/tmp/opam/bootstrap/ocaml/bin:$PATH" ./configure --enable-cold-check && env PATH="/tmp/opam/bootstrap/ocaml/bin:$PATH" make lib-ext all && mkdir -p /usr/local/bin && cp /tmp/opam-build-2.0/opam /usr/local/bin/opam-2.0 && chmod a+x /usr/local/bin/opam-2.0 && rm -rf /tmp/opam-build-2.0
+	RUN cd /tmp/opam-sources && cp -P -R -p . ../opam-build-2.1 && cd ../opam-build-2.1 && git fetch -q && git checkout 2.1 && ln -s ../opam/src_ext/archives src_ext/archives && env PATH="/tmp/opam/bootstrap/ocaml/bin:$PATH" ./configure --enable-cold-check --with-0install-solver && env PATH="/tmp/opam/bootstrap/ocaml/bin:$PATH" make lib-ext all && mkdir -p /usr/local/bin && cp /tmp/opam-build-2.1/opam /usr/local/bin/opam-2.1 && chmod a+x /usr/local/bin/opam-2.1 && rm -rf /tmp/opam-build-2.1
+	RUN cd /tmp/opam-sources && cp -P -R -p . ../opam-build-2.2 && cd ../opam-build-2.2 && git fetch -q && git checkout 2.2 && ln -s ../opam/src_ext/archives src_ext/archives && env PATH="/tmp/opam/bootstrap/ocaml/bin:$PATH" ./configure --enable-cold-check --with-0install-solver --with-vendored-deps && env PATH="/tmp/opam/bootstrap/ocaml/bin:$PATH" make lib-ext all && mkdir -p /usr/local/bin && cp /tmp/opam-build-2.2/opam /usr/local/bin/opam-2.2 && chmod a+x /usr/local/bin/opam-2.2 && rm -rf /tmp/opam-build-2.2
+	RUN cd /tmp/opam-sources && cp -P -R -p . ../opam-build-2.3 && cd ../opam-build-2.3 && git fetch -q && git checkout 2.3 && ln -s ../opam/src_ext/archives src_ext/archives && env PATH="/tmp/opam/bootstrap/ocaml/bin:$PATH" ./configure --enable-cold-check --with-0install-solver --with-vendored-deps && env PATH="/tmp/opam/bootstrap/ocaml/bin:$PATH" make lib-ext all && mkdir -p /usr/local/bin && cp /tmp/opam-build-2.3/opam /usr/local/bin/opam-2.3 && chmod a+x /usr/local/bin/opam-2.3 && rm -rf /tmp/opam-build-2.3
+	RUN cd /tmp/opam-sources && cp -P -R -p . ../opam-build-2.4 && cd ../opam-build-2.4 && git fetch -q && git checkout 2.4 && ln -s ../opam/src_ext/archives src_ext/archives && env PATH="/tmp/opam/bootstrap/ocaml/bin:$PATH" ./configure --enable-cold-check --with-0install-solver --with-vendored-deps && env PATH="/tmp/opam/bootstrap/ocaml/bin:$PATH" make lib-ext all && mkdir -p /usr/local/bin && cp /tmp/opam-build-2.4/opam /usr/local/bin/opam-2.4 && chmod a+x /usr/local/bin/opam-2.4 && rm -rf /tmp/opam-build-2.4
+	RUN cd /tmp/opam-sources && cp -P -R -p . ../opam-build-2.5 && cd ../opam-build-2.5 && git fetch -q && git checkout 2.5 && ln -s ../opam/src_ext/archives src_ext/archives && env PATH="/tmp/opam/bootstrap/ocaml/bin:$PATH" ./configure --enable-cold-check --with-0install-solver --with-vendored-deps && env PATH="/tmp/opam/bootstrap/ocaml/bin:$PATH" make lib-ext all && mkdir -p /usr/local/bin && cp /tmp/opam-build-2.5/opam /usr/local/bin/opam-2.5 && chmod a+x /usr/local/bin/opam-2.5 && rm -rf /tmp/opam-build-2.5
+	RUN cd /tmp/opam-sources && cp -P -R -p . ../opam-build-master && cd ../opam-build-master && git fetch -q && git checkout master && ln -s ../opam/src_ext/archives src_ext/archives && env PATH="/tmp/opam/bootstrap/ocaml/bin:$PATH" ./configure --enable-cold-check --with-0install-solver --with-vendored-deps && env PATH="/tmp/opam/bootstrap/ocaml/bin:$PATH" make lib-ext all && mkdir -p /usr/local/bin && cp /tmp/opam-build-master/opam /usr/local/bin/opam-master && chmod a+x /usr/local/bin/opam-master && rm -rf /tmp/opam-build-master
+
+	FROM ubuntu:resolute
+	RUN ln -fs /usr/share/zoneinfo/Europe/London /etc/localtime
+	COPY <<-EOF /etc/apt/apt.conf.d/mirror-retry
+		Acquire::Retries "5";
+	EOF
+	RUN apt-get -y update
+	RUN DEBIAN_FRONTEND=noninteractive apt-get -y upgrade
+	RUN DEBIAN_FRONTEND=noninteractive apt-get -y install build-essential curl git rsync sudo unzip nano libcap-dev libx11-dev bubblewrap
+	RUN apt-get install -y --allow-remove-essential coreutils-from-gnu coreutils-from-uutils-
+	COPY --from=0 [ "/usr/local/bin/opam-2.0", "/usr/bin/opam-2.0" ]
+	RUN ln /usr/bin/opam-2.0 /usr/bin/opam
+	COPY --from=0 [ "/usr/local/bin/opam-2.1", "/usr/bin/opam-2.1" ]
+	COPY --from=0 [ "/usr/local/bin/opam-2.2", "/usr/bin/opam-2.2" ]
+	COPY --from=0 [ "/usr/local/bin/opam-2.3", "/usr/bin/opam-2.3" ]
+	COPY --from=0 [ "/usr/local/bin/opam-2.4", "/usr/bin/opam-2.4" ]
+	COPY --from=0 [ "/usr/local/bin/opam-2.5", "/usr/bin/opam-2.5" ]
+	COPY --from=0 [ "/usr/local/bin/opam-master", "/usr/bin/opam-dev" ]
+	RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
+	COPY <<-EOF /etc/sudoers.d/opam
+		opam ALL=(ALL:ALL) NOPASSWD:ALL
+	EOF
+	RUN chmod 440 /etc/sudoers.d/opam
+	RUN chown root:root /etc/sudoers.d/opam
+	RUN if getent passwd 1000; then userdel -r $(id -nu 1000); fi
+	RUN useradd --uid 1000 --create-home --shell /bin/bash opam
+	RUN passwd -l opam
+	RUN chown -R opam:opam /home/opam
+	USER opam
+	ENV HOME="/home/opam"
+	WORKDIR /home/opam
+	RUN mkdir .ssh
+	RUN chmod 700 .ssh
+	COPY --chown=opam <<-EOF /home/opam/.opamrc-nosandbox
+		wrap-build-commands: []
+		wrap-install-commands: []
+		wrap-remove-commands: []
+		required-tools: []
+	EOF
+	COPY --chown=opam <<-EOF /home/opam/opam-sandbox-disable
+		#!/bin/sh
+		cp ~/.opamrc-nosandbox ~/.opamrc
+		echo --- opam sandboxing disabled
+	EOF
+	RUN chmod a+x /home/opam/opam-sandbox-disable
+	RUN sudo mv /home/opam/opam-sandbox-disable /usr/bin/opam-sandbox-disable
+	COPY --chown=opam <<-EOF /home/opam/.opamrc-sandbox
+		wrap-build-commands: ["%{hooks}%/sandbox.sh" "build"]
+		wrap-install-commands: ["%{hooks}%/sandbox.sh" "install"]
+		wrap-remove-commands: ["%{hooks}%/sandbox.sh" "remove"]
+	EOF
+	COPY --chown=opam <<-EOF /home/opam/opam-sandbox-enable
+		#!/bin/sh
+		cp ~/.opamrc-sandbox ~/.opamrc
+		echo --- opam sandboxing enabled
+	EOF
+	RUN chmod a+x /home/opam/opam-sandbox-enable
+	RUN sudo mv /home/opam/opam-sandbox-enable /usr/bin/opam-sandbox-enable
+	RUN git config --global user.email "docker@example.com"
+	RUN git config --global user.name "Docker"
+	COPY --link --chown=opam:opam [ ".", "/home/opam/opam-repository" ]
+	RUN opam-sandbox-disable
+	RUN opam init -k git -a /home/opam/opam-repository --bare
+	RUN echo 'archive-mirrors: "https://opam.ocaml.org/cache"' >> ~/.opam/config
+	RUN rm -rf .opam/repo/default/.git
+	COPY --link [ "Dockerfile", "/Dockerfile.opam" ]
+
+ubuntu-26.04/amd64
+	# syntax=docker/dockerfile:1
+
+	# Autogenerated by OCaml-Dockerfile scripts
+	FROM ubuntu:resolute
+	LABEL distro_style="apt"
+	RUN apt-get -y update
+	RUN DEBIAN_FRONTEND=noninteractive apt-get -y upgrade
+	RUN DEBIAN_FRONTEND=noninteractive apt-get -y install build-essential curl git libcap-dev sudo
+	RUN git config --global user.email "docker@example.com"
+	RUN git config --global user.name "Docker"
+	RUN git clone https://github.com/ocaml/opam /tmp/opam && cd /tmp/opam && cp -P -R -p . ../opam-sources && git checkout master && env MAKE='make -j' shell/bootstrap-ocaml.sh && make -C src_ext cache-archives
+	RUN cd /tmp/opam-sources && cp -P -R -p . ../opam-build-2.0 && cd ../opam-build-2.0 && git fetch -q && git checkout 2.0 && ln -s ../opam/src_ext/archives src_ext/archives && env PATH="/tmp/opam/bootstrap/ocaml/bin:$PATH" ./configure --enable-cold-check && env PATH="/tmp/opam/bootstrap/ocaml/bin:$PATH" make lib-ext all && mkdir -p /usr/local/bin && cp /tmp/opam-build-2.0/opam /usr/local/bin/opam-2.0 && chmod a+x /usr/local/bin/opam-2.0 && rm -rf /tmp/opam-build-2.0
+	RUN cd /tmp/opam-sources && cp -P -R -p . ../opam-build-2.1 && cd ../opam-build-2.1 && git fetch -q && git checkout 2.1 && ln -s ../opam/src_ext/archives src_ext/archives && env PATH="/tmp/opam/bootstrap/ocaml/bin:$PATH" ./configure --enable-cold-check --with-0install-solver && env PATH="/tmp/opam/bootstrap/ocaml/bin:$PATH" make lib-ext all && mkdir -p /usr/local/bin && cp /tmp/opam-build-2.1/opam /usr/local/bin/opam-2.1 && chmod a+x /usr/local/bin/opam-2.1 && rm -rf /tmp/opam-build-2.1
+	RUN cd /tmp/opam-sources && cp -P -R -p . ../opam-build-2.2 && cd ../opam-build-2.2 && git fetch -q && git checkout 2.2 && ln -s ../opam/src_ext/archives src_ext/archives && env PATH="/tmp/opam/bootstrap/ocaml/bin:$PATH" ./configure --enable-cold-check --with-0install-solver --with-vendored-deps && env PATH="/tmp/opam/bootstrap/ocaml/bin:$PATH" make lib-ext all && mkdir -p /usr/local/bin && cp /tmp/opam-build-2.2/opam /usr/local/bin/opam-2.2 && chmod a+x /usr/local/bin/opam-2.2 && rm -rf /tmp/opam-build-2.2
+	RUN cd /tmp/opam-sources && cp -P -R -p . ../opam-build-2.3 && cd ../opam-build-2.3 && git fetch -q && git checkout 2.3 && ln -s ../opam/src_ext/archives src_ext/archives && env PATH="/tmp/opam/bootstrap/ocaml/bin:$PATH" ./configure --enable-cold-check --with-0install-solver --with-vendored-deps && env PATH="/tmp/opam/bootstrap/ocaml/bin:$PATH" make lib-ext all && mkdir -p /usr/local/bin && cp /tmp/opam-build-2.3/opam /usr/local/bin/opam-2.3 && chmod a+x /usr/local/bin/opam-2.3 && rm -rf /tmp/opam-build-2.3
+	RUN cd /tmp/opam-sources && cp -P -R -p . ../opam-build-2.4 && cd ../opam-build-2.4 && git fetch -q && git checkout 2.4 && ln -s ../opam/src_ext/archives src_ext/archives && env PATH="/tmp/opam/bootstrap/ocaml/bin:$PATH" ./configure --enable-cold-check --with-0install-solver --with-vendored-deps && env PATH="/tmp/opam/bootstrap/ocaml/bin:$PATH" make lib-ext all && mkdir -p /usr/local/bin && cp /tmp/opam-build-2.4/opam /usr/local/bin/opam-2.4 && chmod a+x /usr/local/bin/opam-2.4 && rm -rf /tmp/opam-build-2.4
+	RUN cd /tmp/opam-sources && cp -P -R -p . ../opam-build-2.5 && cd ../opam-build-2.5 && git fetch -q && git checkout 2.5 && ln -s ../opam/src_ext/archives src_ext/archives && env PATH="/tmp/opam/bootstrap/ocaml/bin:$PATH" ./configure --enable-cold-check --with-0install-solver --with-vendored-deps && env PATH="/tmp/opam/bootstrap/ocaml/bin:$PATH" make lib-ext all && mkdir -p /usr/local/bin && cp /tmp/opam-build-2.5/opam /usr/local/bin/opam-2.5 && chmod a+x /usr/local/bin/opam-2.5 && rm -rf /tmp/opam-build-2.5
+	RUN cd /tmp/opam-sources && cp -P -R -p . ../opam-build-master && cd ../opam-build-master && git fetch -q && git checkout master && ln -s ../opam/src_ext/archives src_ext/archives && env PATH="/tmp/opam/bootstrap/ocaml/bin:$PATH" ./configure --enable-cold-check --with-0install-solver --with-vendored-deps && env PATH="/tmp/opam/bootstrap/ocaml/bin:$PATH" make lib-ext all && mkdir -p /usr/local/bin && cp /tmp/opam-build-master/opam /usr/local/bin/opam-master && chmod a+x /usr/local/bin/opam-master && rm -rf /tmp/opam-build-master
+
+	FROM ubuntu:resolute
+	RUN ln -fs /usr/share/zoneinfo/Europe/London /etc/localtime
+	COPY <<-EOF /etc/apt/apt.conf.d/mirror-retry
+		Acquire::Retries "5";
+	EOF
+	RUN apt-get -y update
+	RUN DEBIAN_FRONTEND=noninteractive apt-get -y upgrade
+	RUN DEBIAN_FRONTEND=noninteractive apt-get -y install build-essential curl git rsync sudo unzip nano libcap-dev libx11-dev bubblewrap
+	RUN apt-get install -y --allow-remove-essential coreutils-from-gnu coreutils-from-uutils-
+	COPY --from=0 [ "/usr/local/bin/opam-2.0", "/usr/bin/opam-2.0" ]
+	RUN ln /usr/bin/opam-2.0 /usr/bin/opam
+	COPY --from=0 [ "/usr/local/bin/opam-2.1", "/usr/bin/opam-2.1" ]
+	COPY --from=0 [ "/usr/local/bin/opam-2.2", "/usr/bin/opam-2.2" ]
+	COPY --from=0 [ "/usr/local/bin/opam-2.3", "/usr/bin/opam-2.3" ]
+	COPY --from=0 [ "/usr/local/bin/opam-2.4", "/usr/bin/opam-2.4" ]
+	COPY --from=0 [ "/usr/local/bin/opam-2.5", "/usr/bin/opam-2.5" ]
+	COPY --from=0 [ "/usr/local/bin/opam-master", "/usr/bin/opam-dev" ]
+	RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
+	COPY <<-EOF /etc/sudoers.d/opam
+		opam ALL=(ALL:ALL) NOPASSWD:ALL
+	EOF
+	RUN chmod 440 /etc/sudoers.d/opam
+	RUN chown root:root /etc/sudoers.d/opam
+	RUN if getent passwd 1000; then userdel -r $(id -nu 1000); fi
+	RUN useradd --uid 1000 --create-home --shell /bin/bash opam
+	RUN passwd -l opam
+	RUN chown -R opam:opam /home/opam
+	USER opam
+	ENV HOME="/home/opam"
+	WORKDIR /home/opam
+	RUN mkdir .ssh
+	RUN chmod 700 .ssh
+	COPY --chown=opam <<-EOF /home/opam/.opamrc-nosandbox
+		wrap-build-commands: []
+		wrap-install-commands: []
+		wrap-remove-commands: []
+		required-tools: []
+	EOF
+	COPY --chown=opam <<-EOF /home/opam/opam-sandbox-disable
+		#!/bin/sh
+		cp ~/.opamrc-nosandbox ~/.opamrc
+		echo --- opam sandboxing disabled
+	EOF
+	RUN chmod a+x /home/opam/opam-sandbox-disable
+	RUN sudo mv /home/opam/opam-sandbox-disable /usr/bin/opam-sandbox-disable
+	COPY --chown=opam <<-EOF /home/opam/.opamrc-sandbox
+		wrap-build-commands: ["%{hooks}%/sandbox.sh" "build"]
+		wrap-install-commands: ["%{hooks}%/sandbox.sh" "install"]
+		wrap-remove-commands: ["%{hooks}%/sandbox.sh" "remove"]
+	EOF
+	COPY --chown=opam <<-EOF /home/opam/opam-sandbox-enable
+		#!/bin/sh
+		cp ~/.opamrc-sandbox ~/.opamrc
+		echo --- opam sandboxing enabled
+	EOF
+	RUN chmod a+x /home/opam/opam-sandbox-enable
+	RUN sudo mv /home/opam/opam-sandbox-enable /usr/bin/opam-sandbox-enable
+	RUN git config --global user.email "docker@example.com"
+	RUN git config --global user.name "Docker"
+	COPY --link --chown=opam:opam [ ".", "/home/opam/opam-repository" ]
+	RUN opam-sandbox-disable
+	RUN opam init -k git -a /home/opam/opam-repository --bare
+	RUN echo 'archive-mirrors: "https://opam.ocaml.org/cache"' >> ~/.opam/config
+	RUN rm -rf .opam/repo/default/.git
+	COPY --link [ "Dockerfile", "/Dockerfile.opam" ]
+
+ocurrent/opam-staging:ubuntu-26.04-opam-s390x, ocurrent/opam-staging:ubuntu-26.04-opam-ppc64le, ocurrent/opam-staging:ubuntu-26.04-opam-arm64, ocurrent/opam-staging:ubuntu-26.04-opam-amd64 -> ocaml/opam:ubuntu-26.04-opam
+4.08.1/s390x
+	# syntax=docker/dockerfile:1
+
+	FROM ocurrent/opam-staging:ubuntu-26.04-opam-s390x
+	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
+	RUN opam switch create 4.08 --packages=ocaml-base-compiler.4.08.1
+	RUN opam pin add -k version ocaml-base-compiler 4.08.1
+	RUN opam install -y opam-depext
+	ENTRYPOINT [ "opam", "exec", "--" ]
+	CMD bash
+	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
+
+4.08.1/ppc64le
+	# syntax=docker/dockerfile:1
+
+	FROM ocurrent/opam-staging:ubuntu-26.04-opam-ppc64le
+	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
+	RUN opam switch create 4.08 --packages=ocaml-base-compiler.4.08.1
+	RUN opam pin add -k version ocaml-base-compiler 4.08.1
+	RUN opam install -y opam-depext
+	ENTRYPOINT [ "opam", "exec", "--" ]
+	CMD bash
+	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
+
+4.08.1/arm64
+	# syntax=docker/dockerfile:1
+
+	FROM ocurrent/opam-staging:ubuntu-26.04-opam-arm64
+	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
+	RUN opam switch create 4.08 --packages=ocaml-base-compiler.4.08.1
+	RUN opam pin add -k version ocaml-base-compiler 4.08.1
+	RUN opam install -y opam-depext
+	ENTRYPOINT [ "opam", "exec", "--" ]
+	CMD bash
+	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
+
+4.08.1/amd64
+	# syntax=docker/dockerfile:1
+
+	FROM ocurrent/opam-staging:ubuntu-26.04-opam-amd64
+	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
+	RUN opam switch create 4.08 --packages=ocaml-base-compiler.4.08.1
+	RUN opam pin add -k version ocaml-base-compiler 4.08.1
+	RUN opam install -y opam-depext
+	ENTRYPOINT [ "opam", "exec", "--" ]
+	CMD bash
+	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
+
+ocurrent/opam-staging:ubuntu-26.04-ocaml-4.08-s390x, ocurrent/opam-staging:ubuntu-26.04-ocaml-4.08-ppc64le, ocurrent/opam-staging:ubuntu-26.04-ocaml-4.08-arm64, ocurrent/opam-staging:ubuntu-26.04-ocaml-4.08-amd64 -> ocaml/opam:ubuntu-26.04-ocaml-4.08
+ocurrent/opam-staging:ubuntu-26.04-ocaml-4.08-s390x, ocurrent/opam-staging:ubuntu-26.04-ocaml-4.08-ppc64le, ocurrent/opam-staging:ubuntu-26.04-ocaml-4.08-arm64, ocurrent/opam-staging:ubuntu-26.04-ocaml-4.08-amd64 -> ocaml/opam:ubuntu-lts-ocaml-4.08
+ocurrent/opam-staging:ubuntu-26.04-ocaml-4.08-s390x, ocurrent/opam-staging:ubuntu-26.04-ocaml-4.08-ppc64le, ocurrent/opam-staging:ubuntu-26.04-ocaml-4.08-arm64, ocurrent/opam-staging:ubuntu-26.04-ocaml-4.08-amd64 -> ocaml/opam:ubuntu-ocaml-4.08
+4.11.2/s390x
+	# syntax=docker/dockerfile:1
+
+	FROM ocurrent/opam-staging:ubuntu-26.04-opam-s390x
+	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
+	RUN opam switch create 4.11 --packages=ocaml-base-compiler.4.11.2
+	RUN opam pin add -k version ocaml-base-compiler 4.11.2
+	RUN opam install -y opam-depext
+	ENTRYPOINT [ "opam", "exec", "--" ]
+	CMD bash
+	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
+
+4.11.2/ppc64le
+	# syntax=docker/dockerfile:1
+
+	FROM ocurrent/opam-staging:ubuntu-26.04-opam-ppc64le
+	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
+	RUN opam switch create 4.11 --packages=ocaml-base-compiler.4.11.2
+	RUN opam pin add -k version ocaml-base-compiler 4.11.2
+	RUN opam install -y opam-depext
+	ENTRYPOINT [ "opam", "exec", "--" ]
+	CMD bash
+	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
+
+4.11.2/arm64
+	# syntax=docker/dockerfile:1
+
+	FROM ocurrent/opam-staging:ubuntu-26.04-opam-arm64
+	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
+	RUN opam switch create 4.11 --packages=ocaml-base-compiler.4.11.2
+	RUN opam pin add -k version ocaml-base-compiler 4.11.2
+	RUN opam install -y opam-depext
+	ENTRYPOINT [ "opam", "exec", "--" ]
+	CMD bash
+	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
+
+4.11.2/amd64
+	# syntax=docker/dockerfile:1
+
+	FROM ocurrent/opam-staging:ubuntu-26.04-opam-amd64
+	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
+	RUN opam switch create 4.11 --packages=ocaml-base-compiler.4.11.2
+	RUN opam pin add -k version ocaml-base-compiler 4.11.2
+	RUN opam install -y opam-depext
+	ENTRYPOINT [ "opam", "exec", "--" ]
+	CMD bash
+	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
+
+ocurrent/opam-staging:ubuntu-26.04-ocaml-4.11-s390x, ocurrent/opam-staging:ubuntu-26.04-ocaml-4.11-ppc64le, ocurrent/opam-staging:ubuntu-26.04-ocaml-4.11-arm64, ocurrent/opam-staging:ubuntu-26.04-ocaml-4.11-amd64 -> ocaml/opam:ubuntu-26.04-ocaml-4.11
+ocurrent/opam-staging:ubuntu-26.04-ocaml-4.11-s390x, ocurrent/opam-staging:ubuntu-26.04-ocaml-4.11-ppc64le, ocurrent/opam-staging:ubuntu-26.04-ocaml-4.11-arm64, ocurrent/opam-staging:ubuntu-26.04-ocaml-4.11-amd64 -> ocaml/opam:ubuntu-lts-ocaml-4.11
+ocurrent/opam-staging:ubuntu-26.04-ocaml-4.11-s390x, ocurrent/opam-staging:ubuntu-26.04-ocaml-4.11-ppc64le, ocurrent/opam-staging:ubuntu-26.04-ocaml-4.11-arm64, ocurrent/opam-staging:ubuntu-26.04-ocaml-4.11-amd64 -> ocaml/opam:ubuntu-ocaml-4.11
+4.14.3/s390x
+	# syntax=docker/dockerfile:1
+
+	FROM ocurrent/opam-staging:ubuntu-26.04-opam-s390x
+	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
+	RUN opam switch create 4.14 --packages=ocaml-base-compiler.4.14.3
+	RUN opam pin add -k version ocaml-base-compiler 4.14.3
+	RUN opam install -y opam-depext
+	ENTRYPOINT [ "opam", "exec", "--" ]
+	CMD bash
+	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
+
+4.14.3/ppc64le
+	# syntax=docker/dockerfile:1
+
+	FROM ocurrent/opam-staging:ubuntu-26.04-opam-ppc64le
+	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
+	RUN opam switch create 4.14 --packages=ocaml-base-compiler.4.14.3
+	RUN opam pin add -k version ocaml-base-compiler 4.14.3
+	RUN opam install -y opam-depext
+	ENTRYPOINT [ "opam", "exec", "--" ]
+	CMD bash
+	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
+
+4.14.3/arm64
+	# syntax=docker/dockerfile:1
+
+	FROM ocurrent/opam-staging:ubuntu-26.04-opam-arm64
+	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
+	RUN opam switch create 4.14 --packages=ocaml-base-compiler.4.14.3
+	RUN opam pin add -k version ocaml-base-compiler 4.14.3
+	RUN opam install -y opam-depext
+	ENTRYPOINT [ "opam", "exec", "--" ]
+	CMD bash
+	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
+
+4.14.3/amd64
+	# syntax=docker/dockerfile:1
+
+	FROM ocurrent/opam-staging:ubuntu-26.04-opam-amd64
+	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
+	RUN opam switch create 4.14 --packages=ocaml-base-compiler.4.14.3
+	RUN opam pin add -k version ocaml-base-compiler 4.14.3
+	RUN opam install -y opam-depext
+	ENTRYPOINT [ "opam", "exec", "--" ]
+	CMD bash
+	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
+
+ocurrent/opam-staging:ubuntu-26.04-ocaml-4.14-s390x, ocurrent/opam-staging:ubuntu-26.04-ocaml-4.14-ppc64le, ocurrent/opam-staging:ubuntu-26.04-ocaml-4.14-arm64, ocurrent/opam-staging:ubuntu-26.04-ocaml-4.14-amd64 -> ocaml/opam:ubuntu-26.04-ocaml-4.14
+ocurrent/opam-staging:ubuntu-26.04-ocaml-4.14-s390x, ocurrent/opam-staging:ubuntu-26.04-ocaml-4.14-ppc64le, ocurrent/opam-staging:ubuntu-26.04-ocaml-4.14-arm64, ocurrent/opam-staging:ubuntu-26.04-ocaml-4.14-amd64 -> ocaml/opam:ubuntu-lts-ocaml-4.14
+ocurrent/opam-staging:ubuntu-26.04-ocaml-4.14-s390x, ocurrent/opam-staging:ubuntu-26.04-ocaml-4.14-ppc64le, ocurrent/opam-staging:ubuntu-26.04-ocaml-4.14-arm64, ocurrent/opam-staging:ubuntu-26.04-ocaml-4.14-amd64 -> ocaml/opam:ubuntu-ocaml-4.14
+5.2.1/s390x
+	# syntax=docker/dockerfile:1
+
+	FROM ocurrent/opam-staging:ubuntu-26.04-opam-s390x
+	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
+	USER root
+	RUN apt-get -y update
+	RUN DEBIAN_FRONTEND=noninteractive apt-get -y upgrade
+	RUN DEBIAN_FRONTEND=noninteractive apt-get -y install libzstd-dev
+	USER opam
+	RUN opam switch create 5.2 --packages=ocaml-base-compiler.5.2.1
+	RUN opam pin add -k version ocaml-base-compiler 5.2.1
+	RUN opam install -y opam-depext
+	ENTRYPOINT [ "opam", "exec", "--" ]
+	CMD bash
+	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
+
+5.2.1/ppc64le
+	# syntax=docker/dockerfile:1
+
+	FROM ocurrent/opam-staging:ubuntu-26.04-opam-ppc64le
+	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
+	USER root
+	RUN apt-get -y update
+	RUN DEBIAN_FRONTEND=noninteractive apt-get -y upgrade
+	RUN DEBIAN_FRONTEND=noninteractive apt-get -y install libzstd-dev
+	USER opam
+	RUN opam switch create 5.2 --packages=ocaml-base-compiler.5.2.1
+	RUN opam pin add -k version ocaml-base-compiler 5.2.1
+	RUN opam install -y opam-depext
+	ENTRYPOINT [ "opam", "exec", "--" ]
+	CMD bash
+	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
+
+5.2.1/arm64
+	# syntax=docker/dockerfile:1
+
+	FROM ocurrent/opam-staging:ubuntu-26.04-opam-arm64
+	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
+	USER root
+	RUN apt-get -y update
+	RUN DEBIAN_FRONTEND=noninteractive apt-get -y upgrade
+	RUN DEBIAN_FRONTEND=noninteractive apt-get -y install libzstd-dev
+	USER opam
+	RUN opam switch create 5.2 --packages=ocaml-base-compiler.5.2.1
+	RUN opam pin add -k version ocaml-base-compiler 5.2.1
+	RUN opam install -y opam-depext
+	ENTRYPOINT [ "opam", "exec", "--" ]
+	CMD bash
+	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
+
+5.2.1/amd64
+	# syntax=docker/dockerfile:1
+
+	FROM ocurrent/opam-staging:ubuntu-26.04-opam-amd64
+	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
+	USER root
+	RUN apt-get -y update
+	RUN DEBIAN_FRONTEND=noninteractive apt-get -y upgrade
+	RUN DEBIAN_FRONTEND=noninteractive apt-get -y install libzstd-dev
+	USER opam
+	RUN opam switch create 5.2 --packages=ocaml-base-compiler.5.2.1
+	RUN opam pin add -k version ocaml-base-compiler 5.2.1
+	RUN opam install -y opam-depext
+	ENTRYPOINT [ "opam", "exec", "--" ]
+	CMD bash
+	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
+
+ocurrent/opam-staging:ubuntu-26.04-ocaml-5.2-s390x, ocurrent/opam-staging:ubuntu-26.04-ocaml-5.2-ppc64le, ocurrent/opam-staging:ubuntu-26.04-ocaml-5.2-arm64, ocurrent/opam-staging:ubuntu-26.04-ocaml-5.2-amd64 -> ocaml/opam:ubuntu-26.04-ocaml-5.2
+ocurrent/opam-staging:ubuntu-26.04-ocaml-5.2-s390x, ocurrent/opam-staging:ubuntu-26.04-ocaml-5.2-ppc64le, ocurrent/opam-staging:ubuntu-26.04-ocaml-5.2-arm64, ocurrent/opam-staging:ubuntu-26.04-ocaml-5.2-amd64 -> ocaml/opam:ubuntu-lts-ocaml-5.2
+ocurrent/opam-staging:ubuntu-26.04-ocaml-5.2-s390x, ocurrent/opam-staging:ubuntu-26.04-ocaml-5.2-ppc64le, ocurrent/opam-staging:ubuntu-26.04-ocaml-5.2-arm64, ocurrent/opam-staging:ubuntu-26.04-ocaml-5.2-amd64 -> ocaml/opam:ubuntu-ocaml-5.2
+5.3.0/s390x
+	# syntax=docker/dockerfile:1
+
+	FROM ocurrent/opam-staging:ubuntu-26.04-opam-s390x
+	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
+	USER root
+	RUN apt-get -y update
+	RUN DEBIAN_FRONTEND=noninteractive apt-get -y upgrade
+	RUN DEBIAN_FRONTEND=noninteractive apt-get -y install libzstd-dev
+	USER opam
+	RUN opam switch create 5.3 --packages=ocaml-base-compiler.5.3.0
+	RUN opam pin add -k version ocaml-base-compiler 5.3.0
+	RUN opam install -y opam-depext
+	ENTRYPOINT [ "opam", "exec", "--" ]
+	CMD bash
+	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
+
+5.3.0/ppc64le
+	# syntax=docker/dockerfile:1
+
+	FROM ocurrent/opam-staging:ubuntu-26.04-opam-ppc64le
+	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
+	USER root
+	RUN apt-get -y update
+	RUN DEBIAN_FRONTEND=noninteractive apt-get -y upgrade
+	RUN DEBIAN_FRONTEND=noninteractive apt-get -y install libzstd-dev
+	USER opam
+	RUN opam switch create 5.3 --packages=ocaml-base-compiler.5.3.0
+	RUN opam pin add -k version ocaml-base-compiler 5.3.0
+	RUN opam install -y opam-depext
+	ENTRYPOINT [ "opam", "exec", "--" ]
+	CMD bash
+	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
+
+5.3.0/arm64
+	# syntax=docker/dockerfile:1
+
+	FROM ocurrent/opam-staging:ubuntu-26.04-opam-arm64
+	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
+	USER root
+	RUN apt-get -y update
+	RUN DEBIAN_FRONTEND=noninteractive apt-get -y upgrade
+	RUN DEBIAN_FRONTEND=noninteractive apt-get -y install libzstd-dev
+	USER opam
+	RUN opam switch create 5.3 --packages=ocaml-base-compiler.5.3.0
+	RUN opam pin add -k version ocaml-base-compiler 5.3.0
+	RUN opam install -y opam-depext
+	ENTRYPOINT [ "opam", "exec", "--" ]
+	CMD bash
+	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
+
+5.3.0/amd64
+	# syntax=docker/dockerfile:1
+
+	FROM ocurrent/opam-staging:ubuntu-26.04-opam-amd64
+	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
+	USER root
+	RUN apt-get -y update
+	RUN DEBIAN_FRONTEND=noninteractive apt-get -y upgrade
+	RUN DEBIAN_FRONTEND=noninteractive apt-get -y install libzstd-dev
+	USER opam
+	RUN opam switch create 5.3 --packages=ocaml-base-compiler.5.3.0
+	RUN opam pin add -k version ocaml-base-compiler 5.3.0
+	RUN opam install -y opam-depext
+	ENTRYPOINT [ "opam", "exec", "--" ]
+	CMD bash
+	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
+
+ocurrent/opam-staging:ubuntu-26.04-ocaml-5.3-s390x, ocurrent/opam-staging:ubuntu-26.04-ocaml-5.3-ppc64le, ocurrent/opam-staging:ubuntu-26.04-ocaml-5.3-arm64, ocurrent/opam-staging:ubuntu-26.04-ocaml-5.3-amd64 -> ocaml/opam:ubuntu-26.04-ocaml-5.3
+ocurrent/opam-staging:ubuntu-26.04-ocaml-5.3-s390x, ocurrent/opam-staging:ubuntu-26.04-ocaml-5.3-ppc64le, ocurrent/opam-staging:ubuntu-26.04-ocaml-5.3-arm64, ocurrent/opam-staging:ubuntu-26.04-ocaml-5.3-amd64 -> ocaml/opam:ubuntu-lts-ocaml-5.3
+ocurrent/opam-staging:ubuntu-26.04-ocaml-5.3-s390x, ocurrent/opam-staging:ubuntu-26.04-ocaml-5.3-ppc64le, ocurrent/opam-staging:ubuntu-26.04-ocaml-5.3-arm64, ocurrent/opam-staging:ubuntu-26.04-ocaml-5.3-amd64 -> ocaml/opam:ubuntu-ocaml-5.3
+5.4.1/s390x
+	# syntax=docker/dockerfile:1
+
+	FROM ocurrent/opam-staging:ubuntu-26.04-opam-s390x
+	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
+	USER root
+	RUN apt-get -y update
+	RUN DEBIAN_FRONTEND=noninteractive apt-get -y upgrade
+	RUN DEBIAN_FRONTEND=noninteractive apt-get -y install libzstd-dev
+	USER opam
+	RUN opam switch create 5.4 --packages=ocaml-base-compiler.5.4.1
+	RUN opam pin add -k version ocaml-base-compiler 5.4.1
+	RUN opam install -y opam-depext
+	ENTRYPOINT [ "opam", "exec", "--" ]
+	CMD bash
+	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
+
+5.4.1/ppc64le
+	# syntax=docker/dockerfile:1
+
+	FROM ocurrent/opam-staging:ubuntu-26.04-opam-ppc64le
+	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
+	USER root
+	RUN apt-get -y update
+	RUN DEBIAN_FRONTEND=noninteractive apt-get -y upgrade
+	RUN DEBIAN_FRONTEND=noninteractive apt-get -y install libzstd-dev
+	USER opam
+	RUN opam switch create 5.4 --packages=ocaml-base-compiler.5.4.1
+	RUN opam pin add -k version ocaml-base-compiler 5.4.1
+	RUN opam install -y opam-depext
+	ENTRYPOINT [ "opam", "exec", "--" ]
+	CMD bash
+	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
+
+5.4.1/arm64
+	# syntax=docker/dockerfile:1
+
+	FROM ocurrent/opam-staging:ubuntu-26.04-opam-arm64
+	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
+	USER root
+	RUN apt-get -y update
+	RUN DEBIAN_FRONTEND=noninteractive apt-get -y upgrade
+	RUN DEBIAN_FRONTEND=noninteractive apt-get -y install libzstd-dev
+	USER opam
+	RUN opam switch create 5.4 --packages=ocaml-base-compiler.5.4.1
+	RUN opam pin add -k version ocaml-base-compiler 5.4.1
+	RUN opam install -y opam-depext
+	ENTRYPOINT [ "opam", "exec", "--" ]
+	CMD bash
+	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
+
+5.4.1/amd64
+	# syntax=docker/dockerfile:1
+
+	FROM ocurrent/opam-staging:ubuntu-26.04-opam-amd64
+	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
+	USER root
+	RUN apt-get -y update
+	RUN DEBIAN_FRONTEND=noninteractive apt-get -y upgrade
+	RUN DEBIAN_FRONTEND=noninteractive apt-get -y install libzstd-dev
+	USER opam
+	RUN opam switch create 5.4 --packages=ocaml-base-compiler.5.4.1
+	RUN opam pin add -k version ocaml-base-compiler 5.4.1
+	RUN opam install -y opam-depext
+	ENTRYPOINT [ "opam", "exec", "--" ]
+	CMD bash
+	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
+
+ocurrent/opam-staging:ubuntu-26.04-ocaml-5.4-s390x, ocurrent/opam-staging:ubuntu-26.04-ocaml-5.4-ppc64le, ocurrent/opam-staging:ubuntu-26.04-ocaml-5.4-arm64, ocurrent/opam-staging:ubuntu-26.04-ocaml-5.4-amd64 -> ocaml/opam:ubuntu-lts
+ocurrent/opam-staging:ubuntu-26.04-ocaml-5.4-s390x, ocurrent/opam-staging:ubuntu-26.04-ocaml-5.4-ppc64le, ocurrent/opam-staging:ubuntu-26.04-ocaml-5.4-arm64, ocurrent/opam-staging:ubuntu-26.04-ocaml-5.4-amd64 -> ocaml/opam:ubuntu
+ocurrent/opam-staging:ubuntu-26.04-ocaml-5.4-s390x, ocurrent/opam-staging:ubuntu-26.04-ocaml-5.4-ppc64le, ocurrent/opam-staging:ubuntu-26.04-ocaml-5.4-arm64, ocurrent/opam-staging:ubuntu-26.04-ocaml-5.4-amd64 -> ocaml/opam:ubuntu-26.04
+ocurrent/opam-staging:ubuntu-26.04-ocaml-5.4-s390x, ocurrent/opam-staging:ubuntu-26.04-ocaml-5.4-ppc64le, ocurrent/opam-staging:ubuntu-26.04-ocaml-5.4-arm64, ocurrent/opam-staging:ubuntu-26.04-ocaml-5.4-amd64 -> ocaml/opam:ubuntu-26.04-ocaml-5.4
+ocurrent/opam-staging:ubuntu-26.04-ocaml-5.4-s390x, ocurrent/opam-staging:ubuntu-26.04-ocaml-5.4-ppc64le, ocurrent/opam-staging:ubuntu-26.04-ocaml-5.4-arm64, ocurrent/opam-staging:ubuntu-26.04-ocaml-5.4-amd64 -> ocaml/opam:ubuntu-lts-ocaml-5.4
+ocurrent/opam-staging:ubuntu-26.04-ocaml-5.4-s390x, ocurrent/opam-staging:ubuntu-26.04-ocaml-5.4-ppc64le, ocurrent/opam-staging:ubuntu-26.04-ocaml-5.4-arm64, ocurrent/opam-staging:ubuntu-26.04-ocaml-5.4-amd64 -> ocaml/opam:ubuntu-ocaml-5.4
+5.5.0~beta1/s390x
+	# syntax=docker/dockerfile:1
+
+	FROM ocurrent/opam-staging:ubuntu-26.04-opam-s390x
+	RUN opam repo add beta git+https://github.com/ocaml/ocaml-beta-repository --set-default
+	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
+	USER root
+	RUN apt-get -y update
+	RUN DEBIAN_FRONTEND=noninteractive apt-get -y upgrade
+	RUN DEBIAN_FRONTEND=noninteractive apt-get -y install libzstd-dev
+	USER opam
+	RUN opam switch create 5.5~beta1 --packages=ocaml-base-compiler.5.5.0~beta1
+	RUN opam pin add -k version ocaml-base-compiler 5.5.0~beta1
+	RUN opam install -y opam-depext
+	ENTRYPOINT [ "opam", "exec", "--" ]
+	CMD bash
+	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
+
+5.5.0~beta1/ppc64le
+	# syntax=docker/dockerfile:1
+
+	FROM ocurrent/opam-staging:ubuntu-26.04-opam-ppc64le
+	RUN opam repo add beta git+https://github.com/ocaml/ocaml-beta-repository --set-default
+	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
+	USER root
+	RUN apt-get -y update
+	RUN DEBIAN_FRONTEND=noninteractive apt-get -y upgrade
+	RUN DEBIAN_FRONTEND=noninteractive apt-get -y install libzstd-dev
+	USER opam
+	RUN opam switch create 5.5~beta1 --packages=ocaml-base-compiler.5.5.0~beta1
+	RUN opam pin add -k version ocaml-base-compiler 5.5.0~beta1
+	RUN opam install -y opam-depext
+	ENTRYPOINT [ "opam", "exec", "--" ]
+	CMD bash
+	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
+
+5.5.0~beta1/arm64
+	# syntax=docker/dockerfile:1
+
+	FROM ocurrent/opam-staging:ubuntu-26.04-opam-arm64
+	RUN opam repo add beta git+https://github.com/ocaml/ocaml-beta-repository --set-default
+	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
+	USER root
+	RUN apt-get -y update
+	RUN DEBIAN_FRONTEND=noninteractive apt-get -y upgrade
+	RUN DEBIAN_FRONTEND=noninteractive apt-get -y install libzstd-dev
+	USER opam
+	RUN opam switch create 5.5~beta1 --packages=ocaml-base-compiler.5.5.0~beta1
+	RUN opam pin add -k version ocaml-base-compiler 5.5.0~beta1
+	RUN opam install -y opam-depext
+	ENTRYPOINT [ "opam", "exec", "--" ]
+	CMD bash
+	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
+
+5.5.0~beta1/amd64
+	# syntax=docker/dockerfile:1
+
+	FROM ocurrent/opam-staging:ubuntu-26.04-opam-amd64
+	RUN opam repo add beta git+https://github.com/ocaml/ocaml-beta-repository --set-default
+	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
+	USER root
+	RUN apt-get -y update
+	RUN DEBIAN_FRONTEND=noninteractive apt-get -y upgrade
+	RUN DEBIAN_FRONTEND=noninteractive apt-get -y install libzstd-dev
+	USER opam
+	RUN opam switch create 5.5~beta1 --packages=ocaml-base-compiler.5.5.0~beta1
+	RUN opam pin add -k version ocaml-base-compiler 5.5.0~beta1
+	RUN opam install -y opam-depext
+	ENTRYPOINT [ "opam", "exec", "--" ]
+	CMD bash
+	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
+
+ocurrent/opam-staging:ubuntu-26.04-ocaml-5.5-beta1-s390x, ocurrent/opam-staging:ubuntu-26.04-ocaml-5.5-beta1-ppc64le, ocurrent/opam-staging:ubuntu-26.04-ocaml-5.5-beta1-arm64, ocurrent/opam-staging:ubuntu-26.04-ocaml-5.5-beta1-amd64 -> ocaml/opam:ubuntu-26.04-ocaml-5.5-beta1
+ocurrent/opam-staging:ubuntu-26.04-ocaml-5.5-beta1-s390x, ocurrent/opam-staging:ubuntu-26.04-ocaml-5.5-beta1-ppc64le, ocurrent/opam-staging:ubuntu-26.04-ocaml-5.5-beta1-arm64, ocurrent/opam-staging:ubuntu-26.04-ocaml-5.5-beta1-amd64 -> ocaml/opam:ubuntu-lts-ocaml-5.5-beta1
+ocurrent/opam-staging:ubuntu-26.04-ocaml-5.5-beta1-s390x, ocurrent/opam-staging:ubuntu-26.04-ocaml-5.5-beta1-ppc64le, ocurrent/opam-staging:ubuntu-26.04-ocaml-5.5-beta1-arm64, ocurrent/opam-staging:ubuntu-26.04-ocaml-5.5-beta1-amd64 -> ocaml/opam:ubuntu-ocaml-5.5-beta1
+5.5.0/s390x
+	# syntax=docker/dockerfile:1
+
+	FROM ocurrent/opam-staging:ubuntu-26.04-opam-s390x
+	RUN opam repo add beta git+https://github.com/ocaml/ocaml-beta-repository --set-default
+	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
+	USER root
+	RUN apt-get -y update
+	RUN DEBIAN_FRONTEND=noninteractive apt-get -y upgrade
+	RUN DEBIAN_FRONTEND=noninteractive apt-get -y install libzstd-dev
+	USER opam
+	RUN opam switch create 5.5 --packages=ocaml-variants.5.5.0+trunk
+	RUN opam pin add -k version ocaml-variants 5.5.0+trunk
+	RUN opam install -y opam-depext
+	ENTRYPOINT [ "opam", "exec", "--" ]
+	CMD bash
+	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
+
+5.5.0/ppc64le
+	# syntax=docker/dockerfile:1
+
+	FROM ocurrent/opam-staging:ubuntu-26.04-opam-ppc64le
+	RUN opam repo add beta git+https://github.com/ocaml/ocaml-beta-repository --set-default
+	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
+	USER root
+	RUN apt-get -y update
+	RUN DEBIAN_FRONTEND=noninteractive apt-get -y upgrade
+	RUN DEBIAN_FRONTEND=noninteractive apt-get -y install libzstd-dev
+	USER opam
+	RUN opam switch create 5.5 --packages=ocaml-variants.5.5.0+trunk
+	RUN opam pin add -k version ocaml-variants 5.5.0+trunk
+	RUN opam install -y opam-depext
+	ENTRYPOINT [ "opam", "exec", "--" ]
+	CMD bash
+	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
+
+5.5.0/arm64
+	# syntax=docker/dockerfile:1
+
+	FROM ocurrent/opam-staging:ubuntu-26.04-opam-arm64
+	RUN opam repo add beta git+https://github.com/ocaml/ocaml-beta-repository --set-default
+	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
+	USER root
+	RUN apt-get -y update
+	RUN DEBIAN_FRONTEND=noninteractive apt-get -y upgrade
+	RUN DEBIAN_FRONTEND=noninteractive apt-get -y install libzstd-dev
+	USER opam
+	RUN opam switch create 5.5 --packages=ocaml-variants.5.5.0+trunk
+	RUN opam pin add -k version ocaml-variants 5.5.0+trunk
+	RUN opam install -y opam-depext
+	ENTRYPOINT [ "opam", "exec", "--" ]
+	CMD bash
+	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
+
+5.5.0/amd64
+	# syntax=docker/dockerfile:1
+
+	FROM ocurrent/opam-staging:ubuntu-26.04-opam-amd64
+	RUN opam repo add beta git+https://github.com/ocaml/ocaml-beta-repository --set-default
+	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
+	USER root
+	RUN apt-get -y update
+	RUN DEBIAN_FRONTEND=noninteractive apt-get -y upgrade
+	RUN DEBIAN_FRONTEND=noninteractive apt-get -y install libzstd-dev
+	USER opam
+	RUN opam switch create 5.5 --packages=ocaml-variants.5.5.0+trunk
+	RUN opam pin add -k version ocaml-variants 5.5.0+trunk
+	RUN opam install -y opam-depext
+	ENTRYPOINT [ "opam", "exec", "--" ]
+	CMD bash
+	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
+
+ocurrent/opam-staging:ubuntu-26.04-ocaml-5.5-s390x, ocurrent/opam-staging:ubuntu-26.04-ocaml-5.5-ppc64le, ocurrent/opam-staging:ubuntu-26.04-ocaml-5.5-arm64, ocurrent/opam-staging:ubuntu-26.04-ocaml-5.5-amd64 -> ocaml/opam:ubuntu-26.04-ocaml-5.5
+ocurrent/opam-staging:ubuntu-26.04-ocaml-5.5-s390x, ocurrent/opam-staging:ubuntu-26.04-ocaml-5.5-ppc64le, ocurrent/opam-staging:ubuntu-26.04-ocaml-5.5-arm64, ocurrent/opam-staging:ubuntu-26.04-ocaml-5.5-amd64 -> ocaml/opam:ubuntu-lts-ocaml-5.5
+ocurrent/opam-staging:ubuntu-26.04-ocaml-5.5-s390x, ocurrent/opam-staging:ubuntu-26.04-ocaml-5.5-ppc64le, ocurrent/opam-staging:ubuntu-26.04-ocaml-5.5-arm64, ocurrent/opam-staging:ubuntu-26.04-ocaml-5.5-amd64 -> ocaml/opam:ubuntu-ocaml-5.5
+5.6.0/s390x
+	# syntax=docker/dockerfile:1
+
+	FROM ocurrent/opam-staging:ubuntu-26.04-opam-s390x
+	RUN opam repo add beta git+https://github.com/ocaml/ocaml-beta-repository --set-default
+	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
+	USER root
+	RUN apt-get -y update
+	RUN DEBIAN_FRONTEND=noninteractive apt-get -y upgrade
+	RUN DEBIAN_FRONTEND=noninteractive apt-get -y install libzstd-dev
+	USER opam
+	RUN opam switch create 5.6 --packages=ocaml-variants.5.6.0+trunk
+	RUN opam pin add -k version ocaml-variants 5.6.0+trunk
+	RUN opam install -y opam-depext
+	ENTRYPOINT [ "opam", "exec", "--" ]
+	CMD bash
+	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
+
+5.6.0/ppc64le
+	# syntax=docker/dockerfile:1
+
+	FROM ocurrent/opam-staging:ubuntu-26.04-opam-ppc64le
+	RUN opam repo add beta git+https://github.com/ocaml/ocaml-beta-repository --set-default
+	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
+	USER root
+	RUN apt-get -y update
+	RUN DEBIAN_FRONTEND=noninteractive apt-get -y upgrade
+	RUN DEBIAN_FRONTEND=noninteractive apt-get -y install libzstd-dev
+	USER opam
+	RUN opam switch create 5.6 --packages=ocaml-variants.5.6.0+trunk
+	RUN opam pin add -k version ocaml-variants 5.6.0+trunk
+	RUN opam install -y opam-depext
+	ENTRYPOINT [ "opam", "exec", "--" ]
+	CMD bash
+	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
+
+5.6.0/arm64
+	# syntax=docker/dockerfile:1
+
+	FROM ocurrent/opam-staging:ubuntu-26.04-opam-arm64
+	RUN opam repo add beta git+https://github.com/ocaml/ocaml-beta-repository --set-default
+	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
+	USER root
+	RUN apt-get -y update
+	RUN DEBIAN_FRONTEND=noninteractive apt-get -y upgrade
+	RUN DEBIAN_FRONTEND=noninteractive apt-get -y install libzstd-dev
+	USER opam
+	RUN opam switch create 5.6 --packages=ocaml-variants.5.6.0+trunk
+	RUN opam pin add -k version ocaml-variants 5.6.0+trunk
+	RUN opam install -y opam-depext
+	ENTRYPOINT [ "opam", "exec", "--" ]
+	CMD bash
+	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
+
+5.6.0/amd64
+	# syntax=docker/dockerfile:1
+
+	FROM ocurrent/opam-staging:ubuntu-26.04-opam-amd64
+	RUN opam repo add beta git+https://github.com/ocaml/ocaml-beta-repository --set-default
+	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
+	USER root
+	RUN apt-get -y update
+	RUN DEBIAN_FRONTEND=noninteractive apt-get -y upgrade
+	RUN DEBIAN_FRONTEND=noninteractive apt-get -y install libzstd-dev
+	USER opam
+	RUN opam switch create 5.6 --packages=ocaml-variants.5.6.0+trunk
+	RUN opam pin add -k version ocaml-variants 5.6.0+trunk
+	RUN opam install -y opam-depext
+	ENTRYPOINT [ "opam", "exec", "--" ]
+	CMD bash
+	COPY --link [ "Dockerfile", "/Dockerfile.ocaml" ]
+
+ocurrent/opam-staging:ubuntu-26.04-ocaml-5.6-s390x, ocurrent/opam-staging:ubuntu-26.04-ocaml-5.6-ppc64le, ocurrent/opam-staging:ubuntu-26.04-ocaml-5.6-arm64, ocurrent/opam-staging:ubuntu-26.04-ocaml-5.6-amd64 -> ocaml/opam:ubuntu-26.04-ocaml-5.6
+ocurrent/opam-staging:ubuntu-26.04-ocaml-5.6-s390x, ocurrent/opam-staging:ubuntu-26.04-ocaml-5.6-ppc64le, ocurrent/opam-staging:ubuntu-26.04-ocaml-5.6-arm64, ocurrent/opam-staging:ubuntu-26.04-ocaml-5.6-amd64 -> ocaml/opam:ubuntu-lts-ocaml-5.6
+ocurrent/opam-staging:ubuntu-26.04-ocaml-5.6-s390x, ocurrent/opam-staging:ubuntu-26.04-ocaml-5.6-ppc64le, ocurrent/opam-staging:ubuntu-26.04-ocaml-5.6-arm64, ocurrent/opam-staging:ubuntu-26.04-ocaml-5.6-amd64 -> ocaml/opam:ubuntu-ocaml-5.6
 windows-mingw
 windows-server-mingw-ltsc2025/amd64
 	# escape=`
@@ -20625,74 +15496,6 @@ ocurrent/opam-staging:windows-server-mingw-ltsc2025-ocaml-5.3-amd64, ocurrent/op
 	COPY [ "Dockerfile", "/Dockerfile.ocaml" ]
 
 ocurrent/opam-staging:windows-server-mingw-ltsc2025-ocaml-5.2-amd64, ocurrent/opam-staging:windows-server-mingw-ltsc2022-ocaml-5.2-amd64, ocurrent/opam-staging:windows-mingw-ltsc2019-ocaml-5.2-amd64 -> ocaml/opam:windows-all-mingw-ocaml-5.2
-5.1.1/amd64
-	# escape=`
-
-	FROM ocurrent/opam-staging:windows-server-mingw-ltsc2025-opam-amd64
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 5.1 --packages=ocaml-base-compiler.5.1.1,system-mingw
-	RUN opam pin add -k version ocaml-base-compiler 5.1.1
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD [ "cmd.exe" ]
-	COPY [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-5.1.1/amd64
-	# escape=`
-
-	FROM ocurrent/opam-staging:windows-server-mingw-ltsc2022-opam-amd64
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 5.1 --packages=ocaml-base-compiler.5.1.1,system-mingw
-	RUN opam pin add -k version ocaml-base-compiler 5.1.1
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD [ "cmd.exe" ]
-	COPY [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-5.1.1/amd64
-	# escape=`
-
-	FROM ocurrent/opam-staging:windows-mingw-ltsc2019-opam-amd64
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 5.1 --packages=ocaml-base-compiler.5.1.1,system-mingw
-	RUN opam pin add -k version ocaml-base-compiler 5.1.1
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD [ "cmd.exe" ]
-	COPY [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-ocurrent/opam-staging:windows-server-mingw-ltsc2025-ocaml-5.1-amd64, ocurrent/opam-staging:windows-server-mingw-ltsc2022-ocaml-5.1-amd64, ocurrent/opam-staging:windows-mingw-ltsc2019-ocaml-5.1-amd64 -> ocaml/opam:windows-all-mingw-ocaml-5.1
-5.0.0/amd64
-	# escape=`
-
-	FROM ocurrent/opam-staging:windows-server-mingw-ltsc2025-opam-amd64
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 5.0 --packages=ocaml-base-compiler.5.0.0,system-mingw
-	RUN opam pin add -k version ocaml-base-compiler 5.0.0
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD [ "cmd.exe" ]
-	COPY [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-5.0.0/amd64
-	# escape=`
-
-	FROM ocurrent/opam-staging:windows-server-mingw-ltsc2022-opam-amd64
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 5.0 --packages=ocaml-base-compiler.5.0.0,system-mingw
-	RUN opam pin add -k version ocaml-base-compiler 5.0.0
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD [ "cmd.exe" ]
-	COPY [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-5.0.0/amd64
-	# escape=`
-
-	FROM ocurrent/opam-staging:windows-mingw-ltsc2019-opam-amd64
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 5.0 --packages=ocaml-base-compiler.5.0.0,system-mingw
-	RUN opam pin add -k version ocaml-base-compiler 5.0.0
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD [ "cmd.exe" ]
-	COPY [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-ocurrent/opam-staging:windows-server-mingw-ltsc2025-ocaml-5.0-amd64, ocurrent/opam-staging:windows-server-mingw-ltsc2022-ocaml-5.0-amd64, ocurrent/opam-staging:windows-mingw-ltsc2019-ocaml-5.0-amd64 -> ocaml/opam:windows-all-mingw-ocaml-5.0
 4.14.3/amd64
 	# escape=`
 
@@ -20727,49 +15530,9 @@ ocurrent/opam-staging:windows-server-mingw-ltsc2025-ocaml-5.0-amd64, ocurrent/op
 	COPY [ "Dockerfile", "/Dockerfile.ocaml" ]
 
 ocurrent/opam-staging:windows-server-mingw-ltsc2025-ocaml-4.14-amd64, ocurrent/opam-staging:windows-server-mingw-ltsc2022-ocaml-4.14-amd64, ocurrent/opam-staging:windows-mingw-ltsc2019-ocaml-4.14-amd64 -> ocaml/opam:windows-all-mingw-ocaml-4.14
-4.13.1/amd64
-	# escape=`
-
-	FROM ocurrent/opam-staging:windows-server-mingw-ltsc2025-opam-amd64
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.13 --packages=ocaml-base-compiler.4.13.1,system-mingw
-	RUN opam pin add -k version ocaml-base-compiler 4.13.1
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD [ "cmd.exe" ]
-	COPY [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.13.1/amd64
-	# escape=`
-
-	FROM ocurrent/opam-staging:windows-server-mingw-ltsc2022-opam-amd64
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.13 --packages=ocaml-base-compiler.4.13.1,system-mingw
-	RUN opam pin add -k version ocaml-base-compiler 4.13.1
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD [ "cmd.exe" ]
-	COPY [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.13.1/amd64
-	# escape=`
-
-	FROM ocurrent/opam-staging:windows-mingw-ltsc2019-opam-amd64
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.13 --packages=ocaml-base-compiler.4.13.1,system-mingw
-	RUN opam pin add -k version ocaml-base-compiler 4.13.1
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD [ "cmd.exe" ]
-	COPY [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-ocurrent/opam-staging:windows-server-mingw-ltsc2025-ocaml-4.13-amd64, ocurrent/opam-staging:windows-server-mingw-ltsc2022-ocaml-4.13-amd64, ocurrent/opam-staging:windows-mingw-ltsc2019-ocaml-4.13-amd64 -> ocaml/opam:windows-all-mingw-ocaml-4.13
 ocurrent/opam-staging:windows-server-mingw-ltsc2025-opam-amd64 -> ocaml/opam:windows-server-mingw-ltsc2025-opam
-ocurrent/opam-staging:windows-server-mingw-ltsc2025-ocaml-4.13-amd64 -> ocaml/opam:windows-server-mingw-ltsc2025-ocaml-4.13
-ocurrent/opam-staging:windows-server-mingw-ltsc2025-ocaml-4.13-amd64 -> ocaml/opam:windows-server-mingw-ocaml-4.13
 ocurrent/opam-staging:windows-server-mingw-ltsc2025-ocaml-4.14-amd64 -> ocaml/opam:windows-server-mingw-ltsc2025-ocaml-4.14
 ocurrent/opam-staging:windows-server-mingw-ltsc2025-ocaml-4.14-amd64 -> ocaml/opam:windows-server-mingw-ocaml-4.14
-ocurrent/opam-staging:windows-server-mingw-ltsc2025-ocaml-5.0-amd64 -> ocaml/opam:windows-server-mingw-ltsc2025-ocaml-5.0
-ocurrent/opam-staging:windows-server-mingw-ltsc2025-ocaml-5.0-amd64 -> ocaml/opam:windows-server-mingw-ocaml-5.0
-ocurrent/opam-staging:windows-server-mingw-ltsc2025-ocaml-5.1-amd64 -> ocaml/opam:windows-server-mingw-ltsc2025-ocaml-5.1
-ocurrent/opam-staging:windows-server-mingw-ltsc2025-ocaml-5.1-amd64 -> ocaml/opam:windows-server-mingw-ocaml-5.1
 ocurrent/opam-staging:windows-server-mingw-ltsc2025-ocaml-5.2-amd64 -> ocaml/opam:windows-server-mingw-ltsc2025-ocaml-5.2
 ocurrent/opam-staging:windows-server-mingw-ltsc2025-ocaml-5.2-amd64 -> ocaml/opam:windows-server-mingw-ocaml-5.2
 ocurrent/opam-staging:windows-server-mingw-ltsc2025-ocaml-5.3-amd64 -> ocaml/opam:windows-server-mingw-ltsc2025-ocaml-5.3
@@ -20778,23 +15541,14 @@ ocurrent/opam-staging:windows-server-mingw-ltsc2025-ocaml-5.4-amd64 -> ocaml/opa
 ocurrent/opam-staging:windows-server-mingw-ltsc2025-ocaml-5.4-amd64 -> ocaml/opam:windows-server-mingw-ltsc2025-ocaml-5.4
 ocurrent/opam-staging:windows-server-mingw-ltsc2025-ocaml-5.4-amd64 -> ocaml/opam:windows-server-mingw-ocaml-5.4
 ocurrent/opam-staging:windows-server-mingw-ltsc2022-opam-amd64 -> ocaml/opam:windows-server-mingw-ltsc2022-opam
-ocurrent/opam-staging:windows-server-mingw-ltsc2022-ocaml-4.13-amd64 -> ocaml/opam:windows-server-mingw-ltsc2022-ocaml-4.13
 ocurrent/opam-staging:windows-server-mingw-ltsc2022-ocaml-4.14-amd64 -> ocaml/opam:windows-server-mingw-ltsc2022-ocaml-4.14
-ocurrent/opam-staging:windows-server-mingw-ltsc2022-ocaml-5.0-amd64 -> ocaml/opam:windows-server-mingw-ltsc2022-ocaml-5.0
-ocurrent/opam-staging:windows-server-mingw-ltsc2022-ocaml-5.1-amd64 -> ocaml/opam:windows-server-mingw-ltsc2022-ocaml-5.1
 ocurrent/opam-staging:windows-server-mingw-ltsc2022-ocaml-5.2-amd64 -> ocaml/opam:windows-server-mingw-ltsc2022-ocaml-5.2
 ocurrent/opam-staging:windows-server-mingw-ltsc2022-ocaml-5.3-amd64 -> ocaml/opam:windows-server-mingw-ltsc2022-ocaml-5.3
 ocurrent/opam-staging:windows-server-mingw-ltsc2022-ocaml-5.4-amd64 -> ocaml/opam:windows-server-mingw-ltsc2022
 ocurrent/opam-staging:windows-server-mingw-ltsc2022-ocaml-5.4-amd64 -> ocaml/opam:windows-server-mingw-ltsc2022-ocaml-5.4
 ocurrent/opam-staging:windows-mingw-ltsc2019-opam-amd64 -> ocaml/opam:windows-mingw-ltsc2019-opam
-ocurrent/opam-staging:windows-mingw-ltsc2019-ocaml-4.13-amd64 -> ocaml/opam:windows-mingw-ltsc2019-ocaml-4.13
-ocurrent/opam-staging:windows-mingw-ltsc2019-ocaml-4.13-amd64 -> ocaml/opam:windows-mingw-ocaml-4.13
 ocurrent/opam-staging:windows-mingw-ltsc2019-ocaml-4.14-amd64 -> ocaml/opam:windows-mingw-ltsc2019-ocaml-4.14
 ocurrent/opam-staging:windows-mingw-ltsc2019-ocaml-4.14-amd64 -> ocaml/opam:windows-mingw-ocaml-4.14
-ocurrent/opam-staging:windows-mingw-ltsc2019-ocaml-5.0-amd64 -> ocaml/opam:windows-mingw-ltsc2019-ocaml-5.0
-ocurrent/opam-staging:windows-mingw-ltsc2019-ocaml-5.0-amd64 -> ocaml/opam:windows-mingw-ocaml-5.0
-ocurrent/opam-staging:windows-mingw-ltsc2019-ocaml-5.1-amd64 -> ocaml/opam:windows-mingw-ltsc2019-ocaml-5.1
-ocurrent/opam-staging:windows-mingw-ltsc2019-ocaml-5.1-amd64 -> ocaml/opam:windows-mingw-ocaml-5.1
 ocurrent/opam-staging:windows-mingw-ltsc2019-ocaml-5.2-amd64 -> ocaml/opam:windows-mingw-ltsc2019-ocaml-5.2
 ocurrent/opam-staging:windows-mingw-ltsc2019-ocaml-5.2-amd64 -> ocaml/opam:windows-mingw-ocaml-5.2
 ocurrent/opam-staging:windows-mingw-ltsc2019-ocaml-5.3-amd64 -> ocaml/opam:windows-mingw-ltsc2019-ocaml-5.3
@@ -21212,43 +15966,7 @@ ocurrent/opam-staging:windows-server-msvc-ltsc2025-ocaml-5.3-amd64, ocurrent/opa
 	COPY [ "Dockerfile", "/Dockerfile.ocaml" ]
 
 ocurrent/opam-staging:windows-server-msvc-ltsc2025-ocaml-4.14-amd64, ocurrent/opam-staging:windows-server-msvc-ltsc2022-ocaml-4.14-amd64, ocurrent/opam-staging:windows-msvc-ltsc2019-ocaml-4.14-amd64 -> ocaml/opam:windows-all-msvc-ocaml-4.14
-4.13.1/amd64
-	# escape=`
-
-	FROM ocurrent/opam-staging:windows-server-msvc-ltsc2025-opam-amd64
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.13 --packages=ocaml-base-compiler.4.13.1,system-msvc
-	RUN opam pin add -k version ocaml-base-compiler 4.13.1
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD [ "cmd.exe" ]
-	COPY [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.13.1/amd64
-	# escape=`
-
-	FROM ocurrent/opam-staging:windows-server-msvc-ltsc2022-opam-amd64
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.13 --packages=ocaml-base-compiler.4.13.1,system-msvc
-	RUN opam pin add -k version ocaml-base-compiler 4.13.1
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD [ "cmd.exe" ]
-	COPY [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-4.13.1/amd64
-	# escape=`
-
-	FROM ocurrent/opam-staging:windows-msvc-ltsc2019-opam-amd64
-	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
-	RUN opam switch create 4.13 --packages=ocaml-base-compiler.4.13.1,system-msvc
-	RUN opam pin add -k version ocaml-base-compiler 4.13.1
-	ENTRYPOINT [ "opam", "exec", "--" ]
-	CMD [ "cmd.exe" ]
-	COPY [ "Dockerfile", "/Dockerfile.ocaml" ]
-
-ocurrent/opam-staging:windows-server-msvc-ltsc2025-ocaml-4.13-amd64, ocurrent/opam-staging:windows-server-msvc-ltsc2022-ocaml-4.13-amd64, ocurrent/opam-staging:windows-msvc-ltsc2019-ocaml-4.13-amd64 -> ocaml/opam:windows-all-msvc-ocaml-4.13
 ocurrent/opam-staging:windows-server-msvc-ltsc2025-opam-amd64 -> ocaml/opam:windows-server-msvc-ltsc2025-opam
-ocurrent/opam-staging:windows-server-msvc-ltsc2025-ocaml-4.13-amd64 -> ocaml/opam:windows-server-msvc-ltsc2025-ocaml-4.13
-ocurrent/opam-staging:windows-server-msvc-ltsc2025-ocaml-4.13-amd64 -> ocaml/opam:windows-server-msvc-ocaml-4.13
 ocurrent/opam-staging:windows-server-msvc-ltsc2025-ocaml-4.14-amd64 -> ocaml/opam:windows-server-msvc-ltsc2025-ocaml-4.14
 ocurrent/opam-staging:windows-server-msvc-ltsc2025-ocaml-4.14-amd64 -> ocaml/opam:windows-server-msvc-ocaml-4.14
 ocurrent/opam-staging:windows-server-msvc-ltsc2025-ocaml-5.3-amd64 -> ocaml/opam:windows-server-msvc-ltsc2025-ocaml-5.3
@@ -21257,14 +15975,11 @@ ocurrent/opam-staging:windows-server-msvc-ltsc2025-ocaml-5.4-amd64 -> ocaml/opam
 ocurrent/opam-staging:windows-server-msvc-ltsc2025-ocaml-5.4-amd64 -> ocaml/opam:windows-server-msvc-ltsc2025-ocaml-5.4
 ocurrent/opam-staging:windows-server-msvc-ltsc2025-ocaml-5.4-amd64 -> ocaml/opam:windows-server-msvc-ocaml-5.4
 ocurrent/opam-staging:windows-server-msvc-ltsc2022-opam-amd64 -> ocaml/opam:windows-server-msvc-ltsc2022-opam
-ocurrent/opam-staging:windows-server-msvc-ltsc2022-ocaml-4.13-amd64 -> ocaml/opam:windows-server-msvc-ltsc2022-ocaml-4.13
 ocurrent/opam-staging:windows-server-msvc-ltsc2022-ocaml-4.14-amd64 -> ocaml/opam:windows-server-msvc-ltsc2022-ocaml-4.14
 ocurrent/opam-staging:windows-server-msvc-ltsc2022-ocaml-5.3-amd64 -> ocaml/opam:windows-server-msvc-ltsc2022-ocaml-5.3
 ocurrent/opam-staging:windows-server-msvc-ltsc2022-ocaml-5.4-amd64 -> ocaml/opam:windows-server-msvc-ltsc2022
 ocurrent/opam-staging:windows-server-msvc-ltsc2022-ocaml-5.4-amd64 -> ocaml/opam:windows-server-msvc-ltsc2022-ocaml-5.4
 ocurrent/opam-staging:windows-msvc-ltsc2019-opam-amd64 -> ocaml/opam:windows-msvc-ltsc2019-opam
-ocurrent/opam-staging:windows-msvc-ltsc2019-ocaml-4.13-amd64 -> ocaml/opam:windows-msvc-ltsc2019-ocaml-4.13
-ocurrent/opam-staging:windows-msvc-ltsc2019-ocaml-4.13-amd64 -> ocaml/opam:windows-msvc-ocaml-4.13
 ocurrent/opam-staging:windows-msvc-ltsc2019-ocaml-4.14-amd64 -> ocaml/opam:windows-msvc-ltsc2019-ocaml-4.14
 ocurrent/opam-staging:windows-msvc-ltsc2019-ocaml-4.14-amd64 -> ocaml/opam:windows-msvc-ocaml-4.14
 ocurrent/opam-staging:windows-msvc-ltsc2019-ocaml-5.3-amd64 -> ocaml/opam:windows-msvc-ltsc2019-ocaml-5.3

--- a/src/conf.ml
+++ b/src/conf.ml
@@ -56,7 +56,7 @@ let switches ~arch ~distro =
   (* TODO: Does Windows include alpha, beta, and release candidate versions? *)
   let with_unreleased = match distro with `WindowsServer _ | `Windows _ -> false | _ -> true in
   let main_switches =
-    Ocaml_version.Releases.(if with_unreleased then recent_with_dev @ unreleased_betas else recent)
+    Ocaml_version.Releases.(if with_unreleased then significant @ dev @ unreleased_betas else significant)
     |> List.filter (fun ov -> Distro.distro_supported_on arch ov distro)
   in
   if is_tier1 then (


### PR DESCRIPTION
Switch non-Windows distros to `Ocaml_version.Releases.significant` (new in ocaml-version 4.1) in place of `recent_with_dev`, reducing the Linux matrix to [4.08; 4.11; 4.14] plus the last two stable releases, with dev and unreleased betas still appended. Windows stays on `recent`.

Bump the pinned opam-repository SHA to pick up dockerfile-opam 8.3.6, which adds Ubuntu 26.04.