### PR TITLE
Bump opam-repository pin for ocaml-dockerfile 8.3.7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     libssl-dev \
     m4 \
     pkg-config
-RUN cd ~/opam-repository && git fetch -q origin master && git reset --hard cf76b487b68928b40a49920699bd7419e8e0e184 && opam update
+RUN cd ~/opam-repository && git fetch -q origin master && git reset --hard 9226b95ebeaa698593640cb2ab228a9c83970303 && opam update
 COPY --chown=opam --link base-images.opam /src/
 WORKDIR /src
 ENV OPAMSOLVERTIMEOUT=600

--- a/builds.expected
+++ b/builds.expected
@@ -8666,7 +8666,7 @@ opensuse-15.6/arm64
 	RUN zypper install --force-resolution -y -t pattern devel_C_C++
 	RUN zypper repos repo-openh264 && zypper removerepo repo-openh264 || true
 	RUN zypper update -y
-	RUN zypper install --force-resolution -y sudo git unzip curl gcc-c++ libcap-devel xz libX11-devel bzip2 which rsync gzip openssl
+	RUN zypper install --force-resolution -y sudo git unzip curl gcc-c++ libcap-devel xz libX11-devel bzip2 which rsync gzip openssl tar
 	RUN git config --global user.email "docker@example.com"
 	RUN git config --global user.name "Docker"
 	RUN git clone https://github.com/ocaml/opam /tmp/opam && cd /tmp/opam && cp -P -R -p . ../opam-sources && git checkout master && env MAKE='make -j' shell/bootstrap-ocaml.sh && make -C src_ext cache-archives
@@ -8684,7 +8684,7 @@ opensuse-15.6/arm64
 	RUN zypper install --force-resolution -y -t pattern devel_C_C++
 	RUN zypper repos repo-openh264 && zypper removerepo repo-openh264 || true
 	RUN zypper update -y
-	RUN zypper install --force-resolution -y sudo git unzip curl gcc-c++ libcap-devel xz libX11-devel bzip2 which rsync gzip openssl bubblewrap
+	RUN zypper install --force-resolution -y sudo git unzip curl gcc-c++ libcap-devel xz libX11-devel bzip2 which rsync gzip openssl tar bubblewrap
 	COPY --from=0 [ "/usr/bin/opam-2.0", "/usr/bin/opam-2.0" ]
 	RUN ln /usr/bin/opam-2.0 /usr/bin/opam
 	COPY --from=0 [ "/usr/bin/opam-2.1", "/usr/bin/opam-2.1" ]
@@ -8748,7 +8748,7 @@ opensuse-15.6/amd64
 	RUN zypper install --force-resolution -y -t pattern devel_C_C++
 	RUN zypper repos repo-openh264 && zypper removerepo repo-openh264 || true
 	RUN zypper update -y
-	RUN zypper install --force-resolution -y sudo git unzip curl gcc-c++ libcap-devel xz libX11-devel bzip2 which rsync gzip openssl
+	RUN zypper install --force-resolution -y sudo git unzip curl gcc-c++ libcap-devel xz libX11-devel bzip2 which rsync gzip openssl tar
 	RUN git config --global user.email "docker@example.com"
 	RUN git config --global user.name "Docker"
 	RUN git clone https://github.com/ocaml/opam /tmp/opam && cd /tmp/opam && cp -P -R -p . ../opam-sources && git checkout master && env MAKE='make -j' shell/bootstrap-ocaml.sh && make -C src_ext cache-archives
@@ -8766,7 +8766,7 @@ opensuse-15.6/amd64
 	RUN zypper install --force-resolution -y -t pattern devel_C_C++
 	RUN zypper repos repo-openh264 && zypper removerepo repo-openh264 || true
 	RUN zypper update -y
-	RUN zypper install --force-resolution -y sudo git unzip curl gcc-c++ libcap-devel xz libX11-devel bzip2 which rsync gzip openssl bubblewrap
+	RUN zypper install --force-resolution -y sudo git unzip curl gcc-c++ libcap-devel xz libX11-devel bzip2 which rsync gzip openssl tar bubblewrap
 	COPY --from=0 [ "/usr/bin/opam-2.0", "/usr/bin/opam-2.0" ]
 	RUN ln /usr/bin/opam-2.0 /usr/bin/opam
 	COPY --from=0 [ "/usr/bin/opam-2.1", "/usr/bin/opam-2.1" ]
@@ -9130,7 +9130,7 @@ opensuse-16.0/arm64
 	RUN zypper install --force-resolution -y -t pattern devel_C_C++
 	RUN zypper repos repo-openh264 && zypper removerepo repo-openh264 || true
 	RUN zypper update -y
-	RUN zypper install --force-resolution -y sudo git unzip curl gcc-c++ libcap-devel xz libX11-devel bzip2 which rsync gzip openssl
+	RUN zypper install --force-resolution -y sudo git unzip curl gcc-c++ libcap-devel xz libX11-devel bzip2 which rsync gzip openssl tar
 	RUN git config --global user.email "docker@example.com"
 	RUN git config --global user.name "Docker"
 	RUN git clone https://github.com/ocaml/opam /tmp/opam && cd /tmp/opam && cp -P -R -p . ../opam-sources && git checkout master && env MAKE='make -j' shell/bootstrap-ocaml.sh && make -C src_ext cache-archives
@@ -9148,7 +9148,7 @@ opensuse-16.0/arm64
 	RUN zypper install --force-resolution -y -t pattern devel_C_C++
 	RUN zypper repos repo-openh264 && zypper removerepo repo-openh264 || true
 	RUN zypper update -y
-	RUN zypper install --force-resolution -y sudo git unzip curl gcc-c++ libcap-devel xz libX11-devel bzip2 which rsync gzip openssl bubblewrap
+	RUN zypper install --force-resolution -y sudo git unzip curl gcc-c++ libcap-devel xz libX11-devel bzip2 which rsync gzip openssl tar bubblewrap
 	COPY --from=0 [ "/usr/bin/opam-2.0", "/usr/bin/opam-2.0" ]
 	RUN ln /usr/bin/opam-2.0 /usr/bin/opam
 	COPY --from=0 [ "/usr/bin/opam-2.1", "/usr/bin/opam-2.1" ]
@@ -9212,7 +9212,7 @@ opensuse-16.0/amd64
 	RUN zypper install --force-resolution -y -t pattern devel_C_C++
 	RUN zypper repos repo-openh264 && zypper removerepo repo-openh264 || true
 	RUN zypper update -y
-	RUN zypper install --force-resolution -y sudo git unzip curl gcc-c++ libcap-devel xz libX11-devel bzip2 which rsync gzip openssl
+	RUN zypper install --force-resolution -y sudo git unzip curl gcc-c++ libcap-devel xz libX11-devel bzip2 which rsync gzip openssl tar
 	RUN git config --global user.email "docker@example.com"
 	RUN git config --global user.name "Docker"
 	RUN git clone https://github.com/ocaml/opam /tmp/opam && cd /tmp/opam && cp -P -R -p . ../opam-sources && git checkout master && env MAKE='make -j' shell/bootstrap-ocaml.sh && make -C src_ext cache-archives
@@ -9230,7 +9230,7 @@ opensuse-16.0/amd64
 	RUN zypper install --force-resolution -y -t pattern devel_C_C++
 	RUN zypper repos repo-openh264 && zypper removerepo repo-openh264 || true
 	RUN zypper update -y
-	RUN zypper install --force-resolution -y sudo git unzip curl gcc-c++ libcap-devel xz libX11-devel bzip2 which rsync gzip openssl bubblewrap
+	RUN zypper install --force-resolution -y sudo git unzip curl gcc-c++ libcap-devel xz libX11-devel bzip2 which rsync gzip openssl tar bubblewrap
 	COPY --from=0 [ "/usr/bin/opam-2.0", "/usr/bin/opam-2.0" ]
 	RUN ln /usr/bin/opam-2.0 /usr/bin/opam
 	COPY --from=0 [ "/usr/bin/opam-2.1", "/usr/bin/opam-2.1" ]
@@ -9604,7 +9604,7 @@ opensuse-tumbleweed/amd64
 	RUN zypper install --force-resolution -y -t pattern devel_C_C++
 	RUN zypper repos repo-openh264 && zypper removerepo repo-openh264 || true
 	RUN zypper update -y
-	RUN zypper install --force-resolution -y sudo git unzip curl gcc-c++ libcap-devel xz libX11-devel bzip2 which rsync gzip openssl
+	RUN zypper install --force-resolution -y sudo git unzip curl gcc-c++ libcap-devel xz libX11-devel bzip2 which rsync gzip openssl tar
 	RUN git config --global user.email "docker@example.com"
 	RUN git config --global user.name "Docker"
 	RUN git clone https://github.com/ocaml/opam /tmp/opam && cd /tmp/opam && cp -P -R -p . ../opam-sources && git checkout master && env MAKE='make -j' shell/bootstrap-ocaml.sh && make -C src_ext cache-archives
@@ -9622,7 +9622,7 @@ opensuse-tumbleweed/amd64
 	RUN zypper install --force-resolution -y -t pattern devel_C_C++
 	RUN zypper repos repo-openh264 && zypper removerepo repo-openh264 || true
 	RUN zypper update -y
-	RUN zypper install --force-resolution -y sudo git unzip curl gcc-c++ libcap-devel xz libX11-devel bzip2 which rsync gzip openssl bubblewrap
+	RUN zypper install --force-resolution -y sudo git unzip curl gcc-c++ libcap-devel xz libX11-devel bzip2 which rsync gzip openssl tar bubblewrap
 	COPY --from=0 [ "/usr/bin/opam-2.0", "/usr/bin/opam-2.0" ]
 	RUN ln /usr/bin/opam-2.0 /usr/bin/opam
 	COPY --from=0 [ "/usr/bin/opam-2.1", "/usr/bin/opam-2.1" ]


### PR DESCRIPTION
Pulls in ocaml-dockerfile 8.3.7, which adds `tar` to the openSUSE/SLES dev package list. The Leap 15.6 base image no longer ships `tar`, so opam bootstrap was failing.

- ocurrent/ocaml-dockerfile#264