### PR TITLE
Use Distro.gcc_version for GCC 15 overlay gating

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     libssl-dev \
     m4 \
     pkg-config
-RUN cd ~/opam-repository && git fetch -q origin master && git reset --hard 28d044eb9ccd9b9275c54a845b30932c3d934aa0 && opam update
+RUN cd ~/opam-repository && git fetch -q origin master && git reset --hard 3e30e43808721339489775ee25d69c4c9c441697 && opam update
 RUN opam option --global solver=builtin-0install
 COPY --chown=opam --link base-images.opam /src/
 WORKDIR /src

--- a/base-images.opam
+++ b/base-images.opam
@@ -27,8 +27,8 @@ depends: [
   "current_rpc"
   "capnp-rpc-unix" {>= "1.2.3"}
   "cmdliner" {>= "1.3.0"}
-  "dockerfile" {>= "8.2.5"}
-  "dockerfile-opam" {>= "8.2.5"}
+  "dockerfile" {>= "8.4.0"}
+  "dockerfile-opam" {>= "8.4.0"}
   "ocaml-version" {>= "3.7.3"}
   "timedesc" {>= "3.0.0"}
   "opam-core"

--- a/builds.expected
+++ b/builds.expected
@@ -6721,6 +6721,7 @@ ocurrent/opam-staging:fedora-44-opam-arm64, ocurrent/opam-staging:fedora-44-opam
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:fedora-44-opam-arm64
+	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.11 --packages=ocaml-base-compiler.4.11.2
 	RUN opam pin add -k version ocaml-base-compiler 4.11.2
@@ -6733,6 +6734,7 @@ ocurrent/opam-staging:fedora-44-opam-arm64, ocurrent/opam-staging:fedora-44-opam
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:fedora-44-opam-amd64
+	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.11 --packages=ocaml-base-compiler.4.11.2
 	RUN opam pin add -k version ocaml-base-compiler 4.11.2
@@ -6747,6 +6749,7 @@ ocurrent/opam-staging:fedora-44-ocaml-4.11-arm64, ocurrent/opam-staging:fedora-4
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:fedora-44-opam-arm64
+	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.14 --packages=ocaml-base-compiler.4.14.3
 	RUN opam pin add -k version ocaml-base-compiler 4.14.3
@@ -6759,6 +6762,7 @@ ocurrent/opam-staging:fedora-44-ocaml-4.11-arm64, ocurrent/opam-staging:fedora-4
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:fedora-44-opam-amd64
+	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.14 --packages=ocaml-base-compiler.4.14.3
 	RUN opam pin add -k version ocaml-base-compiler 4.14.3
@@ -10414,7 +10418,6 @@ ocurrent/opam-staging:ubuntu-25.04-opam-s390x, ocurrent/opam-staging:ubuntu-25.0
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-25.04-opam-s390x
-	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.11 --packages=ocaml-base-compiler.4.11.2
 	RUN opam pin add -k version ocaml-base-compiler 4.11.2
@@ -10427,7 +10430,6 @@ ocurrent/opam-staging:ubuntu-25.04-opam-s390x, ocurrent/opam-staging:ubuntu-25.0
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-25.04-opam-ppc64le
-	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.11 --packages=ocaml-base-compiler.4.11.2
 	RUN opam pin add -k version ocaml-base-compiler 4.11.2
@@ -10440,7 +10442,6 @@ ocurrent/opam-staging:ubuntu-25.04-opam-s390x, ocurrent/opam-staging:ubuntu-25.0
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-25.04-opam-arm64
-	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.11 --packages=ocaml-base-compiler.4.11.2
 	RUN opam pin add -k version ocaml-base-compiler 4.11.2
@@ -10453,7 +10454,6 @@ ocurrent/opam-staging:ubuntu-25.04-opam-s390x, ocurrent/opam-staging:ubuntu-25.0
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-25.04-opam-amd64
-	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.11 --packages=ocaml-base-compiler.4.11.2
 	RUN opam pin add -k version ocaml-base-compiler 4.11.2
@@ -10466,7 +10466,6 @@ ocurrent/opam-staging:ubuntu-25.04-opam-s390x, ocurrent/opam-staging:ubuntu-25.0
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-25.04-opam-riscv64
-	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.11 --packages=ocaml-base-compiler.4.11.2
 	RUN opam pin add -k version ocaml-base-compiler 4.11.2
@@ -10480,7 +10479,6 @@ ocurrent/opam-staging:ubuntu-25.04-ocaml-4.11-s390x, ocurrent/opam-staging:ubunt
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-25.04-opam-s390x
-	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.14 --packages=ocaml-base-compiler.4.14.3
 	RUN opam pin add -k version ocaml-base-compiler 4.14.3
@@ -10493,7 +10491,6 @@ ocurrent/opam-staging:ubuntu-25.04-ocaml-4.11-s390x, ocurrent/opam-staging:ubunt
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-25.04-opam-ppc64le
-	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.14 --packages=ocaml-base-compiler.4.14.3
 	RUN opam pin add -k version ocaml-base-compiler 4.14.3
@@ -10506,7 +10503,6 @@ ocurrent/opam-staging:ubuntu-25.04-ocaml-4.11-s390x, ocurrent/opam-staging:ubunt
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-25.04-opam-arm64
-	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.14 --packages=ocaml-base-compiler.4.14.3
 	RUN opam pin add -k version ocaml-base-compiler 4.14.3
@@ -10519,7 +10515,6 @@ ocurrent/opam-staging:ubuntu-25.04-ocaml-4.11-s390x, ocurrent/opam-staging:ubunt
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-25.04-opam-amd64
-	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.14 --packages=ocaml-base-compiler.4.14.3
 	RUN opam pin add -k version ocaml-base-compiler 4.14.3
@@ -10532,7 +10527,6 @@ ocurrent/opam-staging:ubuntu-25.04-ocaml-4.11-s390x, ocurrent/opam-staging:ubunt
 	# syntax=docker/dockerfile:1
 
 	FROM ocurrent/opam-staging:ubuntu-25.04-opam-riscv64
-	RUN opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default
 	ENV OPAMYES="1" OPAMCONFIRMLEVEL="unsafe-yes" OPAMERRLOGLEN="0" OPAMPRECISETRACKING="1"
 	RUN opam switch create 4.14 --packages=ocaml-base-compiler.4.14.3
 	RUN opam pin add -k version ocaml-base-compiler 4.14.3

--- a/dune-project
+++ b/dune-project
@@ -31,8 +31,8 @@
   current_rpc
   (capnp-rpc-unix (>= 1.2.3))
   (cmdliner (>= 1.3.0))
-  (dockerfile (>= 8.2.5))
-  (dockerfile-opam (>= 8.2.5))
+  (dockerfile (>= 8.4.0))
+  (dockerfile-opam (>= 8.4.0))
   (ocaml-version (>= 3.7.3))
   (timedesc (>= 3.0.0))
   opam-core))

--- a/src/pipeline.ml
+++ b/src/pipeline.ml
@@ -41,7 +41,7 @@ let maybe_add_multicore (run : 'a run) switch =
     Dockerfile.empty
 
 (* GCC 15 changed the default to -std=gnu23, which breaks OCaml < 5.1.
-   Add overlay with patches for affected distros.
+   Add overlay with patches on any distro shipping gcc >= 15.
    Note: 4.14.2 already has the fixes, so only 4.00-4.14.1 and 5.0.0 need patches. *)
 let maybe_add_gcc15_overlay (run : 'a run) distro switch =
   let switch_no_variant = Ocaml_version.without_variant switch in
@@ -49,19 +49,8 @@ let maybe_add_gcc15_overlay (run : 'a run) distro switch =
     Ocaml_version.compare switch_no_variant Ocaml_version.Releases.v5_1_0 < 0 &&
     not (Ocaml_version.equal switch_no_variant Ocaml_version.Releases.v4_14_2)
   in
-  match needs_patch, distro with
-  | true, `Alpine `V3_23
-  | true, `Ubuntu `V25_04
-  | true, `Ubuntu `V25_10
-  | true, `Ubuntu `V26_04
-  | true, `Fedora `V42
-  | true, `Fedora `V43
-  | true, `Debian `Unstable
-  | true, `Debian `Testing
-  | true, `OpenSUSE `V15_6
-  | true, `OpenSUSE `V16_0
-  | true, `OpenSUSE `Tumbleweed
-  | true, `Archlinux `Latest ->
+  match needs_patch, Distro.gcc_version distro with
+  | true, Some (major, _) when major >= 15 ->
     run "opam repo add ocaml-patches-overlay git+https://github.com/ocurrent/opam-repository#patches --set-default"
   | _, _ ->
     Dockerfile.empty


### PR DESCRIPTION
Replace the hand-maintained list of distros needing the GCC 15 patch
overlay (`maybe_add_gcc15_overlay` in `src/pipeline.ml`) with a check
against `Distro.gcc_version`, exposed by ocaml-dockerfile 8.4.0
(ocurrent/ocaml-dockerfile#267). The overlay is now applied to any
distro shipping gcc >= 15, so new distro releases pick it up
automatically without a code change here.

Behavioural shifts visible in `builds.expected`:

- Fedora 44 (gcc 16.1) now gets the overlay — fixes the OCaml 4.11.2
  build failure that prompted this change.
- Ubuntu 25.04 (gcc 14.2) and openSUSE Leap 15.6 (gcc 7.5, already
  deprecated upstream) no longer get the overlay; the previous list
  included them speculatively but neither ships gcc 15.

Also bumps `dockerfile` / `dockerfile-opam` to `>= 8.4.0` and advances
the Dockerfile's opam-repository pin to a commit that includes those
releases.